### PR TITLE
APICTL list apis permissions fix in Docs

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
+++ b/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
@@ -101,8 +101,8 @@ As explained in the above section, you can create any user with a custom role to
 </tr>
 <tr class="even">
 <td>list apis</td>
+<td><strong>API Create</strong> or <strong>API Publish</strong> or <strong>API Subscribe</strong></td>
 <td>-</td>
-<td>apim:api_view</td>
 </tr>
 <tr class="odd">
 <td>import-api</td>

--- a/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
+++ b/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
@@ -102,7 +102,7 @@ As explained in the above section, you can create any user with a custom role to
 <tr class="even">
 <td>list apis</td>
 <td><strong>API Create</strong> or <strong>API Publish</strong> or <strong>API Subscribe</strong></td>
-<td>-</td>
+<td>apim:api_view</td>
 </tr>
 <tr class="odd">
 <td>import-api</td>


### PR DESCRIPTION
## Purpose
Fixing the issue of mentioning users do not need any permission when listing the APIs. (only needed apim:api_view scope)

## Goals
Fixing a doc issue

## Approach
Change it as a user should have either API Create/Publish/Subscriber Permission to listing apis.


![image](https://user-images.githubusercontent.com/42435576/80278200-facaa600-8711-11ea-9565-eccea30cfb93.png)

