### PR TITLE
Doc changes for importing certs in controller

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -818,13 +818,15 @@ Run the following CTL command to change the default location of the export direc
 ## Import SSL Certificate for Secure HTTP Communication with API Manager
 
 Different environments of API Manager can have different SSL certificates for secure HTTP communications. The default
-certificate of WSO2 API Manager is a self signed certificate and in production environments it is advised to use a
-different certificate than default.   
+certificate of WSO2 API Manager is a self-signed certificate and in production environments, it is advised to use a
+different certificate than the default.   
 
-If the certificate is the default WSO2 certificate or a CA signed certificate of a CA trusted by the OS, these
-certificates will be imported by default to the controller. If the CA or the certificate is new, you can add the
-certificate to the ```/home/.wso2apictl/certs``` directory. The certificates added to this directory will be imported 
-whenever an action is performed with the controller. Any DER or PEM encoded certificate can be used with controller.
+If the certificate is the default WSO2 certificate or a CA-signed certificate of a CA (Certificate Authority) trusted by
+the OS, these certificates will be imported by default to the controller. If the CA or the certificate is new or does
+not get imported by default, you can add the certificate to the ```/home/.wso2apictl/certs``` directory. The
+certificates added to this directory will be imported whenever an action is performed with the controller. Any DER or 
+PEM encoded certificate with file extensions of ```*.pem```, ```*.crt``` or ```*.cer``` can be used with the
+controller. 
 
 !!! Info
     If you are using windows, CA certs will not be imported by default and has to be added to the ```/home/.wso2apictl

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -813,4 +813,20 @@ Run the following CTL command to change the default location of the export direc
         - Required :   
             `--export-directory`: Path to directory where APIs should be saved.   
             Default : `/home/.wso2apictl/exported`
+            
+            
+## Import SSL Certificate for Secure HTTP Communication with API Manager
+
+Different environments of API Manager can have different SSL certificates for secure HTTP communications. The default
+certificate of WSO2 API Manager is a self signed certificate and in production environments it is advised to use a
+different certificate than default.   
+
+If the certificate is the default WSO2 certificate or a CA signed signed certificate of a CA trusted by the OS, these
+certificates will be imported by default to the controller. If the CA or the certificate is new, you can add the
+certificate to the ```/home/.wso2apictl/certs``` directory. The certificates added to this directory will be imported 
+whenever an action is performed with the controller. Any DER or PEM encoded certificate can be used with controller.
+
+!!! Info
+    If you are using windows, CA certs will not be imported default and has to be added to the ```/home/.wso2apictl/certs``` 
+    directory.
 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -821,12 +821,12 @@ Different environments of API Manager can have different SSL certificates for se
 certificate of WSO2 API Manager is a self signed certificate and in production environments it is advised to use a
 different certificate than default.   
 
-If the certificate is the default WSO2 certificate or a CA signed signed certificate of a CA trusted by the OS, these
+If the certificate is the default WSO2 certificate or a CA signed certificate of a CA trusted by the OS, these
 certificates will be imported by default to the controller. If the CA or the certificate is new, you can add the
 certificate to the ```/home/.wso2apictl/certs``` directory. The certificates added to this directory will be imported 
 whenever an action is performed with the controller. Any DER or PEM encoded certificate can be used with controller.
 
 !!! Info
-    If you are using windows, CA certs will not be imported default and has to be added to the ```/home/.wso2apictl/certs``` 
-    directory.
+    If you are using windows, CA certs will not be imported by default and has to be added to the ```/home/.wso2apictl
+    /certs``` directory.
 

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -823,7 +823,8 @@ different certificate than the default.
 
 If the certificate is the default WSO2 certificate or a CA-signed certificate of a CA (Certificate Authority) trusted by
 the OS, these certificates will be imported by default to the controller. If the CA or the certificate is new or does
-not get imported by default, you can add the certificate to the ```certs``` directory found in```<APICTL_CONFIG_DIR>```. 
+not get imported by default, you can add the certificate to the ```certs``` directory found in 
+```APICTL_CONFIG_DIR/.wso2apictl```. 
 (Default location of the certs directory is ```/home/.wso2apictl/certs```)  
 
 The certificates added to this directory will be imported whenever an action is performed with the controller. Any

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -823,12 +823,13 @@ different certificate than the default.
 
 If the certificate is the default WSO2 certificate or a CA-signed certificate of a CA (Certificate Authority) trusted by
 the OS, these certificates will be imported by default to the controller. If the CA or the certificate is new or does
-not get imported by default, you can add the certificate to the ```/home/.wso2apictl/certs``` directory. The
-certificates added to this directory will be imported whenever an action is performed with the controller. Any DER or 
-PEM encoded certificate with file extensions of ```*.pem```, ```*.crt``` or ```*.cer``` can be used with the
+not get imported by default, you can add the certificate to the ```certs``` directory found in```<APICTL_CONFIG_DIR>```. 
+(Default location of the certs directory is ```/home/.wso2apictl/certs```)  
+
+The certificates added to this directory will be imported whenever an action is performed with the controller. Any
+DER or PEM encoded certificate with the file extensions of ```*.pem```, ```*.crt``` or ```*.cer``` can be used with the
 controller. 
 
 !!! Info
-    If you are using windows, CA certs will not be imported by default and has to be added to the ```/home/.wso2apictl
-    /certs``` directory.
+    If you are using windows, CA certs will not be imported by default and has to be added to the ```certs``` directory.
 


### PR DESCRIPTION
Added the documentation on the Importing SSL certificates in controller.

Related git issue: https://github.com/wso2/product-apim-tooling/issues/417

This is to cover the doc impact of https://github.com/wso2/product-apim-tooling/issues/235