### PR TITLE
Change of api store's default url

### DIFF
--- a/en/docs/Learn/ConsumeAPI/Customizations/customize-the-api-store-and-gateway-urls-for-tenants.md
+++ b/en/docs/Learn/ConsumeAPI/Customizations/customize-the-api-store-and-gateway-urls-for-tenants.md
@@ -1,6 +1,6 @@
 # Customize the API Store and Gateway URLs for Tenants
 
-The default URL of WSO2 API Manager Store is `https://<HostName>:9443/store` . Follow the steps below to change the URL of the Gateways and API Store tenants in WSO2 API Manager.
+The default URL of WSO2 API Manager Store is `https://<HostName>:9443/devportal` . Follow the steps below to change the URL of the Gateways and API Store tenants in WSO2 API Manager.
 
 -   [Install Nginx and create SSL certificates](#CustomizetheAPIStoreandGatewayURLsforTenants-InstallNginxandcreateSSLcertificates)
 -   [Setup custom domain mapping in the registry](#CustomizetheAPIStoreandGatewayURLsforTenants-Setupcustomdomainmappingintheregistry)


### PR DESCRIPTION
## Purpose
Just a small documentation correction, the default API store url for the APIM was _'https://<HostName>:9443/store'_, but now it is _'https://<HostName>:9443/devportal'_.