### PR TITLE
[Docs]Docs Changes fix for apim-tooling #267

### DIFF
--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -281,13 +281,13 @@ Run any of the following CTL commands to get keys for the API/API Product.
             `--environment` or `-e` : Key generation environment  
             `--name` or `-n` : API or API Product to enerate keys for   
         -   Optional :  
-            `--token` or `-t` : New token endpoint URL of Environment (Which overrides previously provided token endpoint with add-env command)       
+            `--token` or `-t` : New token endpoint of the environment (which overrides previously provided token endpoint with add-env command)       
             `--provider` or `-r` : Provider of the API or API Product  
             `--version` or `-v` : Version of the API or API Product (Currently API Products do not have versions)
 
     !!! note
         NOTE: Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
-        You can override the given token endpoint or default token endpoint using `--token` (`-t`) optional flag and providing the new token endpoint
+        You can override the given token endpoint or the default token endpoint using `--token` (`-t`) optional flag providing a new token endpoint
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 

--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -60,18 +60,16 @@ Let us check out the basic building blocks for creating a CI/CD pipeline with WS
     !!! example
         ``` bash tab="Linux/Unix"
         apictl add-env -e dev \
-                    --apim https://localhost:9443 \
-                    --token https://localhost:8243/token
+                    --apim https://localhost:9443 
 
         apictl add-env -e prod \
-                    --apim https://localhost:9444 \
-                    --token https://localhost:8244/token
+                    --apim https://localhost:9444 
         ```
 
-        ``` bash tab="Mac"
-        apictl add-env -e dev --apim https://localhost:9443 --token https://localhost:8243/token
+        ``` bash tab="Mac/Windows""
+        apictl add-env -e dev --apim https://localhost:9443 
 
-        apictl add-env -e prod --apim https://localhost:9444 --token https://localhost:8244/token
+        apictl add-env -e prod --apim https://localhost:9444 
         ```    
 
     For more information, see [Add an environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment). 
@@ -270,7 +268,11 @@ Run any of the following CTL commands to get keys for the API/API Product.
 
     !!! example
         ```bash
-        apictl get-keys -n PizzaShackAPI -v 1.0.0 -r admin -e dev -k
+        apictl get-keys -n PizzaShackAPI -e dev -k
+        ```
+    !!! example
+        ```bash
+        apictl get-keys -n PizzaShackAPI -v 1.0.0 -e dev -k -r admin -t https://localhost:8243/token
         ```
     !!! info
         **Flags:**  
@@ -279,8 +281,13 @@ Run any of the following CTL commands to get keys for the API/API Product.
             `--environment` or `-e` : Key generation environment  
             `--name` or `-n` : API or API Product to enerate keys for   
         -   Optional :  
+            `--token` or `-t` : New token endpoint URL of Environment (Which overrides previously provided token endpoint with add-env command)       
             `--provider` or `-r` : Provider of the API or API Product  
             `--version` or `-v` : Version of the API or API Product (Currently API Products do not have versions)
+
+    !!! note
+        NOTE: Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
+        You can override the given token endpoint or default token endpoint using `--token` (`-t`) optional flag and providing the new token endpoint
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 

--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -281,13 +281,13 @@ Run any of the following CTL commands to get keys for the API/API Product.
             `--environment` or `-e` : Key generation environment  
             `--name` or `-n` : API or API Product to enerate keys for   
         -   Optional :  
-            `--token` or `-t` : New token endpoint of the environment (which overrides previously provided token endpoint with add-env command)       
+            `--token` or `-t` : New token endpoint of the environment (This overrides the previously provided token endpoint that was provided using the add-env command)       
             `--provider` or `-r` : Provider of the API or API Product  
             `--version` or `-v` : Version of the API or API Product (Currently API Products do not have versions)
 
     !!! note
-        NOTE: Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
-        You can override the given token endpoint or the default token endpoint using `--token` (`-t`) optional flag providing a new token endpoint
+        Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
+        You can override the given token endpoint or the default token endpoint using the `--token` (`-t`) optional flag together with the new token endpoint.
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -127,9 +127,9 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
         !!! note
             The `--environment (-e)` flag is mandatory.
-            You can either provide only the 1 flags `--apim` , or all the other 5 flags (`--registration`, `--publisher`, `--devportal`, `--admin`, `--token`) without providing `--apim` flag.
+            You can either provide only the flag `--apim` , or all the other 5 flags (`--registration`, `--publisher`, `--devportal`, `--admin`, `--token`) without providing `--apim` flag.
             If you are omitting any of `--registration`, `--publisher`, `--devportal`, `--admin` flags, you need to specify `--apim` flag with the API Manager endpoint.
-            In both these  cases `--token`  flag is optional and can be used to provide user preferred token endpoint.
+            In both of the above cases `--token`  flag is optional and can be used to provide an user preferred token endpoint.
 
         !!! example
 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -111,7 +111,6 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             -    Required :  
 
                 `--environment` or `-e` : Name of the environment to be added   
-                `--token` : Token endpoint for the environment
                 AND (either)
                 `--apim` : API Manager endpoint for the environments
                 OR (the following 4)
@@ -119,25 +118,28 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                 `--admin` : Admin endpoint for the environment  
                 `--publisher` : Publisher endpoint for the environment  
                 `--devportal` : DevPortal endpoint for the environment 
+            -   Optional :
+
+                `--token` : Token endpoint for the environment
             
         !!! tip
             When adding an environment, when the optional flags are not given, CTL will automatically derive those from `--apim` flag value.
 
         !!! note
-            The flags `--environment (-e)` and `--token` are mandatory.
-            You can either provide only the 2 flags `--apim` and `--token`, or all the other 5 flags (`--registration`, `--publisher`, `--devportal`, `--admin`, `--token`) without providing `--apim` flag.
+            The `--environment (-e)` flag is mandatory.
+            You can either provide only the 1 flags `--apim` , or all the other 5 flags (`--registration`, `--publisher`, `--devportal`, `--admin`, `--token`) without providing `--apim` flag.
             If you are omitting any of `--registration`, `--publisher`, `--devportal`, `--admin` flags, you need to specify `--apim` flag with the API Manager endpoint.
+            In both these  cases `--token`  flag is optional and can be used to provide user preferred token endpoint.
 
         !!! example
 
             ``` bash tab="Linux/Unix"
             apictl add-env -e dev \
-                        --apim https://localhost:9443 \
-                        --token https://localhost:8243/token
+                        --apim https://localhost:9443 
             ``` 
 
             ``` bash tab="Mac/Windows"
-            apictl add-env -e dev --apim https://localhost:9443 --token https://localhost:8243/token
+            apictl add-env -e dev --apim https://localhost:9443 
             ```               
 
         !!! example
@@ -145,14 +147,14 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             ``` bash tab="Linux/Unix"
             apictl add-env -e production \
                         --registration https://idp.com:9444 \
-                        --token https://gw.com:8244/token \
                         --admin https://apim.com:9444 \
                         --publisher https://apim.com:9444 \
-                        --devportal https://apps.com:9444
+                        --devportal https://apps.com:9444 \
+                        --token https://gw.com:8244/token                        
             ```
 
             ``` bash tab="Mac/Windows"
-            apictl add-env -e production --registration https://idp.com:9444 --token https://gw.com:8244/token --admin https://apim.com:9444 --publisher https://apim.com:9444 --devportal https://apps.com:9444
+            apictl add-env -e production --registration https://idp.com:9444  --admin https://apim.com:9444 --publisher https://apim.com:9444 --devportal https://apps.com:9444 --token https://gw.com:8244/token
             ```  
     
         !!! example


### PR DESCRIPTION
## Purpose
Document changes related to https://github.com/wso2/product-apim-tooling/issues267 issue in apictl. 
Currently , --environment, --token flags are mandatory and a user has to provide either --apim or the other 4 flags (--publisher, --admin, --devportal, --registration) when adding an environment. As an improvement, it is possible to make --token flag optional by using https:localhost:9443/oauth2/token endpoint as same as we do in the UI (without using the gateway endpoint - 8243/token).

When doing this, it needs to inform the user, that when generating keys, we are going to use the https:localhost:9443/oauth2/token endpoint by default and if he/she is using a third party key manager, they need to provide that endpoint as --token endpoint, to be used in the get-keys operation.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/333

## Approach

**/learn/api-controller/getting-started-with-wso2-api-controller/**

<img width="719" alt="Screenshot 2020-06-15 at 13 47 51" src="https://user-images.githubusercontent.com/42435576/84634027-da97b600-af0e-11ea-9be5-bd56d9ad5f39.png">

**/learn/api-controller/ci-cd-with-wso2-api-management/**

<img width="719" alt="Screenshot 2020-06-15 at 13 47 00" src="https://user-images.githubusercontent.com/42435576/84634039-df5c6a00-af0e-11ea-8210-998aacbe4dab.png">

<img width="719" alt="Screenshot 2020-06-15 at 13 47 21" src="https://user-images.githubusercontent.com/42435576/84634049-e1bec400-af0e-11ea-9d33-adc55e93e062.png">



## User stories

- Adding a new environment.
- Generating Keys for an environment.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/336



## Test environment
MacOs 10.15.5
 
