### PR TITLE
Correcting the APICTL version in the warn message about main_config.yaml in "Getting Started with WSO2 API Controller"

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -13,7 +13,7 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
 5.  Execute the following command to start the CTL Tool.
 
     !!! Warn
-        From API Manager Tooling 3.2.0 version onwards, the names of the endpoints have been modified and this causes changing the syntax in `/home/<user>/.wso2apictl/main_config.yaml` file. If you have an older file, you'll get an error while executing the apictl commands due to this. To avoid that, backup and remove `/home/<user>/.wso2apictl/main_config.yaml` file and reconfigure the environments using new commands as explained below in [Add an environment](#add-an-environment) section.
+        From API Manager Tooling 3.1.0 version onwards, the names of the endpoints have been modified and this causes changing the syntax in `/home/<user>/.wso2apictl/main_config.yaml` file. If you have an older file, you'll get an error while executing the apictl commands due to this. To avoid that, backup and remove `/home/<user>/.wso2apictl/main_config.yaml` file and reconfigure the environments using new commands as explained below in [Add an environment](#add-an-environment) section.
 
     ``` go
     ./apictl


### PR DESCRIPTION
## Purpose
Correcting the APICTL version in the **warn** message about adjusting the main_config.yaml as per the old configurations.

## Goals
Avoid the confusions of the users which may arise because of the version in the doc, since this change has been done from 3.1.0.

## Approach
Corrected the version of APICTL to 3.2.0 in the **Getting Started with WSO2 API Controller** as below.
![image](https://user-images.githubusercontent.com/25246848/90513330-17856080-e17d-11ea-9e48-ee3b19b76522.png)