### PR TITLE
Adding the content to change the default WSO2CARBON_DB to a particular database type

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
@@ -60,7 +60,7 @@ Follow the instructions below to set up a IBM DB2 database:
    $ db2 -td/ -vmf '<API-M_HOME>/dbscripts/apimgt/db2.sql';
    ```
 
-## Changing the Carbon database to IBM DB2
+## Changing the database to IBM DB2
 
 - [Creating the datasource connection to IBM DB2](#creating-the-datasource-connection-to-ibm-db2)
 
@@ -168,6 +168,22 @@ Follow the instructions below to change the type of the default datasource.
     
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to IBM DB2**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/db2.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your IBM DB2 database, the username, and password required to access the database and the IBM DB2 driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "db2"
+        url = "jdbc:db2://localhost:50000/carbon_db"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "com.ibm.db2.jcc.DB2Driver"
+        validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
+        ```
 
 1.  Restart the server.
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
@@ -169,9 +169,16 @@ Follow the instructions below to change the type of the default datasource.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1.  Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to IBM DB2**
-            
+
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
+
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/db2.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your IBM DB2 database, the username, and password required to access the database and the IBM DB2 driver details similarly as explained before.
         
@@ -184,8 +191,3 @@ Follow the instructions below to change the type of the default datasource.
         driver = "com.ibm.db2.jcc.DB2Driver"
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
-
-1.  Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
@@ -79,7 +79,7 @@ $ pip install mssql-cli
     `<API-M_HOME>/dbscripts/mb-store/mssql-mb.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to MSSQL, then you need to have seperate databases for each API-M Traffic Manager node.
 
 
-## Changing the Carbon database to MSSQL
+## Changing the database to MSSQL
 
 -   [Creating the datasource connection to MSSQL](#creating-the-datasource-connection-to-mssql)
 
@@ -190,6 +190,22 @@ Follow the steps below to change the type of the default datasource.
 
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to MSSQL**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/mssql.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your MSSQL database, the username, and password required to access the database and the MSSQL driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "mssql"
+        url = "jdbc:sqlserver://localhost:1433;databaseName=carbon_db;SendStringParametersAsUnicode=false"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        validationQuery = "SELECT 1"
+        ```
 
 1.  Restart the server.
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
@@ -191,8 +191,15 @@ Follow the steps below to change the type of the default datasource.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1.  Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, see [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to MSSQL**
+
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
             
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/mssql.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your MSSQL database, the username, and password required to access the database and the MSSQL driver details similarly as explained before.
@@ -206,8 +213,3 @@ Follow the steps below to change the type of the default datasource.
         driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
         validationQuery = "SELECT 1"
         ```
-
-1.  Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, see [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -146,7 +146,7 @@ Follow the  instructions below to set up a MySQL database:
 !!! note
     In the sample commands above, its assumed that the username and password defined in the datasource configurations in `<API-M_HOME>/repository/conf/deployment.toml` file is **wso2user** and **wso2123** respectively.
 
-## Changing the Carbon database to MySQL
+## Changing the database to MySQL
 
 -   [Creating the datasource connection to MySQL](#creating-the-datasource-connection-to-mysql)
 
@@ -248,6 +248,21 @@ Follow the  instructions below to change the type of the default datasources.
 
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to MySQL**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/mysql.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your MySQL database, the username, and password required to access the database and the MySQL driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/carbon_db"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "com.mysql.cj.jdbc.Driver"
+        ```
 
 1.  Restart the server.
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -249,9 +249,16 @@ Follow the  instructions below to change the type of the default datasources.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1.  Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to MySQL**
-            
+        
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
+        
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/mysql.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your MySQL database, the username, and password required to access the database and the MySQL driver details similarly as explained before.
         
@@ -263,8 +270,3 @@ Follow the  instructions below to change the type of the default datasources.
         password = "carbonadmin"
         driver = "com.mysql.cj.jdbc.Driver"
         ```
-
-1.  Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
@@ -166,8 +166,15 @@ Follow the instructions below to change the type of the default datasource.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1. Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to Oracle RAC**
+
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
             
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/oracle_rac.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your Oracle RAC database, the username, and password required to access the database and the Oracle RAC driver details similarly as explained before.
@@ -182,7 +189,3 @@ Follow the instructions below to change the type of the default datasource.
         validationQuery = "SELECT 1 FROM DUAL"
         ```
 
-1. Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
@@ -60,7 +60,7 @@ Copy the Oracle JDBC libraries (for example, the `<ORACLE_HOME>/jdbc/lib/ojdbc14
 !!! note
     `<API-M_HOME>/dbscripts/mb-store/oracle-rac.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to Oracle RAC, then you need to have seperate databases for each API-M Traffic Manager node.
 
-## Changing the Carbon database to Oracle RAC
+## Changing the database to Oracle RAC
 
 - [Creating the datasource connection to Oracle RAC](#creating-the-datasource-connection-to-oracle-rac)
 
@@ -165,6 +165,22 @@ Follow the instructions below to change the type of the default datasource.
 
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to Oracle RAC**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/oracle_rac.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your Oracle RAC database, the username, and password required to access the database and the Oracle RAC driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "oracle"
+        url = "jdbc:oracle:thin:@(DESCRIPTION=(LOAD_BALANCE=on)(ADDRESS=(PROTOCOL=TCP)(HOST=racnode1) (PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=racnode2) (PORT=1521))(CONNECT_DATA=(SERVICE_NAME=rac)))"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "oracle.jdbc.driver.OracleDriver"
+        validationQuery = "SELECT 1 FROM DUAL"
+        ```
 
 1. Restart the server.
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
@@ -168,8 +168,15 @@ Follow the instructions below to change the type of the default datasource.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1.  Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to Oracle**
+
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
             
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/oracle.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your Oracle database, the username, and password required to access the database and the Oracle driver details similarly as explained before.
@@ -183,8 +190,3 @@ Follow the instructions below to change the type of the default datasource.
         driver = "oracle.jdbc.driver.OracleDriver"
         validationQuery = "SELECT 1 FROM DUAL"
         ```
-
-1.  Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
@@ -62,7 +62,7 @@ Follow the instructions below to set up an Oracle database.
 !!! note
     `<API-M_HOME>/dbscripts/mb-store/oracle-mb.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to Oracle, then you need to have seperate databases for each API-M Traffic Manager node.
 
-## Changing the Carbon database to Oracle
+## Changing the database to Oracle
 
 - [Creating the datasource connection to Oracle](#creating-the-datasource-connection-to-oracle)
 
@@ -167,6 +167,22 @@ Follow the instructions below to change the type of the default datasource.
 
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to Oracle**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/oracle.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your Oracle database, the username, and password required to access the database and the Oracle driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "oracle"
+        url = "jdbc:oracle:thin:@localhost:1521/carbon_db"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "oracle.jdbc.driver.OracleDriver"
+        validationQuery = "SELECT 1 FROM DUAL"
+        ```
 
 1.  Restart the server.
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
@@ -180,8 +180,15 @@ Follow the instructions below to change the type of the default datasource.
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
 
+1. Restart the server.
+
     !!! note
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+
+    !!! info
         **Changing WSO2CARBON_DB to PostgreSQL**
+
+        By default `WSO2CARBON_DB` will be an embedded H2 database and it is **not necessary** to change it to another database. But if you have a requirement to change it, you can follow the below steps. (When changing the carbon database, make sure that **each server node have its own WSO2CARBON_DB**. If you don't want to change the carbon database, then you can ignore this section.)
             
         - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/postgresql.sql`.
         -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your PostgreSQL database, the username, and password required to access the database and the PostgreSQL driver details similarly as explained before.
@@ -196,7 +203,3 @@ Follow the instructions below to change the type of the default datasource.
         validationQuery = "SELECT 1"
         ```
 
-1. Restart the server.
-
-    !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
@@ -71,7 +71,7 @@ Follow the  instructions below to set up the PostgreSQL database and users.
 !!! note
     `<API-M_HOME>/dbscripts/mb-store/postgresql-mb.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to PostgreSQL, then you need to have seperate databases for each API-M Traffic Manager node.
 
-## Changing to the Carbon database to PostgreSQL
+## Changing the database to PostgreSQL
 
 - [Creating the datasource connection to PostgreSQL](#creating-the-datasource-connection-to-postgresql)
 
@@ -179,6 +179,22 @@ Follow the instructions below to change the type of the default datasource.
 
     !!! info
         For more information on other parameters that can be defined in the `<API-M_HOME>/repository/conf/deployment.toml` file, see [Tomcat JDBC Connection Pool](http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Tomcat_JDBC_Enhanced_Attributes).
+
+    !!! note
+        **Changing WSO2CARBON_DB to PostgreSQL**
+            
+        - Create tables in the carbon database (`WSO2CARBON_DB`) using the script `<API-M_HOME>/dbscripts/postgresql.sql`.
+        -   Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file. Locate the `[database.local]` configuration element and update the URL pointing to your PostgreSQL database, the username, and password required to access the database and the PostgreSQL driver details similarly as explained before.
+        
+        ``` tab="Example"
+        [database.local]
+        type = "postgre"
+        url = "jdbc:postgresql://localhost:5432/carbon_db"
+        username = "carbonadmin"
+        password = "carbonadmin"
+        driver = "org.postgresql.Driver"
+        validationQuery = "SELECT 1"
+        ```
 
 1. Restart the server.
 


### PR DESCRIPTION
## Purpose
There are some customers that have internal policies like not to use H2. They have to change the carbon database in those situations. Even this is a rare case docs should have this.

## Goals
Old doc space has steps to change the WSO2CARBON_DB. Since it is missing in the new docs, those will be added in a summarized way here.

## Approach
Added the content on **Changing WSO2CARBON_DB to <Database Type>** for all the databases. Below is a screenshot for MySQL.
![image](https://user-images.githubusercontent.com/25246848/90724925-f8054980-e2dc-11ea-8731-c9b7303a3f76.png)

## User stories
The users who want to change the default carbon database to a particular database type of their choice can refer to this doc content.