### PR TITLE
Minor fixes

### DIFF
--- a/en/docs/SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-solaris.md
+++ b/en/docs/SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-solaris.md
@@ -38,7 +38,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
     The file should now look like this:
 
-    ![](../../../../../assets/attachments/103334399/103334401.png)
+    ![](../../../../assets/attachments/103334399/103334401.png)
 
 3.  Save the file.
 

--- a/en/docs/SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-windows.md
+++ b/en/docs/SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-windows.md
@@ -45,7 +45,7 @@ You set up `JAVA_HOME` using the System Properties, as described below. Alternat
 
 2.  In the System Properties window, click the **Advanced** tab, and then click **Environment Variables**.
 
-    ![](../../../../../assets/attachments/26838941/27042150.png)
+    ![](../../../../assets/attachments/26838941/27042150.png)
 
 3.  Click **New** under **System variables** (for all users) or under **User variables** (just for the user who is currently logged in).
 

--- a/en/docs/SetupAndInstall/InstallationGuide/running-the-product.md
+++ b/en/docs/SetupAndInstall/InstallationGuide/running-the-product.md
@@ -89,7 +89,7 @@ Once the server has started, you can run the Management Console by typing its UR
 
 The URL appears next to `Mgt Console URL` in the start script log that is displayed in the command window. For example:
 
-![](../../../assets/img/setup-and-install/running-product-mgt-console-url.png)
+![](../../assets/img/setup-and-install/running-product-mgt-console-url.png)
 
 The URL should be in the following format: `https://<Server Host>:9443/carbon`
 
@@ -152,7 +152,7 @@ Once the server has started, you can run the API Publisher by typing its URL in 
 
 The URL appears next to `API Publisher Default Context` in the start script log that is displayed in the command window. For example:
 
-![](../../../assets/img/setup-and-install/running-product-publisher-url.png)
+![](../../assets/img/setup-and-install/running-product-publisher-url.png)
 
 The URL should be in the following format: `https://<Server Host>:9443/publisher        `
 
@@ -182,7 +182,7 @@ Once the server has started, you can run the Developer Portal by typing its URL 
 
 The URL appears next to `Developer Portal Default Context` in the start script log that is displayed in the command window. For example:
 
-![](../../../assets/img/setup-and-install/running-product-dev-portal-url.png)
+![](../../assets/img/setup-and-install/running-product-dev-portal-url.png)
 
 The URL should be in the following format: `https://<Server Host>:9443/devportal        `
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -372,7 +372,6 @@ nav:
         - Performance Tuning:
               - Tuning Performance: SetupAndInstall/PerfromanceTuningAndTestResults/tuning-performance.md
               - WSO2 API-M Performance and Capacity Planning: SetupAndInstall/PerfromanceTuningAndTestResults/wso2-api-m-performance-and-capacity-planning.md
-              - Performance Tuning and Testing Results: SetupAndInstall/PerfromanceTuningAndTestResults/performance-tuning-and-testing-results.md
         - Upgrading WSO2 API Manager:
               - Upgrading from the Previous Release: SetupAndInstall/UpgradingFromAPreviousRelease/upgrading-from-the-previous-release.md
               - Upgrading from the Previous Release when WSO2 IS is the Key Manager: SetupAndInstall/UpgradingFromAPreviousRelease/upgrading-from-the-previous-release-when-wso2-is-is-the-key-manager.md


### PR DESCRIPTION
## Purpose

- Fixed mkdocs related warnings.
```
WARNING -  Documentation file 'SetupAndInstall/InstallationGuide/running-the-product.md' contains a link to '../assets/img/setup-and-install/running-product-mgt-console-url.png' which is not found in the documentation files. 
WARNING -  Documentation file 'SetupAndInstall/InstallationGuide/running-the-product.md' contains a link to '../assets/img/setup-and-install/running-product-publisher-url.png' which is not found in the documentation files. 
WARNING -  Documentation file 'SetupAndInstall/InstallationGuide/running-the-product.md' contains a link to '../assets/img/setup-and-install/running-product-dev-portal-url.png' which is not found in the documentation files. 
WARNING -  Documentation file 'SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-solaris.md' contains a link to '../assets/attachments/103334399/103334401.png' which is not found in the documentation files. 
WARNING -  Documentation file 'SetupAndInstall/InstallationGuide/InstallingTheProduct/InstallingTheBinary/installing-on-windows.md' contains a link to '../assets/attachments/26838941/27042150.png' which is not found in the documentation files. 
```
- Removed the performance-tuning-and-testing-results page as it was redundant.
