### PR TITLE
Remove set token type related Docs

### DIFF
--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -378,7 +378,7 @@ Run any of the following CTL commands to get keys for the API/API Product.
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 
-    - Using apictl tool the token type , HTTP request timeout, and export directory can be set up and changed. For more information on changing the token type, see [Set token type]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#set-token-type), [Set HTTP request timeout]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#set-http-request-timeout) and [Set export directory]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/##set-export-directory) accordingly. 
+    - Using apictl tool the HTTP request timeout, and export directory can be set up and changed. For more information on changing the HTTP request timeout, see [Set HTTP request timeout]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#set-http-request-timeout) and [Set export directory]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/##set-export-directory) accordingly. 
     - When running the above command, if you have not specified the --version (-v), the tool will consider the version as 1.0.0 by default. If you have specified the version, then that value will be considered.
 
 ### (H.) - Extending a CI/CD pipeline to support API Products

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -744,30 +744,6 @@ Output of ```list envs```, ```list apis``` and ```list apps``` can be formatted 
     </tbody>
 </table>
 
-
-## Set token type
-
-Run the following CTL command to set the token type of the default apictl application.
-
--   **Command**
-        ```go
-        apictl set --token-type <token type>
-        ```
-
-    !!! example
-        ```bash
-        apictl set --token-type JWT
-        ```
-        ```bash
-        apictl set --token-type OAuth
-        ```
-    
-    !!! info
-        **Flags:** 
-
-        -   Required :   
-            `--token-type` or `-t` : Type of the token to be generated
-
 ## Set HTTP request timeout
 
 Run the following CTL command to set the HTTP request timeout.


### PR DESCRIPTION
## Purpose
From APIM 3.2.0 onward ability to specify the token type of an Application as either Opaque or JWT is removed. All new Apps will only support JWT tokens. Therefore we need to remove the apictl flag set --token-type that allows setting the token type is either Opaque or JWT, as it is redundant. Therefore in order to reflect that changes on API Controller documentation, this PR will remove parts related to this flag.

## Goals
Fixes doc changes related to https://github.com/wso2/product-apim-tooling/issues/440
