### PR TITLE
Add a Warning on expose endpoint password

### DIFF
--- a/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
@@ -277,6 +277,15 @@ You can use the API archive exported from the previous section and import it to 
 
     3.  Restart API Manager 3.1.0 server.
 
+!!! warning
+    If you have enabled Secure Endpoint (Refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information), the endpoint password will be removed when exporting an API causing an error when you try to import the sane API to an environment. There are 2 solutions for this.
+
+    1.  If Secure Endpoint is enabled and if the endpoint password should be exposed;
+    `ExposeEndpointPassword` should be set to `true` in the `/_system/config/apimgt/applicationdata/tenant-conf.json` in the registry so that the exported API will contain the endpoint password.
+
+    2.  Or else, if Secure Endpoint is enabled and if the endpoint password should not be exposed;
+    `ExposeEndpointPassword` should be set to `false` in the `/_system/config/apimgt/applicationdata/tenant-conf.json` in the registry (by default this is set to `false`). Here, the secure endpoint password is removed while exporting the API, since it may cause security issues. Hence, the password needs to be added manually when importing the API.
+
 ### Import/Export APIs in Tenanted Environments 
 The environments that you create will be common to the admin and the tenants. Therefore, you do not need to create environments again when exporting and importing APIs between tenanted environments.
 

--- a/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
@@ -278,7 +278,7 @@ You can use the API archive exported from the previous section and import it to 
     3.  Restart API Manager 3.1.0 server.
 
 !!! warning
-    If you have enabled Secure Endpoint (Refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information), the endpoint password will be removed when exporting an API causing an error when you try to import the sane API to an environment. There are 2 solutions for this.
+    If you have enabled Secure Endpoint (Refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information), the endpoint password will be removed when exporting an API causing an error when you try to import the same API to an environment. There are 2 solutions for this.
 
     1.  If Secure Endpoint is enabled and if the endpoint password should be exposed;
     `ExposeEndpointPassword` should be set to `true` in the `/_system/config/apimgt/applicationdata/tenant-conf.json` in the registry so that the exported API will contain the endpoint password.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/228

## Goals
Add a message to the user, so that the user can import already exported APIs without getting an error because of the endpoint password is missing but the security is enabled by eliminating the contradicting situation.

## Approach
Add a Warning message as below on the page **Migrating APIs to Different Environments**.
![image](https://user-images.githubusercontent.com/25246848/78920247-b9e75600-7ab0-11ea-9a7e-f54e8b7713a8.png)

## User stories
- Users can refer the documentation here when he/she wants to import an exported API with Secure Endpoint enabled and the endpoint password exposed.
- Users can refer the documentation here when he/she wants to import an exported API with Secure Endpoint enabled and the endpoint password was not exposed.