### PR TITLE
[Docs]Support x-wso2 Swagger extensions that are already supported by Micro Gateway when importing OAS definitions.-(MasterBranch)

### DIFF
--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -136,7 +136,149 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
 
             First you need to define the scope name (products:read) under `security > default` section inside the required resource and then define the role binding under the `securitySchemes` section.
 
-            Make sure to set the security name as **`default`** when defining the scopes.        
+            Make sure to set the security name as **`default`** when defining the scopes.
+            
+        !!! note
+            You can define WSO2 APIM supported open API extensions for an API when defining a Swagger2 or OpenAPI3 specification to generate an API. These extensions can be used to define endpoint configurations, runtime configurations, resource level, and API level throttling, transport-level security, and CORS configurations and response cache configurations. The list of APIM supported open API extensions is as follows.
+
+            <table>
+                <tbody>
+                    <tr>
+                        <td>
+                            <p><strong>Extension</strong></p>
+                        </td>
+                        <td>
+                            <p><strong>Description</strong></p>
+                        </td>
+                        <td>
+                            <p><strong>API Level/ Resource Level</strong></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-basePath</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">The base path which gateway exposes the API</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level&nbsp;</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-production-endpoints</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify the actual back end of the service</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-sandbox-endpoints</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify the sandbox endpoint of the service if available</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-throttling-tier</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify the rate-limiting for the API or resource</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level/ Resource level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-cors</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify CORS configuration for the API</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level&nbsp;</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-disable-security</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">The resource can be invoked without any authentication</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Resource level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-response-cache</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Enable response caching when creating a new API with cache timeout</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-mutual-ssl</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Enable mutual ssl for API</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-auth-header</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify the authorization header for the API in which either bearer or basic token is sent</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level&nbsp;</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-transports</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify the transport security for the API(http, https and mutual SSL)</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level&nbsp;</span></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p><span style="font-weight: 400;">x-wso2-application-security</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">Specify application security (basic_auth, api_key, oauth2)</span></p>
+                        </td>
+                        <td>
+                            <p><span style="font-weight: 400;">API level/ Resource level</span></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            Let's see how these OpenAPI extensions are used in [Open API definition](https://github.com/wso2/product-microgateway/blob/master/samples/endpoint_by_reference_sample.yaml).
 
      A project folder with the following default structure will be created in the given directory.
 

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -139,7 +139,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
             Make sure to set the security name as **`default`** when defining the scopes.
             
         !!! note
-            You can define WSO2 APIM supported open API extensions for an API when defining a Swagger2 or OpenAPI3 specification to generate an API. These extensions can be used to define endpoint configurations, runtime configurations, resource level, and API level throttling, transport-level security, and CORS configurations and response cache configurations. The list of APIM supported open API extensions is as follows.
+            You can define WSO2 APIM supported open API extensions for an API when defining a Swagger2 or OpenAPI3 specification to generate an API. These extensions can be used to define endpoint configurations, runtime configurations, resource level throttling, and API level throttling, transport-level security, CORS configurations and response cache configurations. The list of APIM supported OpenAPI extensions is as follows.
 
             <table>
                 <tbody>

--- a/en/docs/learn/api-gateway/response-caching.md
+++ b/en/docs/learn/api-gateway/response-caching.md
@@ -14,6 +14,17 @@ Please follow below steps to enable response caching for an API.
 
     ![]({{base_path}}/assets/img/learn/enable-response-caching.png)
 
+    !!! note
+        When creating a new API by using a swagger or open API definition, response caching can be set up by defining an APIM supported open API extension **“x-wso2-response-cache”**.
+
+        !!! example
+            ```yaml
+             x-wso2-response-cache: 
+                enabled: true
+                cacheTimeoutInSeconds: 400
+            ```
+
+
 3.  If you want to change the default response caching settings, edit the following cache mediator properties in the `<API-M_HOME>/repository/resources/api_templates/velocity_template.xml` file:
 
     <table>

--- a/en/docs/learn/api-security/api-authentication/secure-apis-using-oauth2-tokens.md
+++ b/en/docs/learn/api-security/api-authentication/secure-apis-using-oauth2-tokens.md
@@ -220,6 +220,13 @@ Follow the instructions below to add a customized authorization header for an AP
 
 3.  Save and Publish the API.
 
+!!! note
+       When creating an API by importing a swagger or open API definition, the user can define the customized authorization header in the OAS definition using the **“x-wso2-auth-header”** extension.
+
+      ```yaml
+         x-wso2-auth-header: "CustomAuthorizationHeader"
+      ```
+      
 ##Try out the customized authorization header
   
 Before you start , sign in to the API Publisher and deploy the sample API ( `PizzaShackAPI` ) if you haven't done so already, as the following example is based on that API.

--- a/en/docs/learn/design-api/advanced-topics/enabling-cors-for-apis.md
+++ b/en/docs/learn/design-api/advanced-topics/enabling-cors-for-apis.md
@@ -49,6 +49,30 @@ Follow the instructions below to enable CORS response headers globally. Once thi
 
      After you enable CORS, you will be able to see the CORS response header configuration section. 
      
+    !!! note
+        When creating a new API by using a swagger or open API definition, response caching can be set up by defining an APIM supported open API extension **“x-wso2-cors”**.
+        !!! example
+            ```yaml
+            x-wso2-cors: 
+                corsConfigurationEnabled: true
+                accessControlAllowOrigins: 
+                    - "*"
+                accessControlAllowCredentials: false
+                accessControlAllowHeaders: 
+                    - "authorization"
+                    - "Access-Control-Allow-Origin"
+                    - "Content-Type"
+                    - "SOAPAction"
+                    - "apikey"
+                accessControlAllowMethods: 
+                    - "GET"
+                    - "PUT"
+                    - "POST"
+                    - "DELETE"
+                    - "PATCH"
+                    - "OPTIONS"
+            ```
+
 4. Configure the CORS related configurations.
      
      Listed below are the CORS specific response headers supported by the API Gateway and how to configure them.

--- a/en/docs/learn/design-api/create-api/create-a-rest-api-from-a-swagger-definition.md
+++ b/en/docs/learn/design-api/create-api/create-a-rest-api-from-a-swagger-definition.md
@@ -94,6 +94,19 @@ Follow the instructions below to create a REST API using a Open API definition f
      </div>
      </html>
 
+   <html><div class="admonition note">
+     <p class="admonition-title">Note</p>
+        <p> Transport Level Security defines the transport protocol on which the API is exposed. When creating a new API by using a swagger or open API definition, these transport security schemes can be defined using  <b>“x-wso2- transports”</b>and <b>"x-wso2-mutual-ssl”</b>extensions.</p>
+        <div>
+            ```yaml
+            x-wso2-mutual-ssl: "optional"
+            x-wso2-transports: 
+                - "https"
+                - “http”
+            ```
+        </div>
+    </div></html>
+    
 ## Subscriptions
    Navigate to **Subscriptions** page and select **Gold** and **Silver** as the Bussiness plans. After Click **SAVE**
 

--- a/en/docs/learn/rate-limiting/setting-throttling-limits.md
+++ b/en/docs/learn/rate-limiting/setting-throttling-limits.md
@@ -145,4 +145,3 @@ It is also possible to specify a bandwidth per unit time instead of a number of 
                     x-wso2-throttling-tier: 20kPerMin
             ```
 </div>
-

--- a/en/docs/learn/rate-limiting/setting-throttling-limits.md
+++ b/en/docs/learn/rate-limiting/setting-throttling-limits.md
@@ -122,3 +122,27 @@ The default throttling levels are as follows:
 -   **Unlimited:** Unlimited access. The **Default Application** , which is provided out of the box has the tier set to Unlimited.
 
 It is also possible to specify a bandwidth per unit time instead of a number of requests. This can be done through the Admin Portal of API Manager. For information on editing the values of the existing tiers, defining new tiers and specifying a bandwidth per unit time, see [Adding a new application-level throttling tier](../adding-new-throttling-policies/#adding-a-new-application-level-throttling-tier) .
+<div class="admonition info">
+<p class="admonition-title">Note</p>
+<p> When creating an API by importing a swagger or open API definition, the user can define the throttle policies for both API level and resource level using the <b>“x-wso2-throttling-tier"</b> extension.</p>
+            ```yaml
+            x-wso2-basePath: /petstore/v1
+            x-wso2-throttling-tier: 10kPerMin
+            x-wso2-production-endpoints:
+            urls:
+            - https://petstore.swagger.io/v2
+            ```
+<p>Resource level throttle policies also can be defined as well.</p>
+            ```yaml
+            paths:
+                "/pet/findByStatus":
+                    get:
+                    tags:
+                    - pet
+                    summary: Finds Pets by status
+                    description: Multiple status values can be provided with comma separated strings
+                    operationId: findPetsByStatus
+                    x-wso2-throttling-tier: 20kPerMin
+            ```
+</div>
+


### PR DESCRIPTION
## Purpose
With the Fix related to wso2/carbon-apimgt#8485 some of the content in the docs will have to change. As it states when importing an OASDefinition through APIM Publisher Portal or using apictl tool, X-WSO2 vendor extensions are assigned as it fits the newly created API if they are defined in the OAS Definition. This PR will revise and change related topics according to the newly provided support. 


## Goals
Fixes https://github.com/wso2/product-apim/issues/8036

## Approach
**New table about APIM supported open API extensions is added**

![image](https://user-images.githubusercontent.com/42435576/81611496-c84ec780-93f8-11ea-9428-89777e10a885.png)


**The places where the above extensions can be used are provided in the docs under the relevant topics.** 
![image](https://user-images.githubusercontent.com/42435576/81611306-727a1f80-93f8-11ea-9cb8-e096f0837348.png)

![image](https://user-images.githubusercontent.com/42435576/81611374-90e01b00-93f8-11ea-9e19-75a3f7d729bb.png)




## Test environment
Java 1.8_241
MacOS Catalina 10.15.4
