### PR TITLE
Fixed the mkdocs related warning for the Learn/APIGateway files

### DIFF
--- a/en/docs/Learn/APIGateway/MessageMediation/convert-a-json-message-to-soap-and-soap-to-json.md
+++ b/en/docs/Learn/APIGateway/MessageMediation/convert-a-json-message-to-soap-and-soap-to-json.md
@@ -52,7 +52,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
     Next, let's write a sequence to convert the JSON payload to a SOAP request. We do this because the backend accepts SOAP requests.
 
 5.  Navigate to the **Endpoints** section and change the endpoint of the API to <http://ws.cdyne.com/phoneverify/phoneverify.asmx?WSDL>.
-    ![](../../../assets/img/Learn/edit-endpoint.png)
+    [![](../../../assets/img/Learn/edit-endpoint.png)](../../../assets/img/Learn/edit-endpoint.png)
 
 6. Click **Save** to save the Endpoint details of the API.
 
@@ -64,7 +64,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
     ![](../../../assets/img/Learn/eclipse-open-apim.png)
 10.  On the API-M perspective, click the **Login** icon as shown below.
 
-    ![](../../../assets/img/Learn/eclipse-login.png)
+    [![](../../../assets/img/Learn/eclipse-login.png)](../../../assets/img/Learn/eclipse-login.png)
 
 11. On the dialog box that appears, enter the URL, username, and password of the Publisher server.
 
@@ -73,9 +73,9 @@ Let's see how to convert message types using custom sequences. In this tutorial,
 12. On the tree view that appears, expand the folder structure of the existing API.
 
 13. Right-click on the **In** sequence folder and click **Create** to create a new [**In** sequence](https://docs.wso2.com/display/AM250/Key+Concepts#KeyConcepts-Sequences) .
-    ![](../../../assets/img/Learn/eclipse-create-in-seq.png)
+    [![](../../../assets/img/Learn/eclipse-create-in-seq.png)](../../../assets/img/Learn/eclipse-create-in-seq.png)
 14. Name the sequence `JSONtoSOAP`.
-    ![](../../../assets/img/Learn/eclipse-name-resource.png)
+    [![](../../../assets/img/Learn/eclipse-name-resource.png)](../../../assets/img/Learn/eclipse-name-resource.png)
 15. Your sequence now appears on the APIM perspective. From under the **Mediators** section, drag and drop a **PayloadFactory** mediator to your sequence and give the following values to the mediator.
 
         !!! tip
@@ -85,7 +85,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
 
     For details on how you got this configuration, see [PayloadFactory Mediator](https://docs.wso2.com/display/EI650/PayloadFactory+Mediator) in the WSO2 EI documentation.
 
- ![](../../../assets/img/Learn/eclipse-payload-factory.png)
+ [![](../../../assets/img/Learn/eclipse-payload-factory.png)](../../../assets/img/Learn/eclipse-payload-factory.png)
 
     |         |                                                                                                                                                                             |
     |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -130,7 +130,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
       </table>                                                                                                                                                                     |
 
 16. Similarly, add a **Property** mediator to the same sequence and give the following values to the property mediator. This mediator changes the payload type of the outgoing message to soap+xml. More information about the Property mediator can be found [here](https://docs.wso2.com/display/ESB500/Property+Mediator).
-    ![](../../../assets/img/Learn/eclipse-property-mediator.png)
+    [![](../../../assets/img/Learn/eclipse-property-mediator.png)](../../../assets/img/Learn/eclipse-property-mediator.png)
 
     |                |                      |
     |----------------|----------------------|
@@ -145,7 +145,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
     ![](../../../assets/img/Learn/eclipse-outseq-create.png)
 
 19. Name the sequence `SOAPtoJSON` .
-    ![](../../../assets/attachments/Learn/eclipse-create-seq.png)
+    [![](../../../assets/img/Learn/eclipse-create-seq.png)](../../../assets/img/Learn/eclipse-create-seq.png)
 20. Add a **Log** mediator to the sequence and give the following values. Note that the property value provided is a string literal.
 
         !!! info
@@ -175,7 +175,7 @@ Let's see how to convert message types using custom sequences. In this tutorial,
     </tbody>
     </table>
 
-    ![](../../../assets/img/Learn/eclipse-log-mediator-config.png)
+    [![](../../../assets/img/Learn/eclipse-log-mediator-config.png)](../../../assets/img/Learn/eclipse-log-mediator-config.png)
 
 21. Similarly, add a **PayLoadFactory** mediator with the following values. This mediator in the out sequence is used to transform the SOAP message content returned from the backend into JSON.
 
@@ -217,15 +217,15 @@ Let's see how to convert message types using custom sequences. In this tutorial,
     | Value String Capturing Group | 0                |
     | Property Scope               | axis2            |
 
-    ![](../../../assets/img/Learn/eclipse-soap-to-json.png)
+    [![](../../../assets/img/Learn/eclipse-soap-to-json.png)](../../../assets/img/Learn/eclipse-soap-to-json.png)
 
 23. Save the sequence, which is in XML format (e.g., `SOAPtoJSON.xml` ). This will be the **Out** sequence for your API.
 
 24. Click the **Push all changes to the server** icon shown below to commit your changes to the Publisher server.
-    ![](../../../assets/img/Learn/eclipse-push-all-changes.png.png)
+    [![](../../../assets/img/Learn/eclipse-push-all-changes.png)](../../../assets/img/Learn/eclipse-push-all-changes.png)
 
 25. Log back into the API Publisher, select PhoneVerification API and click the **Runtime Configurations** menu link associated with the API and navigate to the **Mediation Policies** section. Click the **Edit** icon and engage the **In** and **Out** mediation policies that you created earlier from the respective sections.
-    ![](../../../assets/img/Learn/engage-created-mediation-policies.png)
+    [![](../../../assets/img/Learn/engage-created-mediation-policies.png)](../../../assets/img/Learn/engage-created-mediation-policies.png)
 
         !!! info
     JSONtoSOAP **in sequence** will serve the purpose of transforming the JSON payload to SOAP before sending it to the SOAP backend. SOAPtoJSON **out sequence** will transform the SOAP message returned from the backend to JSON.
@@ -234,14 +234,14 @@ Let's see how to convert message types using custom sequences. In this tutorial,
 26. **Save** the API.
     You have created an API, a resource to access the SOAP backend and engaged sequences to the request and response paths to convert the message format from JSON to SOAP and back to JSON. Let's subscribe to the API and invoke it.
 27. Log in to the API Devportal and [Subscribe to the API](../../../Learn/Tutorials/subscribe-to-an-api/) and create an access token if you have not done so already.
-    ![](../../../assets/img/Learn/subscribe.png)
+    [![](../../../assets/img/Learn/subscribe.png)](../../../assets/img/Learn/subscribe.png)
 
 28. Select the PhoneVerification API, Go to the **Try Out** menu and expand the POST method.
 
 29. Click on the **Try It Out** and give the payload in the `body` parameter in JSON format and click **Execute**. Here's a sample JSON payload: {"request":{"PhoneNumber":"18006785432","LicenseKey":"0"}}
-    ![](../../../assets/img/Learn/try-it.png)
+    [![](../../../assets/img/Learn/try-it.png)](../../../assets/img/Learn/try-it.png)
 
 30. Note that you get a JSON response to the JSON request whereas the backend accepts SOAP messages. The request and response are converted by the sequences that you engaged in.
-    ![](../../../assets/img/Learn/json-response.png)
+    [![](../../../assets/img/Learn/json-response.png)](../../../assets/img/Learn/json-response.png)
 
 In this tutorial, you converted a message from JSON to SOAP and back to JSON using **In** and **Out** sequences.

--- a/en/docs/Learn/APIGateway/MessageMediation/pass-a-custom-authorization-token-to-the-backend.md
+++ b/en/docs/Learn/APIGateway/MessageMediation/pass-a-custom-authorization-token-to-the-backend.md
@@ -1,7 +1,8 @@
 # Pass a Custom Authorization Token to the Backend
 
 !!! note
-This tutorial uses the WSO2 API Manager Tooling Plug-in .
+    
+    This tutorial uses the WSO2 API Manager Tooling Plug-in .
 
 
 When you send an API request to the backend, you pass a token in the Authorization header of the request. The API Gateway uses this token to authorize access, and then drops it from the outgoing message.  If you wish to use a different (or a custom generated) authorization token than the application generated access token, you can use it as a token exchange mechanism in mediation logic of the API. In this tutorial, we explain how to pass a custom authorization token that is different to the authorization token generated for the application.
@@ -18,19 +19,19 @@ Let's get started.
 
 2.  Click **Window &gt; Open Perspective &gt; Other** to open the Eclipse perspective selection window. Alternatively, click the **Open Perspective** icon shown below at the top right corner.
 
-    ![](../../../assets/img/Learn/eclipse-open-perspective.png)
+    [![](../../../assets/img/Learn/eclipse-open-perspective.png)](../../../assets/img/Learn/eclipse-open-perspective.png)
 
 3.  On the dialog box that appears, click **WSO2 APIManager** and click **OK** .
-    ![](../../../assets/img/Learn/eclipse-open-apim.png)
+    [![](../../../assets/img/Learn/eclipse-open-apim.png)](../../../assets/img/Learn/eclipse-open-apim.png)
 4.  On the APIM perspective, click the **Login** icon as shown below.
-    ![](../../../assets/img/Learn/eclipse-login.png)
+    [![](../../../assets/img/Learn/eclipse-login.png)](../../../assets/img/Learn/eclipse-login.png)
 5.  On the dialog box that appears, enter the URL, username and password (by default `admin` ) of the Publisher server.
-    ![](../../../assets/img/Learn/eclipse-login-to-apim-registry.png)
+    [![](../../../assets/img/Learn/eclipse-login-to-apim-registry.png)](../../../assets/img/Learn/eclipse-login-to-apim-registry.png)
 6.  On the tree view that appears, expand the folder structure of the existing API.
 7.  Right-click on the `in` sequence folder and click **Create** to create a new `in` sequence.
-    ![](../../../assets/img/Learn/eclipse-create-in-seq.png)
-8.  Name the sequence `TokenExchange` .
-    ![](../../../assets/img/Learn/token-exchange-seq.png)
+    [![](../../../assets/img/Learn/eclipse-create-in-seq.png)](../../../assets/img/Learn/eclipse-create-in-seq.png)
+8.  Name the sequence `TokenExchange`.
+    [![](../../../assets/img/Learn/token-exchange-seq.png)](../../../assets/img/Learn/token-exchange-seq.png)
 
 9.  Your sequence now appears on the APIM perspective. From under the **Mediators** section, drag and drop a **Property** mediator to your sequence and give the following values to the mediator.
 
@@ -38,7 +39,7 @@ Let's get started.
     **Tip** : The **Property Mediator** has no direct impact on a message, but rather on the message context flowing through [Synapse](https://docs.wso2.com/display/EI611/Synapse+Configuration+Reference) . For more information, see [Property Mediator](https://docs.wso2.com/display/EI650/Property+Mediator) in the WSO2 EI documentation.
 
 
-    The following property mediator is used to assign the Custom transport level property to another property called **Custom** .
+    The following property mediator is used to assign the Custom transport level property to another property called **Custom**.
 
     |                   |                                     |
     |-------------------|-------------------------------------|
@@ -47,7 +48,7 @@ Let's get started.
     | Value Type        | EXPRESSION                          |
     | Value Expression  | get-property('transport', 'Custom') |
 
-    ![](../../../assets/img/Learn/eclipse-token-exchange-property.png)
+    [![](../../../assets/img/Learn/eclipse-token-exchange-property.png)](../../../assets/img/Learn/eclipse-token-exchange-property.png)
 
 10. Similarly, add another **Property** mediator to your sequence and give the following values to the mediator. This property mediator is used to construct a transport level property called **Authorization** and assign itself the value of the Custom property created above.
 
@@ -59,7 +60,7 @@ Let's get started.
     | Value Expression  | get-property('Custom') |
     | Property Scope    | transport              |
 
-    ![](../../../assets/img/Learn/eclipse-token-exchange-property-2.png)
+    [![](../../../assets/img/Learn/eclipse-token-exchange-property-2.png)](../../../assets/img/Learn/eclipse-token-exchange-property-2.png)
 
 11. Add a third **Property** mediator to your sequence and give the following values to the mediator. This property mediator is used to remove the **Custom** property from the transport level.
 
@@ -70,7 +71,7 @@ Let's get started.
     | Property Action   | remove       |
     | Property Scope    | transport    |
 
-    ![](/assets/img/Learn/eclipse-token-exchange-property-3.png)
+    [![](../../../assets/img/Learn/eclipse-token-exchange-property-3.png)](../../../assets/img/Learn/eclipse-token-exchange-property-3.png)
 
 12. Save the sequence.
 
@@ -144,6 +145,6 @@ Let's get started.
     ```
 
 24. Note the response that you get in the command line. According to the sample backend used in this tutorial, you get the response as "Request Received."
-    ![](../../../assets/img/Learn/custom-header-response.png.png)
+    [![](../../../assets/img/Learn/custom-header-response.png)](../../../assets/img/Learn/custom-header-response.png)
 
 In this tutorial, you passed a custom token that the backend expects along with the system-generated Authorization token, and invoked an API successfully by swapping the system's token with your custom token.

--- a/en/docs/Learn/APIGateway/api-gateways-with-dedicated-backends.md
+++ b/en/docs/Learn/APIGateway/api-gateways-with-dedicated-backends.md
@@ -4,19 +4,19 @@ We can extend the [multiple gateway environments](../maintaining-separate-produc
 
 However, the API Publisher can only provide a single static endpoint for an API in the implementation. Therefore, the API call is directed to a single endpoint in whichever Gateway the API is deployed in, as depicted in the diagram below.
 
-[![](../../../assets/img/Learn/single-endpoint.png)](../../../assets/img/Learn/single-endpoint.png)
+[![Single endpoint](../../assets/img/Learn/single-endpoint.png)](../../assets/img/Learn/single-endpoint.png)
 
 However, in most situations, you would want to have each Gateway proxying to a dedicated backend API. To provide that capability, WSO2 API Manager provides the ability to specify parameterized endpoint URLs at the time of specifying the API endpoint URL. This URL is resolved at runtime with the details (host and port) specified at the startup of each Gateway. Each gateway then points to a dedicated backend API, as depicted in the digram below.
 
-[![](../../../assets/img/Learn/dedicated-endpoint.png)](../../../assets/img/Learn/dedicated-endpoint.png)
+[![Dedicated endpoint](../../assets/img/Learn/dedicated-endpoint.png)](../../assets/img/Learn/dedicated-endpoint.png)
 ### Configuring Parameterized Endpoints
 
 Follow the steps below to configure a parameterized endpoint as the API endpoint.
 
 1.  Start the WSO2 API Manager server that includes the API Publisher component and create an API.
-2.  Go to the **Endpoints** tab of the API and replace the host and port of the API endpoint with {uri.var.host} and {uri.var.port} respectively, as shown below.
+2.  Go to the **Endpoints** tab of the API and replace the host and port of the API endpoint with `{uri.var.host}` and `{uri.var.port} ` respectively, as shown below.
 
-    [![](../../../assets/img/Learn/dedicated-backend-def.png)](../../../assets/img/Learn/dedicated-backend-def.png)
+    [![Dedicated backend definition](../../assets/img/Learn/dedicated-backend-def.png)](../../assets/img/Learn/dedicated-backend-def.png)
 
 3.  Save and [publish](../../DesignAPI/PublishAPI/publish-an-api) the API.
 

--- a/en/docs/Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md
+++ b/en/docs/Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md
@@ -8,14 +8,15 @@ When you publish an API using the API Publisher, it gets deployed on the API Gat
 
 This is the default scenario. Because this Gateway instance handles both production and sandbox token traffic, it is called a hybrid API Gateway. When an API request comes to the API Gateway, it checks whether the requesting token is of type PRODUCTION or SANDBOX and forwards the request to the appropriate endpoint. The diagram below depicts this scenario.
 
-[![](../../../assets/img/Learn/hybrid-gw.png)](../../../assets/img/Learn/hybrid-gw.png)
+[![Hybrid Gateway](../../assets/img/Learn/hybrid-gw.png)](../../assets/img/Learn/hybrid-gw.png)
+
 #### Multiple Gateways to handle production and sandbox requests separately
 
 Having a single Gateway instance to pass through both types of requests can negatively impact the performance of the production server. To avoid this, you can set up separate API Gateways. The production API Gateway handles requests that are made using PRODUCTION type tokens and the sandbox API Gateway handles requests that are made using SANDBOX type tokens.
 
 The diagram below depicts this using two Gateways:
 
-[![](../../../assets/img/Learn/production-sandbox-gws.png)](../../../assets/img/Learn/production-sandbox-gws.png)
+[![Production and sandbox gateways](../../assets/img/Learn/production-sandbox-gws.png)](../../assets/img/Learn/production-sandbox-gws.png)
 
 In either of the two approaches, if an API Gateway receives an invalid token, it returns an error to the requesting client saying that the token is invalid.
 
@@ -61,7 +62,7 @@ The `type` attribute of the environment can take the following values:
 
 If you work with Gateways in different geographical locations, configuring multiple environments in the `<API-M_HOME>/repository/conf/deployment.toml` file is recommended. The diagram below depicts a sample setup:
 
-[![](../../../assets/img/Learn/multi-reigion-gw.png)](../../../assets/img/Learn/multi-reigion-gw.png)
+[![Multi-region Gateway](../../assets/img/Learn/multi-reigion-gw.png)](../../assets/img/Learn/multi-reigion-gw.png)
 
 **Figure** : API Gateways in different geographical regions
 

--- a/en/docs/Learn/APIGateway/message-tracing.md
+++ b/en/docs/Learn/APIGateway/message-tracing.md
@@ -22,12 +22,12 @@ can be viewed via the terminal or the `wso2carbon` log file.
     | Enable Logging                    | Enable Logging in the available logging handler in order to log the tracing message. |
     | Enable Analytics Event Publishing | Publish tracing events to WSO2 API Manager Analytics                                 |
 
-    ![](../../../assets/img/Learn/messageTraceronly.png)
+    [![Message tracing](../../assets/img/Learn/messageTraceronly.png)](../../assets/img/Learn/messageTraceronly.png)
     
 5.  Add an event publisher to log the trace messages in the APIM the `wso2carbon` log file.
 
     1.  Go to **Main &gt; Event &gt; Publishers** and click **Add Event Publisher** .
-        ![](../../../assets/img/Learn/addEventPublisher.png)
+        [![Add event publisher option](../../assets/img/Learn/addEventPublisher.png)](../../assets/img/Learn/addEventPublisher.png)
     2.  In Create a New Event Publisher page, add the following details and click **Add Event Publisher** .
 
         <table>
@@ -67,7 +67,7 @@ can be viewed via the terminal or the `wso2carbon` log file.
 
         Leave the **Unique Identifier** field blank.
         
-        ![](../../../assets/img/Learn/message_tracer_logger_publisher.png)
+        [![Add a Event Publisher](../../assets/img/Learn/message_tracer_logger_publisher.png)](../../assets/img/Learn/message_tracer_logger_publisher.png)
 
 After enabling message tracing, dump message content, and logging, you will see a log message similar to the following 
 on the API Console/terminal for events such as API invocation etc.
@@ -131,7 +131,7 @@ As an additional step you can publish these trace messages to WSO2 API Manager A
 1.  Sign in to WSO2 APIM Management Console ( <https://localhost:9443/carbon> ) if you have not done so already.
 2.  Select **Enable Analytics Event Publishing** , which is in the Message Tracing Configuration page and click **Update** .
 
-    ![](../../../assets/img/Learn/analyticsEventPublishing.png)
+    [![Enable analytics Event Publishing](../../assets/img/Learn/analyticsEventPublishing.png)](../../assets/img/Learn/analyticsEventPublishing.png)
     After you have saved the changes, WSO2 APIM will generate a stream definition in the 
     `<APIM_HOME>/repository/deployment/server/eventstreams/DAS_MESSAGE_TRACE_1.0.0.json` file.
 
@@ -147,7 +147,7 @@ WSO2 API Manager Analytics.
 
         You will see the deployed stream under event streams.
         
-        ![](../../../assets/img/Learn/dasStream.png)
+        [![DAS_MESSAGE_TRACE:1.0.0](../../assets/img/Learn/dasStream.png)](../../assets/img/Learn/dasStream.png)
         
     2.  Click the **Edit** option that is relevant to the stream definition `DAS_MESSAGE_TRACE:1.0.0` file so that it 
     opens in the edit view.
@@ -157,16 +157,16 @@ WSO2 API Manager Analytics.
     4.  In the next page select Persist Event Stream and select all the attribute check-boxes in order to persist all 
     the information and click Save Event Stream.
         
-        ![](../../../assets/img/Learn/saveEventStream.png)
+        [![Save Event Stream](../../assets/img/Learn/saveEventStream.png)](../../assets/img/Learn/saveEventStream.png)
     
 7.  Add an Event receiver to point to the Event stream.
 
     1.  Go to **Main -&gt; Event -&gt; Receivers** in WSO2 API Manager Analytics and click **Add Event Receiver** .
         
-        ![](../../../assets/img/Learn/addReceiver.png)    
+        [![Add Receiver option](../../assets/img/Learn/addReceiver.png)] (../../assets/img/Learn/addReceiver.png)   
     
     2.  Add the following details and click 
-        **Add Event Receiver** .
+        **Add Event Receiver**.
 
         | Property                        | Value                     |
         |---------------------------------|---------------------------|
@@ -176,13 +176,13 @@ WSO2 API Manager Analytics.
         | Event Stream                    | DAS\_MESSAGE\_TRACE:1.0.0 |
         | Message format                  | wso2event                 |
 
-        ![](../../../assets/img/Learn/newEventReceiver.png)
+        [![Add a new Event Receiver](../../assets/img/Learn/newEventReceiver.png)](../../assets/img/Learn/newEventReceiver.png)
         
 8.  Configure a publisher that can publish events to WSO2 API Manager Analytics.
     1.  Sign in to WSO2 APIM Management console ( <https://localhost:9443/carbon> ) if you have not done so already.
     2.  Go to **Main &gt; Event &gt; Publishers** and click **Add Event Publisher** .
-        ![](../../../assets/img/Learn/addEventPublisher.png)
-    3.  In Create a New Event Publisher page, add the following details and click **Add Event Publisher** .
+        [![Add Event Publisher option](../../assets/img/Learn/addEventPublisher.png)](../../assets/img/Learn/addEventPublisher.png)
+    3.  In Create a New Event Publisher page, add the following details and click **Add Event Publisher**.
 
         <table>
             <thead>
@@ -245,7 +245,7 @@ WSO2 API Manager Analytics.
 
         Leave the **Authenticator URL** field blank.  
         
-        ![](../../../assets/img/Learn/newEventPublisher.png)
+        [![Add a new Event Publisher](../../assets/img/Learn/newEventPublisher.png)](../../assets/img/Learn/newEventPublisher.png)
         
 If you have also enabled Analytics event Publishing in addition to enabling message tracing, dump message content, and logging, you can see the results in WSO2 API Manager Analytics by following the steps below:
 
@@ -253,4 +253,4 @@ If you have also enabled Analytics event Publishing in addition to enabling mess
 2.  Navigate to **Main &gt; Data Explorer.**
 3.  Select the table **DAS\_MESSAGE\_TRACE** and click **Search** .
     You will see the event data traced in the WSO2 Analytics Data Explorer as shown below.
-    ![](../../../assets/img/Learn/dasMessageData.png)
+    [![](../../assets/img/Learn/dasMessageData.png)](../../assets/img/Learn/dasMessageData.png)

--- a/en/docs/Learn/APIGateway/overview-of-the-api-gateway.md
+++ b/en/docs/Learn/APIGateway/overview-of-the-api-gateway.md
@@ -2,7 +2,7 @@
 
 WSO2 API Manager is a fully open-source and is released under [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html), one of the most business-friendly licenses available today. It provides Web interfaces for development teams to deploy and monitor APIs, and for consumers to subscribe to, discover and consume APIs through a user-friendly Developer Portal. 
 
-![](../../../assets/img/Learn/apim-overview.png)
+[![API-M overview](../../assets/img/Learn/apim-overview.png)](../../assets/img/Learn/apim-overview.png)
 
 **WSO2 API Gateway** which is powered by [WSO2 EI](https://docs.wso2.com/display/EI650/WSO2+Enterprise+Integrator+Documentation) provides a runtime, backend component (an API proxy) for API calls.
 It secures, protects, manages, and scales API calls by intercepting API requests and applying policies such as throttling and security using handlers and managing API statistics.
@@ -16,7 +16,7 @@ When the API Manager is running, you can access the Gateway using the URL [https
     Although the API Gateway contains EI features, it is recommended not to use it for EI-specific tasks. Use it only for Gateway functionality related to API invocations. For example, if you want to call external services like SAP, use a separate EI cluster for that.
 
 **Gateway Architecture**
-![](../../../assets/img/Learn/gateway-overview.png)
+[![Gateway overview](../../assets/img/Learn/gateway-overview.png)](../../assets/img/Learn/gateway-overview.png)
 
 When an API request first hit to the WSO2 API Gateway it is received by the HTTP/HTTPS `transports`.The transport is responsible for carrying messages that are in a specific format.
 Transport provides a receiver, which is used to receive messages, and a sender, which is used to send messages.

--- a/en/docs/Learn/Extensions/adding-mediation-extensions.md
+++ b/en/docs/Learn/Extensions/adding-mediation-extensions.md
@@ -63,31 +63,33 @@ In this example, the Send mediator in a proxy service using the [VFS transport](
 
 #### Create and upload using the WSO2 API Manager Tooling Plug-in
 
-**The recommended way** to engage a mediation extension sequence per API is to create a custom sequence using the [WSO2 API Manager Tooling Plug-in](https://docs.wso2.com/display/AM260/Installing+the+API+Manager+Tooling+Plug-In), upload it via its APIM Perspective and then engage it using the API Publisher. The following tutorial demonstrates how to do this: [Change the Default Mediation Flow of API Requests](../../../Learn/APIGateway/MessageMediation/change-the-default-mediation-flow-of-api-requests.md).
+**The recommended way** to engage a mediation extension sequence per API is to create a custom sequence using the [WSO2 API Manager Tooling Plug-in](https://docs.wso2.com/display/AM260/Installing+the+API+Manager+Tooling+Plug-In), upload it via its APIM Perspective and then engage it using the API Publisher. The following tutorial demonstrates how to do this: [Change the Default Mediation Flow of API Requests](../../../Learn/APIGateway/MessageMediation/change-the-default-mediation-flow-of-api-requests/).
 
 #### Create and upload manually in the API Publisher
 
 You can also create a mediation sequence manually and upload it from the API Publisher itself. For instance, you can copy the above default mediation flow content into an XML file. 
 From the **Left Menu** Goto **Runtime Configurations** and select **Edit** option in the **Message Mediation** section. You can do this for Request, Response and/or Fault message flows.
 
-![](../../../assets/img/Learn/edit-mediation.png)
+![](../../assets/imgLearn/edit-mediation.png)
 
 In the **Select a Mediation Policy** popup you can select **Custom Policies** radio button and upload the above-created mediation XML file.
 Once the file is uploaded, save the API. When you invoke the API, the request is sent to the endpoint referred to in the **To** header.
 
-![](../../../assets/img/Learn/upload-mediation.png)
+![](../../assets/imgLearn/upload-mediation.png)
 #### **Editing a mediation policy**
 
 If you want to edit an already uploaded mediation policy,
 
 1.  Click the download icon next to it, as shown below:
-    ![](../../../assets/img/Learn/download-and-edit-mediation.png)3.  Edit the downloaded mediation XML file and re-upload it as a Custom Policy.
+    ![](../../assets/img/Learn/download-and-edit-mediation.png)
+    
+2.  Edit the downloaded mediation XML file and re-upload it as a Custom Policy.
 
 #### Deselect an already selected a mediation policy
 
 If you want to dis-engage any mediation policy that is already engaged in Request/ Response/ Fault flow you can go to the Edit option as above and select **None** as the mediation policy and save the API.
 
-![](../../../assets/img/Learn/none-mediation.png)
+![](../../assets/img/Learn/none-mediation.png)
 
 #### Create manually and save in the file system
 


### PR DESCRIPTION
## Purpose
Fixed the mkdocs related warning for the Learn/APIGateway files.

```
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/single-endpoint.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/single-endpoint.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/dedicated-endpoint.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/dedicated-endpoint.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/dedicated-backend-def.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/api-gateways-with-dedicated-backends.md' contains a link to '../assets/img/Learn/dedicated-backend-def.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/hybrid-gw.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/hybrid-gw.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/production-sandbox-gws.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/production-sandbox-gws.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/multi-reigion-gw.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/maintaining-separate-production-and-sandbox-gateways.md' contains a link to '../assets/img/Learn/multi-reigion-gw.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/messageTraceronly.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/addEventPublisher.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/message_tracer_logger_publisher.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/analyticsEventPublishing.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/dasStream.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/saveEventStream.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/addReceiver.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/newEventReceiver.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/addEventPublisher.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/newEventPublisher.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/message-tracing.md' contains a link to '../assets/img/Learn/dasMessageData.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/overview-of-the-api-gateway.md' contains a link to '../assets/img/Learn/apim-overview.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/overview-of-the-api-gateway.md' contains a link to '../assets/img/Learn/gateway-overview.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/MessageMediation/convert-a-json-message-to-soap-and-soap-to-json.md' contains a link to 'assets/attachments/Learn/eclipse-create-seq.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/MessageMediation/convert-a-json-message-to-soap-and-soap-to-json.md' contains a link to 'assets/img/Learn/eclipse-push-all-changes.png.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/APIGateway/MessageMediation/pass-a-custom-authorization-token-to-the-backend.md' contains a link to 'assets/img/Learn/custom-header-response.png.png' which is not found in the documentation files.
WARNING -  Documentation file 'Learn/Extensions/adding-mediation-extensions.md' contains a link to '../Learn/APIGateway/MessageMediation/change-the-default-mediation-flow-of-api-requests.md' which is not found in the documentation files.
```