### PR TITLE
Add dashboard portal port info to docs.

### DIFF
--- a/en/docs/learn/analytics/default-ports-of-wso2-api-m-analytics.md
+++ b/en/docs/learn/analytics/default-ports-of-wso2-api-m-analytics.md
@@ -2,10 +2,8 @@
 
 Given below are the specific ports used by WSO2 API-M Analytics.
 
-#### Ports inherited from WSO2 SP
-
--   7712 - Thrift SSL port for secure transport, where the client is authenticated to use WSO2 API-M Analytics.
--   7612 - Thrift TCP port where WSO2 API-M Analytics receives events from clients.
--   7444 - The default port for the Streaming Integrator Store API.
--   9444 - MSF4J HTTPS Port in the Streaming Integrator. This is used by the Microgateway.
-
+-   7712 - Thrift SSL port for secure transport, where the client(gateway) is authenticated to use WSO2 API-M Analytics.
+-   7612 - Thrift TCP port where WSO2 API-M Analytics receives events from clients(gateways).
+-   7444 - The default port for the Siddhi Store REST API.
+-   9444 - MSF4J HTTPS Port used to upload analytics data from the microgateway.
+-   9643 - Default port for the analytics dashboard portal. 


### PR DESCRIPTION
## Purpose

Dashboard portal port was missing in the doc. Also reworded Stream processor to APIM Analytics to avoid confusion. 