### PR TITLE
Modify the example in Configuring Environment Specific Parameters

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -44,10 +44,10 @@ The following code snippet contains sample configuration of the parameter file.
             production:
               url: 'https://dev.wso2.com'
           security:
-           - enabled: true
-             type: basic
-             username: admin
-             password: admin
+            - enabled: true
+              type: basic
+              username: admin
+              password: admin
           certs:
             - hostName: 'https://dev.wso2.com'
               alias: Dev
@@ -58,15 +58,15 @@ The following code snippet contains sample configuration of the parameter file.
           endpoints:
             production:
               url: 'https://test.wso2.com'
-          security:
-           - enabled: true
-             type: digest
-             username: admin
-             password: admin
               config:
                 retryTimeOut: $RETRY
             sandbox:
               url: 'https://test.sandbox.wso2.com'
+          security:
+            - enabled: true
+              type: digest
+              username: admin
+              password: admin
     ```
 Instead of the default `api_params.yaml`, you can a provide custom parameter file using `--params` flag. A sample command will be as follows.
 


### PR DESCRIPTION
## Purpose
The security field is misplaced in the example in **Configuring Environment Specific Parameters**. It will be corrected here.

## Goals
Adjust the security field and indents associated with it.

## Approach
The security parameters field under the test environment was moved down and the indents were adjusted for security parameters to match with other parameters as shown below.
![image](https://user-images.githubusercontent.com/25246848/78983881-b1d7f680-7b42-11ea-8b9c-a0ddacbe6558.png)

## User stories
A user can refer to this example and the security parameter setting to know how to do it successfully.