### PR TITLE
Fix to avoid mkdocs build warnings for monetizing and json-schema-validator

### DIFF
--- a/en/docs/Learn/APIMonetization/monetizing-an-api.md
+++ b/en/docs/Learn/APIMonetization/monetizing-an-api.md
@@ -50,7 +50,7 @@ Let's use the
 
      2. [Obtain the keys](https://stripe.com/docs/keys#api-keys).  
 
-        ![Obtain keys](../../../assets/img/Learn/obtain-keys.png)
+        ![Obtain keys](../../assets/img/Learn/obtain-keys.png)
         
  2.  Create an account for the API Publisher.  
     
@@ -65,7 +65,7 @@ Let's use the
     1. Sign in to the Tenant Admin's Stripe account.
     2. Click **Connect** > **Get Started** > **Build a platform or marketplace** > **Continue** to create a platform account.
 
-        ![Create a platform account](../../../assets/img/Learn/create-platform-account.png)
+        ![Create a platform account](../../assets/img/Learn/create-platform-account.png)
 
     3. The Tenant Admin has to share the OAuth link, which is in the following format, with the API Publisher.
         
@@ -85,11 +85,11 @@ Let's use the
 
     5.  Activate your API Publisher account or click **skip this account form** to work in developer mode.
 
-         ![Work in developer mode](../../../assets/img/Learn/developer-mode.png)
+         ![Work in developer mode](../../assets/img/Learn/developer-mode.png)
 
          A cURL command appears.
 
-         ![cURL to get the Connect ID](../../../assets/img/Learn/stripe-connect-id-curl.png)
+         ![cURL to get the Connect ID](../../assets/img/Learn/stripe-connect-id-curl.png)
 
     6. The API Publisher has to share the latter mentioned cURL command with the Tenant Admin.
 
@@ -176,7 +176,7 @@ When working with API Monetization that involves dynamic business plans (usage-b
 
     2. Build the implementation of the respective monetization interface and add the JAR into the `<API-M_HOME>/repository/components/lib` directory.
         
-        In this example scenario, you need to add the [org.wso2.apim.monetization.impl-1.0-SNAPSHOT.jar](../../../assets/attachments/learn/org.wso2.apim.monetization.impl-1.0-SNAPSHOT.jar) JAR into the latter mentioned `lib` folder. Note that this JAR has been derived by building the [wso2-am-stripe-plugin repository](https://github.com/wso2-extensions/wso2-am-stripe-plugin). 
+        In this example scenario, you need to add the [org.wso2.apim.monetization.impl-1.0-SNAPSHOT.jar](../../assets/attachments/learn/org.wso2.apim.monetization.impl-1.0-SNAPSHOT.jar) JAR into the latter mentioned `lib` folder. Note that this JAR has been derived by building the [wso2-am-stripe-plugin repository](https://github.com/wso2-extensions/wso2-am-stripe-plugin). 
 
     3.  Define the monetization implementation in WSO2 API Manager.
      
@@ -622,7 +622,7 @@ When working with API Monetization that involves dynamic business plans (usage-b
 
          `/_system/config/apimgt/applicationdata/tenant-conf.json`
 
-         ![Resources page](../../../assets/img/Learn/tenant-config.png)
+         ![Resources page](../../assets/img/Learn/tenant-config.png)
     
     5. Add the following configuration in the `tenant-conf.json` file using the WSO2 API-M Management Console.  
 
@@ -692,13 +692,13 @@ When working with API Monetization that involves dynamic business plans (usage-b
          <head>
          </head>
          <body>
-             <img src="../../../assets/img/Learn/subscription-commercial-tier.png" alt="Subscription to a paid business plan" title="Paid business plan" width="400" />
+             <img src="../../assets/img/Learn/subscription-commercial-tier.png" alt="Subscription to a paid business plan" title="Paid business plan" width="400" />
          </body>
      </html>
 
      After you save the policy, a plan gets created in the Stripe account of the Tenant Admin.  
 
-     ![Stripe account after creating a paid business plan](../../../assets/img/Learn/Stripe-account-after-creating-a-commercial-tier.png)  
+     ![Stripe account after creating a paid business plan](../../assets/img/Learn/Stripe-account-after-creating-a-commercial-tier.png)  
      
      When you update the details of this business plan, the plan in Stripe will get updated with the corresponding details. Likewise, when you delete a business plan, the plan in Stripe will get deleted.
 
@@ -708,7 +708,7 @@ When working with API Monetization that involves dynamic business plans (usage-b
     `https://<hostname>:9443/publisher`
 
 2.  Click on the API that you wish to monetize.  
-    ![Enable monetization](../../../assets/img/Learn/enable-monetization.png)
+    ![Enable monetization](../../assets/img/Learn/enable-monetization.png)
 
 3.  Click **Monetization** to navigate to the Monetization configurations.
 
@@ -725,20 +725,20 @@ When working with API Monetization that involves dynamic business plans (usage-b
 
 When subscribing to an API, simultaneously a customer is created in the Stripe platform account (e.g., the Stripe account is created for the Tenant Admin). The following screenshot shows the customer record in the platform Stripe account.
 
-![Customer created in stripe](../../../assets/img/Learn/customer-created-in-stripe.png)
+![Customer created in stripe](../../assets/img/Learn/customer-created-in-stripe.png)
 
 The following screenshot depicts the details of the newly created customer in the platform Stripe account.
 
-![New customer details](../../../assets/img/Learn/new-customer-details.png)
+![New customer details](../../assets/img/Learn/new-customer-details.png)
 
 Thereafter, the customer details are copied to the Stripe account of the API Publisher, which is the connected account.
 
-![Shared customer in connected account](../../../assets/img/Learn/shared-customer-in-connected-account.png)
+![Shared customer in connected account](../../assets/img/Learn/shared-customer-in-connected-account.png)
 
 The following are the details of the shared customer that appears in the
 Stripe UI.
 
-![Shared customer details](../../../assets/img/Learn/shared-customer-details.png)
+![Shared customer details](../../assets/img/Learn/shared-customer-details.png)
 
 Specific Stripe billing plans correspond to specific WSO2 API Manager business plans. Therefore, when an App developer subscribes to an API via the API Developer Portal, Stripe will use the information in their business plan to create a corresponding subscription for the App developer in Stripe.  
 
@@ -786,7 +786,7 @@ You can use the admin REST API, which is available in WSO2 API Manager, to publi
 
     After making an admin API call the bill gets generated in the Stripe connected account.
 
-    ![Pricing](../../../assets/img/Learn/pricing.png) The charging process takes place at the end of the billing cycle. As this example scenario uses a usage-based business plan, the payment that the subscribers make for their bills are sent to the API Publisher via the billing engine.
+    ![Pricing](../../assets/img/Learn/pricing.png) The charging process takes place at the end of the billing cycle. As this example scenario uses a usage-based business plan, the payment that the subscribers make for their bills are sent to the API Publisher via the billing engine.
 
 ### Step 5 - Monitor usage of a monetized API
 
@@ -805,7 +805,7 @@ The Application Developers who are subscribed to a dynamic business plan can sig
 
      The list of subscriptions that correspond to the API appears.
 
-     ![Subscription details via the API Publisher Portal](../../../assets/img/Learn/subscription-dev-portal.png)
+     ![Subscription details via the API Publisher Portal](../../assets/img/Learn/subscription-dev-portal.png)
 
 3. Click **View Invoice** to view the invoice corresponding to a specific API.
 
@@ -813,7 +813,7 @@ The Application Developers who are subscribed to a dynamic business plan can sig
     <head>
     </head>
     <body>
-    <img src="../../../assets/img/Learn/invoice-details.png" alt="Subscriber's Invoice details" title="Subscriber's invoice details" width="500" />
+    <img src="../../assets/img/Learn/invoice-details.png" alt="Subscriber's Invoice details" title="Subscriber's invoice details" width="500" />
     </body>
      </html>
 
@@ -831,7 +831,7 @@ The API Publisher can access the billing information related to each of the subs
 
      The list of subscriptions that correspond to the API appears.
 
-     ![Subscription details via the API Publisher Portal](../../../assets/img/Learn/subscription-details-publisher.png)
+     ![Subscription details via the API Publisher Portal](../../assets/img/Learn/subscription-details-publisher.png)
 
 4. Click **View Invoice** to view the invoice that corresponds to a specific subscriber.
 
@@ -839,7 +839,7 @@ The API Publisher can access the billing information related to each of the subs
     <head>
     </head>
     <body>
-    <img src="../../../assets/img/Learn/invoice-details.png" alt="Invoice details" title="Invoice details" width="500" />
+    <img src="../../assets/img/Learn/invoice-details.png" alt="Invoice details" title="Invoice details" width="500" />
     </body>
      </html>
 
@@ -853,7 +853,7 @@ Follow the instructions below to disable monetization for an API:
 2.  Click on the monetized API for which you need to disable monetization.
 
 3.  Click **Monetization** to go to the Monetization configurations.  
-    ![Disable monetization](../../../assets/img/Learn/disable-monetization.png)
+    ![Disable monetization](../../assets/img/Learn/disable-monetization.png)
 
 4.  Click **Enable Monetization** to unselect the enable monetization option.
 

--- a/en/docs/Learn/APISecurity/Authentication/json-schema-validator.md
+++ b/en/docs/Learn/APISecurity/Authentication/json-schema-validator.md
@@ -14,13 +14,13 @@ If the request fails the validations, the JSON Schema Validator sends a bad requ
 
 The following diagram illustrates the message flow when sending a valid request.
 
-![JSON schema validator - Sending a valid request](../../../../assets/img/Learn/json-validator-send-valid-request.png)
+![JSON schema validator - Sending a valid request](../../../assets/img/Learn/json-validator-send-valid-request.png)
 
 **Sending an invalid request**
 
 The following diagram illustrates the message flow when sending an invalid request.
 
-![JSON schema validator - Sending an invalid request](../../../../assets/img/Learn/json-validator-send-invalid-request.png)
+![JSON schema validator - Sending an invalid request](../../../assets/img/Learn/json-validator-send-invalid-request.png)
 
 **Example:**
 
@@ -46,13 +46,13 @@ The following response is displayed.
 
 The following diagram illustrates the message flow when sending a valid response.
 
-![JSON schema validator - Sending a valid response](../../../../assets/img/Learn/json-validator-send-valid-response.png)
+![JSON schema validator - Sending a valid response](../../../assets/img/Learn/json-validator-send-valid-response.png)
 
 **Invalid response from the backend**
 
 The following diagram illustrates the message flow when sending an invalid response.
 
-![JSON schema validator - Sending an invalid response](../../../../assets/img/Learn/json-validator-send-invalid-response.png)
+![JSON schema validator - Sending an invalid response](../../../assets/img/Learn/json-validator-send-invalid-response.png)
 
 **Example**
 
@@ -97,6 +97,6 @@ The following validation response from the Gateway is displayed.
 
      By default, the schema validation property is set to `false`.
 
-     ![Enable API schema validation](../../../../assets/img/Learn/api-runtime-config.png)
+     ![Enable API schema validation](../../../assets/img/Learn/api-runtime-config.png)
 
 5. Click **SAVE**.


### PR DESCRIPTION
## Purpose
Made changes to get rid of the for monetizing-an-api.md and json-schema-validator.md related following warning messages that appear when running mkdocs build.

```
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/obtain-keys.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/create-platform-account.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/developer-mode.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/stripe-connect-id-curl.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/attachments/learn/org.wso2.apim.monetization.impl-1.0-SNAPSHOT.jar' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/tenant-config.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/Stripe-account-after-creating-a-commercial-tier.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/enable-monetization.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/customer-created-in-stripe.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/new-customer-details.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/shared-customer-in-connected-account.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/shared-customer-details.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/pricing.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/subscription-dev-portal.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/subscription-details-publisher.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIMonetization/monetizing-an-api.md' contains a link to '../assets/img/Learn/disable-monetization.png' which is not found in the documentation files. 
```

```
WARNING -  Documentation file 'Learn/APISecurity/Authentication/json-schema-validator.md' contains a link to '../assets/img/Learn/json-validator-send-valid-request.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APISecurity/Authentication/json-schema-validator.md' contains a link to '../assets/img/Learn/json-validator-send-invalid-request.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APISecurity/Authentication/json-schema-validator.md' contains a link to '../assets/img/Learn/json-validator-send-valid-response.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APISecurity/Authentication/json-schema-validator.md' contains a link to '../assets/img/Learn/json-validator-send-invalid-response.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APISecurity/Authentication/json-schema-validator.md' contains a link to '../assets/img/Learn/api-runtime-config.png' which is not found in the documentation files. 
```