### PR TITLE
Fix postgres database type in migration guide

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-300.md
@@ -381,7 +381,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         ```tab="PostgreSQL"
         [database.apim_db]
-        type = "postgre"
+        type = "postgres"
         url = "jdbc:postgresql://localhost:5432/mig_am_db"
         username = "username"
         password = "password"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
@@ -382,7 +382,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         ```tab="PostgreSQL"
         [database.apim_db]
-        type = "postgre"
+        type = "postgres"
         url = "jdbc:postgresql://localhost:5432/mig_am_db"
         username = "username"
         password = "password"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
@@ -382,7 +382,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         ```tab="PostgreSQL"
         [database.apim_db]
-        type = "postgre"
+        type = "postgres"
         url = "jdbc:postgresql://localhost:5432/mig_am_db"
         username = "username"
         password = "password"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
@@ -381,7 +381,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         ```tab="PostgreSQL"
         [database.apim_db]
-        type = "postgre"
+        type = "postgres"
         url = "jdbc:postgresql://localhost:5432/mig_am_db"
         username = "username"
         password = "password"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
@@ -380,7 +380,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         ```tab="PostgreSQL"
         [database.apim_db]
-        type = "postgre"
+        type = "postgres"
         url = "jdbc:postgresql://localhost:5432/mig_am_db"
         username = "username"
         password = "password"


### PR DESCRIPTION
I have no idea where the second change in en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-300.md came from 