### PR TITLE
Adds description for analytics dashboard permission delegation to users.

### DIFF
--- a/en/docs/learn/analytics/managing-dashboard-permissions.md
+++ b/en/docs/learn/analytics/managing-dashboard-permissions.md
@@ -37,7 +37,7 @@ Now let's see how we can change the default permissions that is set for each of 
 
 ## Permission Level and User Role Mapping
 
-Following table illustrates the default mapping between permission level for each analytics dashboard and user role for default configuration of permission level, user roles and their scopes.
+Following table illustrates the default mapping between the permission level for each analytics dashboard and user role. This table can be referred to assign a role to a user in order to provide the required permissions. 
 
 | **User role**       | **APIM Admin**    | **APIM Publisher**  | **APIM Developer Portal** |
 |---------------------|-------------------|---------------------|---------------------------|

--- a/en/docs/learn/analytics/managing-dashboard-permissions.md
+++ b/en/docs/learn/analytics/managing-dashboard-permissions.md
@@ -35,3 +35,14 @@ Now let's see how we can change the default permissions that is set for each of 
 !!! Info
       List of available scopes will be populated for each permission level. Dashboard owners can set the required scopes for each of those permission levels. Each permission level can have multiple scopes.
 
+## Permission Level and User Role Mapping
+
+Following table illustrates the default mapping between permission level for each analytics dashboard and user role for default configuration of permission level, user roles and their scopes.
+
+| **User role**       | **APIM Admin**    | **APIM Publisher**  | **APIM Developer Portal** |
+|---------------------|-------------------|---------------------|---------------------------|
+| admin               | Owner / Editor    | Owner / Editor      | Owner / Editor            |
+| Internal/analytics  | Not allowed       | Viewer              | Not allowed               |
+| Internal/creator    | Not allowed       | Viewer              | Not allowed               |
+| Internal/publisher  | Not allowed       | Viewer              | Not allowed               |
+| Internal/subscriber | Not allowed       | Not allowed         | Viewer                    |


### PR DESCRIPTION
## Purpose
Adding description for analytics dashboard permission delegation to users. A flow of defined permission levels are delegated when users log in to the analytics dashboards.

## Goals
Filling the permission delegation gap in the documentation