### PR TITLE
Add documentation to describe listing and deleting APIs/API Products/Applications and generating keys for APIs/API Products using the API Controller

### DIFF
--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -248,24 +248,24 @@ The **apictl** tool should be installed in the automation servers to begin the p
     in the testing environment. This default behavior can be changed via the **apictl** tool, which assigns APIs the `CREATED` state after importing. 
 
 <a name="G"></a>
-### (G.) - Get keys for an API
+### (G.) - Get keys for an API/API Product
 
-Follow the instructions below to generate a JWT/OAuth token for testing purposes using CTL in order to invoke an API by subscribing to it using a new application created by CTL:
+Follow the instructions below to generate a JWT/OAuth token for testing purposes using CTL in order to invoke an API or an API Product by subscribing to it using a new application created by CTL:
 
 !!! tip
     - Make sure that WSO2 API Manager is started and the CTL tool is running. For more information, see [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool). 
     - You should log in to the API Manager in the environment by following the instructions in [Login to an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#login-to-an-environment).
 
-Run any of the following CTL commands to get keys for the API.
+Run any of the following CTL commands to get keys for the API/API Product.
 
 - **Command**
 
     ```bash
-    apictl get-keys -n <API name> -v <API version> -r <API provider> -e <environment> -k
+    apictl get-keys -n <API or API Product name> -v <API or API Product version> -r <API or API Product provider> -e <environment> -k
     ```  
 
     ```bash
-    apictl get-keys --name <API name> --version <API version> --provider <API provider> --environment <environment> -k
+    apictl get-keys --name <API or API Product name> --version <API or API Product version> --provider <API or API Product provider> --environment <environment> -k
     ```
 
     !!! example
@@ -277,13 +277,15 @@ Run any of the following CTL commands to get keys for the API.
             
         -   Required :  
             `--environment` or `-e` : Key generation environment  
-            `--name` or `-n` : API to enerate keys for  
-            `--version` or `-v` : Version of the API  
-            `--provider` or `-r` : Provider of the API   
+            `--name` or `-n` : API or API Product to enerate keys for   
+        -   Optional :  
+            `--provider` or `-r` : Provider of the API or API Product  
+            `--version` or `-v` : Version of the API or API Product (Currently API Products do not have versions)
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 
     - Using apictl tool the token type , HTTP request timeout, and export directory can be set up and changed. For more information on changing the token type, see [Set token type]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#set-token-type), [Set HTTP request timeout]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#set-http-request-timeout) and [Set export directory]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/##set-export-directory) accordingly. 
+    - When running the above command, if you have not specified the --version (-v), the tool will consider the version as 1.0.0 by default. If you have specified the version, then that value will be considered.
 
 Now, you know the building blocks of creating a CI/CD pipeline using **apictl**. By using the above, you can create 
 an automated pipeline for API promotion between environments using either one of the latter mentioned approaches. 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -456,6 +456,132 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             36d51e55-3f1e-4f85-86ee-8fe73b0c8adff  SampleApplication   sampleUser  APPROVED   orgA
             ``` 
         
+## Delete an API/API Product/Application in an environment
+Follow the instructions below to delete an API/API Product/Application in an environment using CTL:
+
+1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
+For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
+2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
+3.  Run the corresponding CTL command below to delete an API/API Product/Application in an environment.
+
+    1. Delete an API in an environment.
+
+        -   **Command**
+            ``` bash
+            apictl delete api -n <API name> -v <API version> -e <environment> -k
+            ```
+            ``` bash
+            apictl delete api --name <API name> --version <API version> --environment <environment> --insecure
+            ```
+            ``` bash
+            apictl delete api --name <API name> --version <API version> --environment <environment> --provider <API provider> --insecure
+            ```
+
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment from which the API should be deleted  
+                    `--name` or `-n` : Name of the API to be deleted  
+                    `--version` or `-v` : Version of the API to be deleted  
+                -   Optional :  
+                    `--provider` or `-r` : Provider of the API to be deleted  
+
+            !!! example
+                ```bash
+                apictl delete api -n PizzaShackAPI -v 1.0.0 -e dev -k
+                ```
+                ```bash
+                apictl delete api --name PizzaShackAPI --version 1.0.0 --environment production --insecure
+                ```    
+                ```go
+                apictl delete api --name PizzaShackAPI --version 1.0.0 --environment production --provider Alice --insecure
+                ```  
+
+        -   **Response**
+
+            ```go
+            PizzaShackAPI API deleted successfully!
+            ```
+
+    2. Delete an API Product in an environment.
+
+        -   **Command**
+            ``` bash
+            apictl delete api-product -n <API Product name> -e <environment> -k
+            ```
+            ``` bash
+            apictl delete api-product --name <API Product name> --environment <environment> --insecure
+            ```
+            ``` bash
+            apictl delete api-product --name <API Product name> --environment <environment> --provider <API Product provider> --insecure
+            ```
+
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment from which the API Product should be deleted  
+                    `--name` or `-n` : Name of the API Prodcut to be deleted   
+                -   Optional :  
+                    `--provider` or `-r` : Provider of the API Product to be deleted  
+
+            !!! example
+                ```bash
+                apictl delete api-product -n LeasingAPIProduct -e dev -k
+                ```
+                ```bash
+                apictl delete api-product --name LeasingAPIProduct -environment production --insecure
+                ```    
+                ```go
+                apictl delete api-product --name LeasingAPIProduct --environment production --provider Alice --insecure
+                ```  
+
+        -   **Response**
+
+            ```go
+            LeasingAPIProduct API Product deleted successfully!
+            ```
+    
+    3. Delete an Application in an environment.
+
+        -   **Command**
+            ``` bash
+            apictl delete app -n <application name> -e <environment> -k
+            ```
+            ``` bash
+            apictl delete app -name <application name> --environment <environment> --insecure
+            ```
+            ``` bash
+            apictl delete app --name <application name> --environment <environment> --owner <application owner> --insecure
+            ```
+
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment from which the Application should be deleted  
+                    `--name` or `-n` : Name of the Application to be deleted   
+                -   Optional :  
+                    `--owner` or `-o` : Owner of the Application to be deleted  
+
+            !!! example
+                ```bash
+                apictl delete app -n DefaultApplication -e dev -k
+                ```
+                ```bash
+                apictl delete app --name DefaultApplication --environment production --insecure
+                ```    
+                ```go
+                apictl delete app --name DefaultApplication --environment production --owner sampleUser --insecure
+                ```  
+
+        -   **Response**
+
+            ```go
+            DefaultApplication Application deleted successfully!
+            ``` 
+
 ## Set token type
 
 Run the following CTL command to set the token type of the default apictl application.

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -325,98 +325,136 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             apictl logout dev
             ```
 
-## List APIs of an environment
-Follow the instructions below to display a list of APIs in an environment using CTL:
+## List APIs/API Products/Applications in an environment
+Follow the instructions below to display a list of APIs/API Products/Applications in an environment using CTL:
 
 1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
-3.  Run any of the following CTL commands to list the APIs.
+3.  Run the corresponding CTL command below to list APIs/API Products/Applications in an environment.
 
-    -   **Command**
-        ``` bash
-        apictl list apis -e <environment> -k
-        ```
-        ``` bash
-        apictl list apis --environment <environment> --insecure
-        ```
-        ``` bash
-        apictl list apis --environment <environment> --query <API search query> --insecure
-        ```
+    1. List APIs in an environment.
 
-        !!! info
-            **Flags:**  
-            
-            -   Required :  
-                `--environment` or `-e` : Environment to be searched  
-            -   Optional :  
-                `--query` or `-q` : Search query pattern 
-
-        !!! example
-            ```bash
-            apictl list apis -e dev -k
+        -   **Command**
+            ``` bash
+            apictl list apis -e <environment> -k
             ```
-            ```bash
-            apictl list apis --environment production --insecure
-            ```    
-            ```go
-            apictl list apis --environment production --query "provider:Alice name:PizzaShackAPI" --insecure
-            ```  
-
-    -   **Response**
-
-        ```go
-        ID                                     NAME                VERSION             CONTEXT             STATUS              PROVIDER
-        12d6e73c-778d-45ac-b57d-117c6c5092a4   PhoneVerification   1.0                 /phoneverify        PUBLISHED           admin
-        91fe87c3-f0d7-4c35-81f5-0e0e42d8e19f   PizzaShackAPI       2.0.0               /pizzashack         CREATED             Alice
-        ```
-
-## List applications of an environment
-Follow the instructions below to display a list of applications in an environment using CTL:
-
-1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
-For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
-2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
-3.  Run any of the following CTL commands to list the applications.
-
-    -   **Command**
-        ``` bash
-        apictl list apps -e <environment> -k
-        ```
-        ``` bash
-        apictl list apps --environment <environment> --insecure
-        ```
-        ``` bash
-        apictl list apps --environment <environment> --owner <application owner> --insecure
-        ```
-
-        !!! info
-            **Flags:**  
-            
-            -   Required :  
-                `--environment` or `-e` : Environment to be searched  
-            -   Optional :  
-                `--owner` or `-o` : Owner of the Application 
-
-        !!! example
-            ```bash
-            apictl list apps -e dev -k
+            ``` bash
+            apictl list apis --environment <environment> --insecure
             ```
-            ```bash
-            apictl list apps --environment production --insecure
-            ```    
+            ``` bash
+            apictl list apis --environment <environment> --query <API search query> --insecure
+            ```
+
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment to be searched  
+                -   Optional :  
+                    `--query` or `-q` : Search query pattern  
+                    `--limit` or `-l` : Maximum number of APIs to return
+
+            !!! example
+                ```bash
+                apictl list apis -e dev -k
+                ```
+                ```bash
+                apictl list apis --environment production --insecure
+                ```    
+                ```go
+                apictl list apis --environment production --query provider:Alice name:PizzaShackAPI --insecure
+                ```  
+
+        -   **Response**
+
             ```go
-            apictl list apps --environment production --owner sampleUser --insecure
-            ```  
+            ID                                     NAME                VERSION             CONTEXT             STATUS              PROVIDER
+            12d6e73c-778d-45ac-b57d-117c6c5092a4   PhoneVerification   1.0                 /phoneverify        PUBLISHED           admin
+            91fe87c3-f0d7-4c35-81f5-0e0e42d8e19f   PizzaShackAPI       2.0.0               /pizzashack         CREATED             Alice
+            ```
 
-    -   **Response**
+    2. List API Products in an environment.
+    
+        -   **Command**
+            ``` bash
+            apictl list api-products -e <environment> -k
+            ```
+            ``` bash
+            apictl list api-products --environment <environment> --insecure
+            ```
+            ``` bash
+            apictl list api-products --environment <environment> --query <API search query> --insecure
+            ```
 
-        ```go
-        ID                                     NAME                OWNER       STATUS     GROUP ID
-        29b4fcc6-05a4-42a7-aa64-f1a1b8a7b979   DefaultApplication  admin       APPROVED 
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment to be searched  
+                -   Optional :  
+                    `--query` or `-q` : Search query pattern  
+                    `--limit` or `-l` : Maximum number of API Products to return
 
-        36d51e55-3f1e-4f85-86ee-8fe73b0c8adff  SampleApplication   sampleUser  APPROVED   orgA
-        ```  
+            !!! example
+                ```bash
+                apictl list api-products -e dev -k
+                ```
+                ```bash
+                apictl list api-products --environment production --insecure
+                ```    
+                ```go
+                apictl list api-products --environment production --query provider:Alice name:PizzaShackAPI --limit 25 --insecure
+                ```  
+
+        -   **Response**
+
+            ```go
+            ID                                     NAME                CONTEXT              STATUS              PROVIDER
+            b39e08d7-caa9-40d0-a430-b8e840dd7c31   LeasingAPIProduct   /leasingapiproduct   PUBLISHED           admin
+            ab422af2-b19e-4e6a-a34b-8f45c50db0d5   CreditAPIProduct    /creditapiproduct    PUBLISHED           Alice
+            ```
+    
+    3. List Applications in an environment.
+
+        -   **Command**
+            ``` bash
+            apictl list apps -e <environment> -k
+            ```
+            ``` bash
+            apictl list apps --environment <environment> --insecure
+            ```
+            ``` bash
+            apictl list apps --environment <environment> --owner <application owner> --insecure
+            ```
+
+            !!! info
+                **Flags:**  
+                
+                -   Required :  
+                    `--environment` or `-e` : Environment to be searched  
+                -   Optional :  
+                    `--owner` or `-o` : Owner of the Application  
+                    `--limit` or `-l` : Maximum number of applications to return
+
+            !!! example
+                ```bash
+                apictl list apps -e dev -k
+                ```
+                ```bash
+                apictl list apps --environment production --insecure
+                ```    
+                ```go
+                apictl list apps --environment production --owner sampleUser --insecure
+                ```  
+
+        -   **Response**
+
+            ```go
+            ID                                     NAME                OWNER       STATUS     GROUP ID
+            29b4fcc6-05a4-42a7-aa64-f1a1b8a7b979   DefaultApplication  admin       APPROVED 
+            36d51e55-3f1e-4f85-86ee-8fe73b0c8adff  SampleApplication   sampleUser  APPROVED   orgA
+            ``` 
         
 ## Set token type
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/284
Fixes: https://github.com/wso2/product-apim-tooling/issues/294
Fixes documentation issues on get-keys, listing and deleting API Products in https://github.com/wso2/product-apim-tooling/issues/288

## Goals
Modifying the documentation on listing APIs/API Products /Applications, generating keys for APIs/API Products and deleting APIs/API Products /Applications using API Controller.

## Approach
- Restructured the documentation on listing APIs and applications by adding a new topic as **List APIs/API Products/Applications in an environment** to the page **Getting Started with WSO2 API Controller** as follows.
![list](https://user-images.githubusercontent.com/25246848/80945325-339d0600-8e09-11ea-9ccf-ecf2144bbd6c.png)

- Added the documentation on **Delete APIs/API Products/Applications in an environment** to the page **Getting Started with WSO2 API Controller** as follows.
![delete](https://user-images.githubusercontent.com/25246848/80945573-b756f280-8e09-11ea-8bba-befc92f1cf5c.png)

- Modify documentation on **Get keys for an API** to **Get keys for an API/API Product** by making version and the provider flags optional while also enhancing it to be used in API Products as shown below.
![get-keys](https://user-images.githubusercontent.com/25246848/80945915-83300180-8e0a-11ea-94ed-29f0610d2e80.png)

## User stories
Users can refer to the documentation to learn how to list or delete APIs/API Products/Applications and generate keys for an API/API Product using the API Controller. 

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/286
https://github.com/wso2/product-apim-tooling/pull/287
https://github.com/wso2/product-apim-tooling/pull/295