### PR TITLE
Removing the section on "Add an API Category using the Admin REST API"

### DIFF
--- a/en/docs/develop/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping.md
+++ b/en/docs/develop/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping.md
@@ -10,7 +10,7 @@ Initially, the Admins will define API categories. Thereafter, API providers will
 You can add an API category using any of the following methods:
 
 - [Add an API Category using the Admin Portal UI]({{base_path}}/learn/consume-api/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping/#add-an-api-category-using-the-admin-portal-ui)
-- [Add an API Category using the Admin REST API]({{base_path}}/learn/consume-api/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping/#add-an-api-category-using-the-admin-rest-api)
+- Add an API Category using the Admin REST API. (You can use the POST resource in the **API Category (Individual)** section [here]({{base_path}}/develop/product-apis/admin-apis/admin-v1/admin-v1))
 
 ### Add an API Category using the Admin Portal UI
 
@@ -31,28 +31,6 @@ You can add an API category using any of the following methods:
     [![Add API categories]({{base_path}}/assets/img/learn/new_add_category.png)]({{base_path}}/assets/img/learn/new_add_category.png)
 
 4. Click **Save**.
-
-### Add an API Category using the Admin REST API
-
-``` java tab="Format"
-curl -k -X POST -H "Authorization: Bearer <ACCESS_TOKEN>" -H "Content-Type: application/json" "https://localhost:9443/api/am/admin/v1/api-categories" -d @category-data.json
-```
-
-``` java tab="Sample"
-curl -k -X POST -H "Authorization: Bearer 0d63e133-7ad6-3aeb-9ca9-9299e0708122" -H "Content-Type: application/json" "https://localhost:9443/api/am/admin/v1/api-categories" -d '{ "name":"Finance", "description":"Finance related APIS" }'
-```
-
-!!!Note
-    ACCESS_TOKEN should have **admin_operations** scope.
-
-**Sample payload**
-
-```
-{
-"name": "Sales",
-"description": "Sales category"
-}
-```
 
 ## Step 2 - Attach the API Category to an API
 

--- a/en/docs/develop/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping.md
+++ b/en/docs/develop/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping.md
@@ -1,7 +1,7 @@
 
 # API Category based Grouping
 
-You can use API categories to group APIs. In previous versions of WSO2 API Manager, the process of grouping APIs was carried out by using tag wise groups. Unlike tag wise grouping API categories do not use a naming convention. Therefore, the admin does not need to take into consideration any naming conventions when using API category based grouping.
+You can use API categories to group APIs. API categories do not use a naming convention. Therefore, the admin does not need to take into consideration any naming conventions when using API category based grouping.
 
 Initially, the Admins will define API categories. Thereafter, API providers will add API categories to APIs when designing them via the API Publisher. API categories allow API providers to categorize APIs that have similar attributes. When a categorized API gets published to the Developer Portal, its categories appear as clickable links to the API consumers. The API consumers can use the available API categories to quickly jump to a category of interest.
 
@@ -20,17 +20,22 @@ You can add an API category using any of the following methods:
 
 2. Click **API Category** and then click **API Categories**.
     
-    [![Add categories page]({{base_path}}/assets/img/learn/new_api_category_left_tag.png)]({{base_path}}/assets/img/learn/new_api_category_left_tag.png)
-
-2. Click **Add New Category**.
+    <img src="{{base_path}}/assets/img/learn/new_api_category_left_tag.png" width="300" alt="API categories menu">
+    
+3. Click **Add New Category**.
 
     [![Add API category page]({{base_path}}/assets/img/learn/new_click_add_category.png)]({{base_path}}/assets/img/learn/new_click_add_category.png)
 
-3. Enter a name and a description for the category.
+4. Enter a name and a description for the API category.
 
-    [![Add API categories]({{base_path}}/assets/img/learn/new_add_category.png)]({{base_path}}/assets/img/learn/new_add_category.png)
+     | Field          |  Value                 |
+     |----------------|------------------------|
+     |  Name          |  Finance               |
+     |  Description   |  Finance related APIs  |
 
-4. Click **Save**.
+    <img src="{{base_path}}/assets/img/learn/new_add_category.png" width="500" alt="Add API category">
+
+5. Click **Save**.
 
 ## Step 2 - Attach the API Category to an API
 


### PR DESCRIPTION
## Purpose
Removing the subsection named **Add an API Category using the Admin REST API** in the page **API Category based Grouping**

## Goals
Since we have the REST API docs for Admin v1 now, removing the unnecessary content related to **API Category based Grouping**.

## Approach
- Earlier there was a section as below in the **API Category based Grouping** page.
  ![image](https://user-images.githubusercontent.com/25246848/90491565-b601c980-e15d-11ea-8863-00ed9c0584a2.png)
- Removed it and modified the content as below asking to refer the REST API docs.
  ![image](https://user-images.githubusercontent.com/25246848/90491630-cc0f8a00-e15d-11ea-971d-de7c80f01c25.png)

## User stories
Users can refer the new Admin v1 REST API docs when creating API categories.