### PR TITLE
Update configuring-wso2-identity-server-as-a-key-manager.md

### DIFF
--- a/en/docs/install-and-setup/deploying-wso2-api-manager/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager.md
+++ b/en/docs/install-and-setup/deploying-wso2-api-manager/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager.md
@@ -182,13 +182,13 @@ The steps to setup and configure the databases for WSO2 IS as the Key Manager no
         ```
         
     ``` tab="Format"        
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://<traffic-manager-ip>:<binary-data-publishing-port>"]
     traffic_manager_auth_urls=["ssl://<traffic-manager-ip>:<binary-data-publishing-authentication-port>"]
     ```
          
     ``` tab="Example"
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://tm.wso2.com:9611"]
     traffic_manager_auth_urls=["ssl://tm.wso2.com:9711"]
     ```
@@ -196,21 +196,21 @@ The steps to setup and configure the databases for WSO2 IS as the Key Manager no
     If the traffic Manager deployment with High Availability(HA), the endpoints of both nodes has to be configured as follows.
     
     ``` tab="Format"        
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://<traffic-manager-1-ip>:<binary-data-publishing-port>"]
     traffic_manager_auth_urls=["ssl://<traffic-manager-1-ip>:<binary-data-publishing-authentication-port>"]
     
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://<traffic-manager-2-ip>:<binary-data-publishing-port>"]
     traffic_manager_auth_urls=["ssl://<traffic-manager-2-ip>:<binary-data-publishing-authentication-port>"]
     ```
          
     ``` tab="Example"
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://tm1.wso2.com:9611"]
     traffic_manager_auth_urls=["ssl://tm1.wso2.com:9711"]
     
-    [apim.throttling.url_group]]
+    [[apim.throttling.url_group]]
     traffic_manager_urls=["tcp://tm2.wso2.com:9611"]
     traffic_manager_auth_urls=["ssl://tm2.wso2.com:9711"]    
     ```


### PR DESCRIPTION
## Purpose
Fixing the wrong documentation.

When we configure the deployment toml as in the documentation, we get the following error. If we configure to have only one square bracket, it will not add any configuration to api-manager.xml. So, correcting it to the proper format.



[2020-03-12 12:49:15,611] ERROR {org.wso2.config.mapper.TomlParser} - Unexpected ']]', expected ] or . (line 91, column 27)
[2020-03-12 12:49:15,611]  SEVERE {org.wso2.carbon.server.Main handleConfiguration} - Error while performing configuration changes
org.wso2.config.mapper.ConfigParserException: Error parsing deployment configuration
	at org.wso2.config.mapper.TomlParser.parse(TomlParser.java:140)
	at org.wso2.config.mapper.ConfigParser.parse(ConfigParser.java:249)
	at org.wso2.config.mapper.ConfigParser.deploy(ConfigParser.java:217)
	at org.wso2.config.mapper.ConfigParser.deployAndStoreMetadata(ConfigParser.java:180)
	at org.wso2.config.mapper.ConfigParser.parse(ConfigParser.java:127)
	at org.wso2.carbon.server.Main.handleConfiguration(Main.java:231)
	at org.wso2.carbon.server.Main.main(Main.java:103)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.wso2.carbon.bootstrap.Bootstrap.loadClass(Bootstrap.java:70)
	at org.wso2.carbon.bootstrap.Bootstrap.main(Bootstrap.java:51)
