### PR TITLE
Removing SDK generation doc temporarily

### DIFF
--- a/en/docs/Learn/DesignAPI/AdvancedTopics/generating-server-stubs-and-client-sdks-in-the-api-publisher.md
+++ b/en/docs/Learn/DesignAPI/AdvancedTopics/generating-server-stubs-and-client-sdks-in-the-api-publisher.md
@@ -3,13 +3,13 @@
 Software Development Kits (SDKs) contain the necessary toolkits to create a client application to invoke a particular API. If an API consumer wants to create an application, they can generate a server stub or client side SDK for a supported language/framework and use it to write a software application to consume the subscribed APIs.
 
 !!! note
-SDK generation is not supported with the APIs that are created using OpenAPI 3.0 support.
+    SDK generation is not supported with the APIs that are created using OpenAPI 3.0 support.
 
 
 The API Publisher has an embedded [swagger editor](http://editor.swagger.io/#/) with the ability to generate server code and client SDKs then and there.
 
 !!! note
-Client SDK and Server Stub generation in API Publisher is only supported for Rest APIs.
+    Client SDK and Server Stub generation in API Publisher is only supported for Rest APIs.
 
 
 1.  Open an existing API and choose to edit it.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -96,7 +96,6 @@ nav:
                 - Adding Custom Properties to APIs: Learn/DesignAPI/AdvancedTopics/adding-custom-properties-to-apis.md
                 - Enabling Access Control Support for API Publisher: Learn/DesignAPI/AdvancedTopics/enabling-access-control-support-for-api-publisher.md
                 - Enabling CORS for APIs: Learn/DesignAPI/AdvancedTopics/enabling-cors-for-apis.md
-                - Generating server stubs and client SDKs in the API Publisher:  Learn/DesignAPI/AdvancedTopics/generating-server-stubs-and-client-sdks-in-the-api-publisher.md
                 - Adding an API State Change Workflow: Learn/DesignAPI/AdvancedTopics/adding-an-api-state-change-workflow.md
                 - Block Subscription to an API: Learn/DesignAPI/AdvancedTopics/block-subscription-to-an-api.md 
         - Consume API:


### PR DESCRIPTION
## Purpose
Removing SDK generation doc temporarily. Need to add it back if this feature is supported in the future.

