### PR TITLE
Modifying the examples on xml_validator.xml with the field "entityExpansionLimit"

### DIFF
--- a/en/docs/learn/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
+++ b/en/docs/learn/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
@@ -22,6 +22,7 @@ is given below.
     <property name="maxAttributeLength" value="100"/>
     <property name="entityExpansionLimit" value="100"/>
     <property name="maxChildrenPerElement" value="100"/>
+    <property name="entityExpansionLimit" value="100"/>
     <property name="schemaValidation" value="true"/>
     <switch source="get-property('To')">
         <case regex=".*/addResource.*">

--- a/en/docs/learn/api-security/threat-protection/gateway-threat-protectors/xml-threat-protection-for-api-gateway.md
+++ b/en/docs/learn/api-security/threat-protection/gateway-threat-protectors/xml-threat-protection-for-api-gateway.md
@@ -24,6 +24,7 @@ The xml\_validator sequence specifies the properties to be limited in the payloa
         <property name="maxAttributeLength" value="100"/>
         <property name="entityExpansionLimit" value="100"/>
         <property name="maxChildrenPerElement" value="100"/>
+        <property name="entityExpansionLimit" value="100"/>
         <property name="schemaValidation" value="true"/>
         <switch source="get-property('To')">
             <case regex=".*/addResource.*">


### PR DESCRIPTION
## Purpose
As a support to https://github.com/wso2/product-apim/pull/8575, updating the documentation will be done here.

## Goals
Adding the property **entityExpansionLimit** to the example of xml_validator.xml

## Approach
Updated the xml_validator.xml in the page **XML Threat Protection for API Gateway** under **API Security/Threat Protection**.
![image](https://user-images.githubusercontent.com/25246848/86465441-3eafdc00-bd4f-11ea-9f69-0be94fc4bbd0.png)

## User stories
Can refer to the correct example file inside the API.

## Related PRs
https://github.com/wso2/product-apim/pull/8575