### PR TITLE
Remove documentation changes related to the functionalities get-keys, list and delete API Products

### DIFF
--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -248,24 +248,24 @@ The **apictl** tool should be installed in the automation servers to begin the p
     in the testing environment. This default behavior can be changed via the **apictl** tool, which assigns APIs the `CREATED` state after importing. 
 
 <a name="G"></a>
-### (G.) - Get keys for an API/API Product
+### (G.) - Get keys for an API
 
-Follow the instructions below to generate a JWT/OAuth token for testing purposes using CTL in order to invoke an API or an API Product by subscribing to it using a new application created by CTL:
+Follow the instructions below to generate a JWT/OAuth token for testing purposes using CTL in order to invoke an API by subscribing to it using a new application created by CTL:
 
 !!! tip
     - Make sure that WSO2 API Manager is started and the CTL tool is running. For more information, see [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool). 
     - You should log in to the API Manager in the environment by following the instructions in [Login to an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#login-to-an-environment).
 
-Run any of the following CTL commands to get keys for the API/API Product.
+Run any of the following CTL commands to get keys for the API.
 
 - **Command**
 
     ```bash
-    apictl get-keys -n <API or API Product name> -v <API or API Product version> -r <API or API Product provider> -e <environment> -k
+    apictl get-keys -n <API name> -v <API version> -r <API provider> -e <environment> -k
     ```  
 
     ```bash
-    apictl get-keys --name <API or API Product name> --version <API or API Product version> --provider <API or API Product provider> --environment <environment> -k
+    apictl get-keys --name <API name> --version <API version> --provider <API provider> --environment <environment> -k
     ```
 
     !!! example
@@ -277,10 +277,10 @@ Run any of the following CTL commands to get keys for the API/API Product.
             
         -   Required :  
             `--environment` or `-e` : Key generation environment  
-            `--name` or `-n` : API or API Product to enerate keys for   
+            `--name` or `-n` : API to generate keys for   
         -   Optional :  
-            `--provider` or `-r` : Provider of the API or API Product  
-            `--version` or `-v` : Version of the API or API Product (Currently API Products do not have versions)
+            `--provider` or `-r` : Provider of the API  
+            `--version` or `-v` : Version of the API  
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -319,7 +319,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             apictl logout dev
             ```
 
-## List APIs/API Products/Applications in an environment
+## List APIs/Applications in an environment
 Follow the instructions below to display a list of APIs/API Products/Applications in an environment using CTL:
 
 1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
@@ -386,48 +386,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                 If no advanced attribute modifier has been specified, the API names containing the search term will 
                 be returned as a result.
 
-    2. List API Products in an environment.
-    
-        -   **Command**
-            ``` bash
-            apictl list api-products -e <environment> -k
-            ```
-            ``` bash
-            apictl list api-products --environment <environment> --insecure
-            ```
-            ``` bash
-            apictl list api-products --environment <environment> --query <API search query> --insecure
-            ```
-
-            !!! info
-                **Flags:**  
-                
-                -   Required :  
-                    `--environment` or `-e` : Environment to be searched  
-                -   Optional :  
-                    `--query` or `-q` : Search query pattern  
-                    `--limit` or `-l` : Maximum number of API Products to return
-
-            !!! example
-                ```bash
-                apictl list api-products -e dev -k
-                ```
-                ```bash
-                apictl list api-products --environment production --insecure
-                ```    
-                ```go
-                apictl list api-products --environment production --query provider:Alice name:PizzaShackAPI --limit 25 --insecure
-                ```  
-
-        -   **Response**
-
-            ```go
-            ID                                     NAME                CONTEXT              STATUS              PROVIDER
-            b39e08d7-caa9-40d0-a430-b8e840dd7c31   LeasingAPIProduct   /leasingapiproduct   PUBLISHED           admin
-            ab422af2-b19e-4e6a-a34b-8f45c50db0d5   CreditAPIProduct    /creditapiproduct    PUBLISHED           Alice
-            ```
-    
-    3. List Applications in an environment.
+    2. List Applications in an environment.
 
         -   **Command**
             ``` bash
@@ -468,7 +427,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             36d51e55-3f1e-4f85-86ee-8fe73b0c8adff  SampleApplication   sampleUser  APPROVED   orgA
             ``` 
         
-## Delete an API/API Product/Application in an environment
+## Delete an API/Application in an environment
 Follow the instructions below to delete an API/API Product/Application in an environment using CTL:
 
 1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
@@ -515,47 +474,8 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             ```go
             PizzaShackAPI API deleted successfully!
             ```
-
-    2. Delete an API Product in an environment.
-
-        -   **Command**
-            ``` bash
-            apictl delete api-product -n <API Product name> -e <environment> -k
-            ```
-            ``` bash
-            apictl delete api-product --name <API Product name> --environment <environment> --insecure
-            ```
-            ``` bash
-            apictl delete api-product --name <API Product name> --environment <environment> --provider <API Product provider> --insecure
-            ```
-
-            !!! info
-                **Flags:**  
-                
-                -   Required :  
-                    `--environment` or `-e` : Environment from which the API Product should be deleted  
-                    `--name` or `-n` : Name of the API Prodcut to be deleted   
-                -   Optional :  
-                    `--provider` or `-r` : Provider of the API Product to be deleted  
-
-            !!! example
-                ```bash
-                apictl delete api-product -n LeasingAPIProduct -e dev -k
-                ```
-                ```bash
-                apictl delete api-product --name LeasingAPIProduct -environment production --insecure
-                ```    
-                ```go
-                apictl delete api-product --name LeasingAPIProduct --environment production --provider Alice --insecure
-                ```  
-
-        -   **Response**
-
-            ```go
-            LeasingAPIProduct API Product deleted successfully!
-            ```
     
-    3. Delete an Application in an environment.
+    2. Delete an Application in an environment.
 
         -   **Command**
             ``` bash


### PR DESCRIPTION
## Purpose
Removing the changes related to API Products that have been done in https://github.com/wso2/docs-apim/pull/1134

## Goals
Remove API Product related information from the API Controller documentation since the full feature is not completed yet.

## Approach
Removed API Product related documentation content from the sections **Getting Started with WSO2 API Controller** and **CI/CD with WSO2 API Manager**.

## Related PRs
https://github.com/wso2/docs-apim/pull/1134