### PR TITLE
Improve the apictl documentation on CI/CD and change port numbers for dev and prod environments for APIM 3.0.0

### DIFF
--- a/en/docs/learn/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
+++ b/en/docs/learn/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
@@ -5,7 +5,7 @@ and API Publisher Portal. First, an API developer develops his/her own backend m
 Specification for it. Thereafter, he/she can create an API using that OpenAPI specification and deploy it to the desired 
 WSO2 API Management environment without accessing the Publisher Portal directly.
 
-Let's see create a CI/CD pipeline using Jenkins as the automation tool and Github as the source code management repository. Let's use Postman to write the test scripts in order to test the API that is deployed in WSO2 API Manager.
+Let's create a CI/CD pipeline using Jenkins as the automation tool and Github as the source code management repository. Let's use Postman to write the test scripts in order to test the API that is deployed in WSO2 API Manager.
 
 ## Prerequisites
 

--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -37,7 +37,7 @@ Based on the API Project generation, a powerful pipeline for API automation can 
 [![]({{base_path}}/assets/img/learn/api-controller/api-automation-with-openapi-swagger.png)]({{base_path}}/assets/img/learn/api-controller/api-automation-with-openapi-swagger.png)
 
 
-**To migrate APIs using the Developer First approach via CI/CD** carry out <a href="#A">A</a>, <a href="#D">D</a>, <a href="#E">E</a>, and <a href="#F">F</a></a>, which is listed under the Building blocks for creating a CI/CD pipeline section, in sequential order.
+**To migrate APIs using the Developer First approach via CI/CD** carry out <a href="#A">A</a>, <a href="#D">D</a>, <a href="#E">E</a>, and <a href="#F">F</a>, which is listed under the Building blocks for creating a CI/CD pipeline section, in sequential order.
 
 _________________
 ## Building blocks for creating a CI/CD pipeline
@@ -58,17 +58,23 @@ Let us check out the basic building blocks for creating a CI/CD pipeline with WS
 3.  Add API Manager environments using the `add-env` command.
 
     !!! example
-        ``` bash
+        ``` bash tab="Linux/Unix"
         apictl add-env -e dev \
-                    --registration https://localhost:9444/client-registration/v0.15/register \
-                    --apim https://localhost:9444 \
-                    --token https://localhost:8244/token \
-
-        apictl add-env -e prod \
                     --registration https://localhost:9443/client-registration/v0.15/register \
                     --apim https://localhost:9443 \
                     --token https://localhost:8243/token \
+
+        apictl add-env -e prod \
+                    --registration https://localhost:9444/client-registration/v0.15/register \
+                    --apim https://localhost:9444 \
+                    --token https://localhost:8244/token \
         ```
+
+        ``` bash tab="Mac"
+        apictl add-env -e dev --registration https://localhost:9443/client-registration/v0.15/register --apim https://localhost:9443 --token https://localhost:8243/token
+
+        apictl add-env -e prod --registration https://localhost:9444/client-registration/v0.15/register --apim https://localhost:9444 --token https://localhost:8244/token
+        ```  
 
     For more information, see [Add an environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment). 
 
@@ -147,7 +153,7 @@ The **apictl** can export an API as an archive from a lower environment (i.e., d
 <a name="D"></a>
 ### (D.) - Initialize the project using a Swagger/OpenAPI specification
 
-Execute the following command to directly generate the `PetstoreAPI` project using a Swagger/OpenAPI specification.
+Execute the following command to directly generate the `PetstoreAPI` project using a Swagger/OpenAPI specification. (You can download the Swagger/OpenAPI specification from [here](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v2.0/yaml/petstore.yaml).)
 
 !!! example
     ```bash
@@ -260,11 +266,11 @@ The **apictl** tool should be installed in the automation servers to begin the p
 
 3. Sign in to the API Publisher.
 
-     `https://localhost:9443/publisher`
+     `https://localhost:9444/publisher`
 
 4. Check the details of the API.
      
-     You will see that the API has been imported with correct environment-specific details that you defined and also that the API is in the `PUBLISHED` state.
+     You will see that the API has been imported with correct environment-specific details that you defined. Also, If you have followed, <a href="#A">A</a>, <a href="#B">B</a>, <a href="#C">C</a>, <a href="#E">E</a>, and <a href="#F">F</a>, you can see that the API is in the `PUBLISHED` state and if you have followed <a href="#A">A</a>, <a href="#D">D</a>, <a href="#E">E</a>, and <a href="#F">F</a>, then your API will be in `CREATED` state.
 
 !!! info  
     -   When exporting an API, the **apictl** tool will also export the API’s lifecycle status. When importing to another environment, this lifecycle status will be preserved. This ensures that the API has the same state across environments. 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -123,29 +123,29 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
             ``` bash tab="Linux/Unix"
             apictl add-env -e dev \
-                        --registration https://localhost:9444/client-registration/v0.15/register \
-                        --apim https://localhost:9444 \
-                        --token https://localhost:8244/token \
+                        --registration https://localhost:9443/client-registration/v0.15/register \
+                        --apim https://localhost:9443 \
+                        --token https://localhost:8243/token \
             ``` 
 
             ``` bash tab="Mac"
-            ./apictl add-env -e dev --registration https://localhost:9444/client-registration/v0.15/register --apim https://localhost:9444 --token https://localhost:8244/token
+            apictl add-env -e dev --registration https://localhost:9443/client-registration/v0.15/register --apim https://localhost:9443 --token https://localhost:8243/token
             ```               
 
         !!! example
 
             ``` bash tab="Linux/Unix"
             apictl add-env -e production \
-                        --registration https://localhost:9443/client-registration/v0.15/register \
-                        --apim https://localhost:9443 \
-                        --token https://localhost:8243/token \
-                        --admin https://localhost:9443/api/am/admin/v0.15 \
-                        --api_list https://localhost:9443/api/am/publisher/v0.15/apis \
-                        --app_list https://localhost:9443/api/am/store/v0.15/applications
+                        --registration https://localhost:9444/client-registration/v0.15/register \
+                        --apim https://localhost:9444 \
+                        --token https://localhost:8244/token \
+                        --admin https://localhost:9444/api/am/admin/v0.15 \
+                        --api_list https://localhost:9444/api/am/publisher/v0.15/apis \
+                        --app_list https://localhost:9444/api/am/store/v0.15/applications
             ```
 
             ``` bash tab="Mac"
-            apictl add-env -e production --registration https://localhost:9443/client-registration/v0.15/register --apim https://localhost:9443 --token https://localhost:8243/token --admin https://localhost:9443/api/am/admin/v0.15 --api_list https://localhost:9443/api/am/publisher/v0.15/apis --app_list https://localhost:9443/api/am/store/v0.15/applications
+            apictl add-env -e production --registration https://localhost:9444/client-registration/v0.15/register --apim https://localhost:9444 --token https://localhost:8244/token --admin https://localhost:9444/api/am/admin/v0.15 --api_list https://localhost:9444/api/am/publisher/v0.15/apis --app_list https://localhost:9444/api/am/store/v0.15/applications
             ```  
     
     -   **Response**


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/947

## Goals
- Improve the documentation on CI/CD 
- Change the port numbers of dev and prod environments
- Add examples

## Approach
- Add new links and clarification for documentation in https://github.com/wso2/docs-apim/blob/3.0.0/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
- Assigned the lower port number value to dev (lower environment) and larger port value to prod (upper environment)
- Add examples for both linux/unix and mac in appropriate pages