### PR TITLE
Redoing https://github.com/wso2/docs-apim/pull/1398

### DIFF
--- a/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml
+++ b/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml
@@ -6860,7 +6860,7 @@ definitions:
         type: array
         items:
           type: string
-        example: "Pizzashack", "Petstore"
+        example: ["MicroGW1", "MicroGW2"]
       mediationPolicies:
         type: array
         items:

--- a/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml
+++ b/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml
@@ -6860,12 +6860,16 @@ definitions:
         type: array
         items:
           type: string
-        example: ["Pizzashack", "Petstore"]
+        example: "Pizzashack", "Petstore"
       mediationPolicies:
         type: array
         items:
           $ref: '#/definitions/MediationPolicy'
-        example:  [ {"name": "json_to_xml_in_message","type": "in"}, {"name": "xml_to_json_out_message","type": "out"}, {"name": "json_fault","type": "fault"} ]
+          example: [
+            {"name": "json_to_xml_in_message","type": "in"},
+            {"name": "xml_to_json_out_message","type": "out"},
+            {"name": "json_fault","type": "fault"}
+          ]
       subscriptionAvailability:
         type: string
         description: The subscription availability. Accepts one of the following. current_tenant, all_tenants or specific_tenants.
@@ -6920,10 +6924,10 @@ definitions:
         example: APPROVED
       createdTime:
         type: string
-        example: "2017-02-20T13:57:16.229"
+        example: '2017-02-20T13:57:16.229'
       lastUpdatedTime:
         type: string
-        example: "2017-02-20T13:57:16.229"
+        example: '2017-02-20T13:57:16.229'
       endpointConfig:
         type: object
         description: |


### PR DESCRIPTION
## Purpose
As the changes in PR https://github.com/wso2/docs-apim/pull/1398 have not been done in the respective `carbon-apimgt` repo, new changes to `publisher-v1.yaml` wiped-out the changes that were done in [1]. Therefore, I added the changes back.

[1] https://github.com/wso2/docs-apim/pull/1398