### PR TITLE
[APIM 3.2.0] Change the indentation and update the field names of api_params.yaml

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
@@ -25,7 +25,7 @@ API Manager supports four (4) main types of endpoints as follows.
         - `production`: An array which consists the multiple production endpoints
         - `sandbox`: An array which consists the multiple sandbox endpoints
         - `sessionManagement` (Optional): Values can be `none`, `transport`, `soap`, `simpleClientSession` and if not specified the default value is `transport`
-        - `sessionTimeout` (Optional): The number of milliseconds after which the session would time out
+        - `sessionTimeOut` (Optional): The number of milliseconds after which the session would time out
 
     -   **failoverEndpoints** field should be specified if the `endpointRoutingPolicy` is `failover`. This field contains the following.
 
@@ -89,7 +89,7 @@ The following is an example `api_params.yaml` file for this scenario. (Note that
                 - url: https://dev1.sandbox.wso2.com
                 - url: https://dev2.sandbox.wso2.com
             sessionManagement: transport
-            sessionTimeout: 5000
+            sessionTimeOut: 5000
     ```
 
 #### 3. HTTP/REST Endpoint - With failover
@@ -165,7 +165,7 @@ The following is an example `api_params.yaml` file for this scenario. (Make sure
                 - url: https://dev1.sandbox.wso2.com
                 - url: https://dev2.sandbox.wso2.com
             sessionManagement: soap
-            sessionTimeout: 5000
+            sessionTimeOut: 5000
     ```
 
 #### 3. HTTP/SOAP Endpoint - With failover
@@ -201,7 +201,7 @@ The following is an example `api_params.yaml` file for this scenario. (Make sure
 
 !!! example
     ```go   
-      environments:
+    environments:
         - name: test
           endpoints:
               production:

--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -23,16 +23,16 @@ environments:
                   retryDelay: <retry_delay_in_ms>
                   factor: <suspension_factor>
       security:
-        - enabled: <whether_security_is_enabled>
+          enabled: <whether_security_is_enabled>
           type: <endpoint_authentication_type_basic_or_digest>
           username: <endpoint_username>
           password: <endpoint_password>
       gatewayEnvironments:
-        - <gateway_environment_name>           
+          - <gateway_environment_name>           
       certs:
-        - hostName: <endpoint_url>
-          alias: <certificate_alias>
-          path: <certificate_file_path>
+          - hostName: <endpoint_url>
+            alias: <certificate_alias>
+            path: <certificate_file_path>
 ```
 The following code snippet contains sample configuration of the parameter file.
 
@@ -41,29 +41,29 @@ The following code snippet contains sample configuration of the parameter file.
     environments:
         - name: dev
           endpoints:
-            production:
-              url: 'https://dev.wso2.com'
+              production:
+                  url: 'https://dev.wso2.com'
           security:
-            - enabled: true
+              enabled: true
               type: basic
               username: admin
               password: admin
           certs:
-            - hostName: 'https://dev.wso2.com'
-              alias: Dev
-              path: ~/.certs/dev.pem 
+              - hostName: 'https://dev.wso2.com'
+                alias: Dev
+                path: ~/.certs/dev.pem 
           gatewayEnvironments:
-            - Production and Sandbox    
+              - Production and Sandbox    
         - name: test
           endpoints:
-            production:
-              url: 'https://test.wso2.com'
-              config:
-                retryTimeOut: $RETRY
-            sandbox:
-              url: 'https://test.sandbox.wso2.com'
+              production:
+                  url: 'https://test.wso2.com'
+                  config:
+                      retryTimeOut: $RETRY
+              sandbox:
+                  url: 'https://test.sandbox.wso2.com'
           security:
-            - enabled: true
+              enabled: true
               type: digest
               username: admin
               password: admin


### PR DESCRIPTION
## Purpose
The indentation of api_params.yaml was wrong in some places. Also, the **sessionTimout** field should be converted to **sessionTimeOut** in the documentation. 

## Goals
Provide the correct template for api_params.yaml

## Approach
- Changed the **security** field in the api_params.yaml to an object, which was earlier denoted as an array in the page **Configuring Environment Specific Parameters** under **API Controller/Advanced Topics**
- Corrected **sessionTimout** as **sessionTimeOut** in the page **Configuring Different Endpoint Types** under **API Controller/Advanced Topics**
- Changed the indentation of the example for **Dynamic Endpoints** in the page **Configuring Different Endpoint Types** under **API Controller/Advanced Topics**

## User stories
Users can followup the correct examples with the correct template of api_params.yaml when importing APIs using the API Controller.