### PR TITLE
[Docs] Change examples and commands given under remove-env command 

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -187,18 +187,12 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
     -   **Command**
 
         ```bash
-        apictl remove-env -e <environment-name> 
+        apictl remove env <environment-name> 
         ``` 
 
-        !!! info
-            **Flags:**  
-            
-            -    Required :     
-                `--environment` or `-e`: Name of the environment to be removed  
-  
         !!! example
             ```bash
-            apictl remove-env --environment production
+            apictl remove env production
             ```
 
     -   **Response**


### PR DESCRIPTION
## Purpose
In documents the environment remove command and related examples are given in the format of
remove-env -e <environment_name>. But with the fix https://github.com/wso2/product-apim-tooling/pull/296/files this command structure is changed and those changes has to be reflected in Docs also

## Goals
Fixes : https://github.com/wso2/product-apim-tooling/issues/297

## Approach
Change command and examples as apictl **remove env <environment_name>**

![image](https://user-images.githubusercontent.com/42435576/81094707-8b2e9500-8f21-11ea-95da-8e90cc1a9ae7.png)



## Test environment
MacOS Catallina 10.15.4
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.