### PR TITLE
Making table name IDN_OAUTH2_RESOURCE_SCOPE lowercase in PostgreSQL migration scripts

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
@@ -2612,7 +2612,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
@@ -2520,7 +2520,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
@@ -2270,7 +2270,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
@@ -2091,7 +2091,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
@@ -2482,7 +2482,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
@@ -1277,7 +1277,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
@@ -1105,7 +1105,7 @@ Follow the instructions below to move all the existing API Manager configuration
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE';
+        WHERE constraint_type = 'PRIMARY KEY' AND tc.table_name = 'idn_oauth2_resource_scope';
         EXECUTE con_name;
         END $$;
         


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9088

## Goals
Make the table name idn_oauth2_resource_scope lowercase in PostgreSQL scripts in migration doc content.

## Approach
Convert **tc.table_name = 'IDN_OAUTH2_RESOURCE_SCOPE'** to  **tc.table_name = 'idn_oauth2_resource_scope'** in PostgreSQL migration db scripts.

## Test environment
PostgreSQL 12.3