### PR TITLE
Add underscore to database configuration tag

### DIFF
--- a/en/docs/reference/ConfigCatalog.md
+++ b/en/docs/reference/ConfigCatalog.md
@@ -217,7 +217,7 @@ enable_h2_console = true</code></pre>
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
-                            <code>[databaseconfiguration]</code>
+                            <code>[database_configuration]</code>
 
                             <p>
                                 Configurations required to enable browsing the H2 database from a web browser.

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -217,7 +217,7 @@ enable_h2_console = true</code></pre>
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
-                            <code>[databaseconfiguration]</code>
+                            <code>[database_configuration]</code>
 
                             <p>
                                 Configurations required to enable browsing the H2 database from a web browser.

--- a/en/docs/wip/config-catalog.md
+++ b/en/docs/wip/config-catalog.md
@@ -223,7 +223,7 @@ enable_h2_console = true</code></pre>
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
-                            <code>[databaseconfiguration]</code>
+                            <code>[database_configuration]</code>
 
                             <p>
                                 Configurations required to enable browsing the H2 database from a web browser.


### PR DESCRIPTION
## Purpose
Add the missing underscore to the database configuration tag.

## Goals
Correct the word "databaseconfiguration" as "database_configuration" under the topic **Configuration Catalog**.

## Approach
Add an underscore between the words "database" and "configuration".