### PR TITLE
Updating the correct behaviour which happens when locking a user account

### DIFF
--- a/en/docs/install-and-setup/setup/security/user-account-management.md
+++ b/en/docs/install-and-setup/setup/security/user-account-management.md
@@ -51,11 +51,8 @@ The following steps show how to enable account locking. See [Account Locking by 
     ![enable-account-lock]({{base_path}}/assets/img/administer/product-security/identity-management-for-the-api-dev-portal/account-lock-config.png)
 
 !!! info
-    An error message similar to the following will be logged in wso2carbon.log when the account is locked.
-    
-    ``` java
-    ERROR - Account is locked for user alex in user store PRIMARY in tenant carbon.super. Cannot login until the account is unlocked.
-    ```
+    - If you have configured the email sending module as mentioned in [Configuring the Email Sending Module](https://is.docs.wso2.com/en/5.10.0/setup/configuring-email-sending/) and if the particular locked user's email address is correct in his profile, he/she will receive an email stating that the account is locked.
+    - Again another email will be sent when the account is unlocked.
 
 ### Account locking by an administrative user
 


### PR DESCRIPTION
## Purpose
In **User Account Management** documentation, it states an error message will be shown as below.
![image](https://user-images.githubusercontent.com/25246848/90612007-17d93680-e225-11ea-8df5-54867e6fc643.png)
But it is not displayed anymore. Instead, If you have configured the email sending module and if the particular locked user's email address is correct in his profile, he/she will receive an email stating that the account is locked.

## Goals
Mention the correct behaviour when locking a user account.

## Approach
- Removed the below content which was in the docs previously.
  ![image](https://user-images.githubusercontent.com/25246848/90612007-17d93680-e225-11ea-8df5-54867e6fc643.png)
- Added the below content instead of the above content.
  ![image](https://user-images.githubusercontent.com/25246848/90612086-2f182400-e225-11ea-9ca3-a77b7655c84d.png)