### PR TITLE
Fix confusion in supported cert/keystore types for mutual SSL

### DIFF
--- a/en/docs/Learn/APISecurity/APIAuthentication/secure-apis-using-mutual-ssl.md
+++ b/en/docs/Learn/APISecurity/APIAuthentication/secure-apis-using-mutual-ssl.md
@@ -17,10 +17,7 @@ This section explains how to APIs in WSO2 API Manager can be secured using mutua
 4.  Click **Upload Certificate** to upload a new client certificate.
     
     !!! note
-        This feature currently supports only the following formats for keystores and certificates.
-
-        -   Keystore : `.jks            `
-        -   Certificate : `.crt            `
+        This feature currently supports only the `.crt` format for certificates.
 
         If you need to use a certificate in any other format, you can convert it using a standard tool before uploading.
 


### PR DESCRIPTION
## Purpose
> Remove supported keystore types for mutual SSL. Supported keystore (trust store) is not relavant to here.