### PR TITLE
Fixed mkdocs related warnings in Learn/APIController/

### DIFF
--- a/en/docs/Learn/APIController/building-a-cicd-pipeline.md
+++ b/en/docs/Learn/APIController/building-a-cicd-pipeline.md
@@ -17,7 +17,7 @@ The CI/CD process makes a developer’s life easier by providing an automated me
 
 ## CI/CD With WSO2 API Management
 
-![CI/CD Pipeline for APIs with WSO2 API Manager](../../../assets/img/Learn/ci-cd-pipeline-for-apis-with-wso2-apim.png)
+[![CI/CD Pipeline for APIs with WSO2 API Manager](../../assets/img/Learn/ci-cd-pipeline-for-apis-with-wso2-apim.png)](../../assets/img/Learn/ci-cd-pipeline-for-apis-with-wso2-apim.png)
 
 WSO2 API Manager provides a clean and elegant solution to address automating API deployment. It automates from environment migration to lifecycle management and solves many issues regarding the manual process. The solution was designed to be platform-agnostic and version control-centric.
 
@@ -65,7 +65,7 @@ The apictl tool supports detecting environment variables defined in usual notati
 
 Once the file is placed in the project directory, the tool will auto-detect the parameters file upon import and create an environment-based artifact for API Manager. If the api_params.yaml is not found in the project directory, the tool will lookup in the project’s base path and the current working directory. It can also provide a custom path for the parameter file using the --params flag. We recommend keeping API and environment-specific parameters in separate repositories.
 
-![Creating environment-based artifacts with API-M CTL](../../../assets/img/Learn/creating-env-based-artifacts.png)
+[![Creating environment-based artifacts with API-M CTL](../../assets/img/Learn/creating-env-based-artifacts.png)](../../assets/img/Learn/creating-env-based-artifacts.png)
 
 The Automation Server can be configured to run a specific pipeline for promoting artifacts to other environments. The DevOps team can develop this pipeline further to include automated tests, workflow approvals, and other tasks. The apictl tool should be installed in automation servers to begin the process. Since the tool supports a variety of platforms, including Linux/Windows and macOS, this can be done easily.
 
@@ -99,7 +99,7 @@ With this, the Swagger/OpenAPI specification becomes a single source of truth fo
 
 For example, when an organization depends on microservices architecture, this method can be utilized to create an automated pipeline to take Swagger/OpenAPI specification to upper environments.
 
-![API automation with OpenAPI/Swagger](../../../assets/img/Learn/api-automation-with-openapi-swagger.png)
+[![API automation with OpenAPI/Swagger](../../assets/img/Learn/api-automation-with-openapi-swagger.png)](../../assets/img/Learn/api-automation-with-openapi-swagger.png)
 
 Based on API Project generation, a powerful pipeline for API automation can be developed with OpenAPI/Swagger. It allows rapid API development and increases developer productivity.
 

--- a/en/docs/Learn/APIController/migrating-applications-to-different-environments.md
+++ b/en/docs/Learn/APIController/migrating-applications-to-different-environments.md
@@ -24,7 +24,7 @@ WSO2 API Controller, **apictl** allows you to maintain multiple environments run
 
 The lifecycle of an application could be defined as the stages of an application between the development and production environments. The feature facilitates to manage the application life cycle by allowing the user to migrate the applications within desired environments. The user should have admin permissions in order to use this.
 
-![Managing Application Lifecycle](../../../assets/img/Learn/managing-application-lifecycle.png)
+[![Managing Application Lifecycle](../../assets/img/Learn/managing-application-lifecycle.png)](../../assets/img/Learn/managing-application-lifecycle.png)
 
 
 ## Export an Application
@@ -179,12 +179,12 @@ You can import an application to your environment as a zipped application. When 
 There are three options to import applications in a single-tenant environment.
 
 -   Application A in environment 1 is migrated to environment 2. Some APIs may not be available in environment 2 (API B in this case) and the relevant subscriptions are not added in such cases (skipped).
-    ![Importing Applications across Two Environments with the Same Owner](../../../assets/img/Learn/import-apps-tenanted-env1.png)
+    [![Importing Applications across Two Environments with the Same Owner](../../assets/img/Learn/import-apps-tenanted-env1.png)](../../assets/img/Learn/import-apps-tenanted-env1.png)
 
 -   A different owner can be specified while importing an application to environment 2,  without preserving the original user of environment 1.
-    ![Importing Applications across Two environments with Different Owners](../../../assets/img/Learn/import-apps-tenanted-env2.png)
+    [![Importing Applications across Two environments with Different Owners](../../assets/img/Learn/import-apps-tenanted-env2.png)](../../assets/img/Learn/import-apps-tenanted-env2.png)
 -   The original owner of the application can be preserved when the application is imported to environment 2 by adding the `--preserveOwner` flag.
-    ![Importing Applications across Two environments with Preserve Owner](../../../assets/img/Learn/import-apps-tenanted-env3.png)
+    [![Importing Applications across Two environments with Preserve Owner](../../assets/img/Learn/import-apps-tenanted-env3.png)](../../assets/img/Learn/import-apps-tenanted-env3.png)
 
 ### Import Applications in a Multi Tenant Environment
 


### PR DESCRIPTION
## Purpose
This fix is to remove the following mkdocs warning.

```
WARNING -  Documentation file 'Learn/APIController/building-a-cicd-pipeline.md' contains a link to '../assets/img/Learn/ci-cd-pipeline-for-apis-with-wso2-apim.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/building-a-cicd-pipeline.md' contains a link to '../assets/img/Learn/creating-env-based-artifacts.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/building-a-cicd-pipeline.md' contains a link to '../assets/img/Learn/api-automation-with-openapi-swagger.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/migrating-applications-to-different-environments.md' contains a link to '../assets/img/Learn/managing-application-lifecycle.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/migrating-applications-to-different-environments.md' contains a link to '../assets/img/Learn/import-apps-tenanted-env1.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/migrating-applications-to-different-environments.md' contains a link to '../assets/img/Learn/import-apps-tenanted-env2.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIController/migrating-applications-to-different-environments.md' contains a link to '../assets/img/Learn/import-apps-tenanted-env3.png' which is not found in the documentation files. 
```