### PR TITLE
Adding documentation content to explain the usage of the owner flag when listing apps using the API Controller

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -466,7 +466,13 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             ID                                     NAME                OWNER       STATUS     GROUP ID
             29b4fcc6-05a4-42a7-aa64-f1a1b8a7b979   DefaultApplication  admin       APPROVED 
             36d51e55-3f1e-4f85-86ee-8fe73b0c8adff  SampleApplication   sampleUser  APPROVED   orgA
-            ``` 
+            ```
+
+            !!! tip 
+                When using the `apictl list apps -e dev` command, you can either specify `-o` (`--owner`) flag or not.
+
+                - When someone has invoked the command **without specifying the owner flag**, it will list all the applications in that environment which belongs to the tenant that the currently logged in user belongs.
+                - When someone has invoked the command **by specifying the owner flag**, it will list all the applications belongs to that particular owner in that environment.
         
 ## Delete an API/API Product/Application in an environment
 Follow the instructions below to delete an API/API Product/Application in an environment using CTL:


### PR DESCRIPTION
## Purpose
Adding documentation for https://github.com/wso2/product-apim-tooling/issues/205

## Goals
Add documentation content to explain the usage of the owner (-o/--owner) flag when listing application using the API Controller.

## Approach
Added a tip in the page **Getting Started with WSO2 API Controller** under the section **c. List Applications in an environment**.
![image](https://user-images.githubusercontent.com/25246848/83502991-0b73f600-a4e0-11ea-8d22-e0f5bb3bf4c2.png)

## User stories
Users can refer this to learn about the usage of the owner flag and to identify when to use it or not.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/8380
- https://github.com/wso2/product-apim-tooling/pull/209