### PR TITLE
[3.0.0] Adding the missing content on configuring keystores in migration from 2.x versions

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
@@ -1475,6 +1475,24 @@ Follow the instructions below to move all the existing API Manager configuration
     - keystore.internal - The keystore used for internal encryption/decrypton
     - keystore.tls - The keystore used for SSL encryption
     ```
+    !!! Attention
+        In API Manager 3.0.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in the previous version, you need to add the following configuration to the `<API-M_3.0.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.2.0 and primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
+
+        ``` java
+        [keystore.primary]
+        file_name = "primary.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+
+        [keystore.internal]
+        file_name = "internal.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+        ```
 
     !!! note "If you have enabled Secure Vault"
         If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/administer/product-security/logins-and-passwords/working-with-encrypted-passwords) for more details.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
@@ -1302,6 +1302,25 @@ Follow the instructions below to move all the existing API Manager configuration
     - keystore.tls - The keystore used for SSL encryption
     ```
 
+    !!! Attention
+        In API Manager 3.0.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in the previous version, you need to add the following configuration to the `<API-M_3.0.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.5.0 and primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
+
+        ``` java
+        [keystore.primary]
+        file_name = "primary.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+
+        [keystore.internal]
+        file_name = "internal.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+        ```
+
     !!! note "If you have enabled Secure Vault"
         If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/administer/product-security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
@@ -1651,6 +1651,25 @@ Follow the instructions below to move all the existing API Manager configuration
     - keystore.tls - The keystore used for SSL encryption
     ```
 
+    !!! Attention
+        In API Manager 3.0.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in the previous version, you need to add the following configuration to the `<API-M_3.0.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.1.0 and primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
+
+        ``` java
+        [keystore.primary]
+        file_name = "primary.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+
+        [keystore.internal]
+        file_name = "internal.jks"
+        type = "JKS"
+        password = "wso2carbon"
+        alias = "wso2carbon"
+        key_password = "wso2carbon"
+        ```
+
     !!! note "If you have enabled Secure Vault"
         If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/administer/product-security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 


### PR DESCRIPTION
## Purpose
In API Manager 3.x versions, it is required to use a certificate with the RSA key size greater than 2048. When migrating from 2.x versions issues can be arisen if you do not configure your key stores properly.

## Goals
Adding the missing documentation on correctly configuring key stores when migrating from 2.x versions to 3.x versions.

## Approach
![image](https://user-images.githubusercontent.com/25246848/89895056-cb747200-dbf8-11ea-87fb-57920d7f015a.png)

- As shown in the above screenshot, the content was added to the missing documentation pages listed below.
  - APIM 2.2.0 to APIM 3.0.0
  - APIM 2.5.0 to APIM 3.0.0
  - APIM 2.6.0 to APIM 3.0.0

## User stories
- Users can configure the key stores properly when migrating and the issues will not arise.

## Related PRs
> List any other related PRs