### PR TITLE
Fixed the mkdocs issues related to Learn/Analytics/

### DIFF
--- a/en/docs/Learn/Analytics/AnalyzingAPIMStatisticsWithBatchAnalytics/viewing-api-statistics.md
+++ b/en/docs/Learn/Analytics/AnalyzingAPIMStatisticsWithBatchAnalytics/viewing-api-statistics.md
@@ -194,7 +194,7 @@ The status of the APIs (all API versions) represented in a tabular view.
 !!! note
 <p>Note that only the APIs that have traffic are represented in this tabular representation.</p>
 
-<p><strong>Limited</strong> - If an API receives an alert due to one of the reasons indicated in <a href="Alert-Types_103335140.html#AlertTypes-AvailabilityofAPIs(healthmonitoring)">Availability of APIs (health monitoring)</a> , the API status changes to <strong>Limited</strong> .</p>
+<p><strong>Limited</strong> - If an API receives an alert due to one of the reasons indicated in <a href="../../../Learn/Analytics/ManagingAlertsWithRealTimeAnalytics/alert-types/#availability-of-apis-api-health-monitoring">Availability of APIs (health monitoring)</a> , the API status changes to <strong>Limited</strong> .</p>
 !!! note
 <p>For more information on how to view the generated alerts, see <a href="_Viewing_Alerts_">Viewing Alerts</a> .</p>
 

--- a/en/docs/Learn/Analytics/integrating-with-google-analytics.md
+++ b/en/docs/Learn/Analytics/integrating-with-google-analytics.md
@@ -7,15 +7,15 @@ This guide explains how to setup API Manager in order to feed runtime statistics
 1.  Setup a Google Analytics account if not subscribed already and receive a Tracking ID, which is of the format "UA-XXXXXXXX-X". A Tracking ID is issued at the time an account is created with Google Analytics.
 2.  Log in to the API Manager management console (`https://localhost:9443/carbon`) using admin/admin credentials and go to **Main -&gt; Resources -&gt; Browse** menu.
 
-    ![Browse Management Console](../../../assets/img/Learn/management-console-browse.png)
+    ![Browse Management Console](../../assets/img/Learn/management-console-browse.png)
 
 3.  Navigate to /_system/governance/apimgt/statistics/ga-config.xml file.
 
-    ![ga-config file](../../../assets/img/Learn/ga-config-xml.png)
+    ![ga-config file](../../assets/img/Learn/ga-config-xml.png)
 
 4.  Change the &lt;Enabled&gt; element to `true` , set your tracking ID in &lt;TrackingID&gt; element and **Save**.
 
-    ![Enable Google Analytics Tracking](../../../assets/img/Learn/enable-google-analytics.png)
+    ![Enable Google Analytics Tracking](../../assets/img/Learn/enable-google-analytics.png)
 
 5.  If you want to enable tracking for tenants, log in to the management console with a tenant's credentials, click **Source View**, and then add the following parameter to the `org.wso2.carbon.mediation.registry.WSO2Registry` registry definition near the top (repeat this step for each tenant):
 
@@ -23,23 +23,23 @@ This guide explains how to setup API Manager in order to feed runtime statistics
 
     The following screen shot illustrates this change:
 
-    ![Screen shot of service bus source view with registry configuration highlighted](../../../assets/img/Learn/service-bus-configuration.png)
+    ![Screen shot of service bus source view with registry configuration highlighted](../../assets/img/Learn/service-bus-configuration.png)
     
 6.  API Manager is now integrated with Google Analytics. A user who has subscribed to a published API through the API Store should see an icon as `Real-Time` after logging into their Google Analytics account. Click on this icon and select **Overview**.
 
-7.  Invoke the above API using the embedded [WSO2 REST Client](../../../../Learn/ConsumeAPI/InvokeApis/InvokeApisUsingTools/invoke-an-api-using-the-integrated-api-console/)(or any third-part rest client such as cURL).
+7.  Invoke the above API using the embedded [WSO2 REST Client](../../../Learn/ConsumeAPI/InvokeApis/InvokeApisUsingTools/invoke-an-api-using-the-integrated-api-console/)(or any third-part rest client such as cURL).
 
     #### Real-time statistics
 
 8.  This is one invocation of the API. Accordingly, Google Analytics graphs and statistics will be displayed at runtime. This example displays the **PageViews** per second graph and 1 user as active.
 
-    ![Google Analytics Graphs](../../../assets/img/Learn/google-analytics-graphs.png)
+    ![Google Analytics Graphs](../../assets/img/Learn/google-analytics-graphs.png)
     
     #### Report statistics
 
     Google analytics reporting statistics take more than 24 hours from the time of invocation to populate. Shown below is a sample Dashboard with populated statistics.
 
-    ![Google Analytics Report](../../../assets/img/Learn/google-analytics-report.png)
+    ![Google Analytics Report](../../assets/img/Learn/google-analytics-report.png)
     
     There are widgets with statistics related to Audience, Traffic, Page Content, Visit Duration etc. You can add any widget of your preference to dashboard.
 

--- a/en/docs/Learn/Analytics/purging-analytics-data.md
+++ b/en/docs/Learn/Analytics/purging-analytics-data.md
@@ -19,7 +19,7 @@ Data Purging is enabled by default for all the aggregation tables. However, you 
 
 3.  Click the **edit** link that corresponds to the APIM DATA PURGING business rule.
 
-    ![](../../../assets/img/Learn/business-rules-manager.png)
+    ![](../../assets/img/Learn/business-rules-manager.png)
 
 4.  Click **Save and Deploy** to enable data purging in the `APIMIpAccessSummary` and `APIMIpAccessAlertCount` tables. When the above business rule is enabled, it will purge data from `APIMIpAccessSummary` and `APIMIpAccessAlertCount` tables every time the trigger is triggered. The default time interval for the trigger is 1 years.
 


### PR DESCRIPTION
## Purpose
Fixed the following mkdocs issues related to Learn/Analytics/

```
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/management-console-browse.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/ga-config-xml.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/enable-google-analytics.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/service-bus-configuration.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/google-analytics-graphs.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/integrating-with-google-analytics.md' contains a link to '../assets/img/Learn/google-analytics-report.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/purging-analytics-data.md' contains a link to '../assets/img/Learn/business-rules-manager.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/purging-analytics-data.md' contains a link to '../assets/img/Learn/apim-data-purging-businees-rules-template.png' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/AnalyzingAPIMStatisticsWithBatchAnalytics/viewing-api-statistics.md' contains a link to 'Learn/Analytics/AnalyzingAPIMStatisticsWithBatchAnalytics/Alert-Types_103335140.html' which is not found in the documentation files. 
WARNING -  Documentation file 'Learn/Analytics/MonitoringWithWSO2CarbonMetrics/enabling-metrics-and-storage-types.md' contains a link to 'Learn/Analytics/MonitoringWithWSO2CarbonMetrics/images/icons/grey_arrow_down.png' which is not found in the documentation files. 

```