### PR TITLE
Modifying a broken link in SAML2 SSO documentation

### DIFF
--- a/en/docs/develop/extending-api-manager/saml2-sso/configuring-external-idp-through-identity-server-for-sso.md
+++ b/en/docs/develop/extending-api-manager/saml2-sso/configuring-external-idp-through-identity-server-for-sso.md
@@ -1,7 +1,7 @@
 # Configuring External IDP through Identity Server for SSO
 
 !!! note
-    Please follow [Configuring WSO2 API Manager apps as SAML 2.0 SSO service providers](../../../../learn/extensions/saml2-sso/configuring-identity-server-as-idp-for-sso/) to configure WSO2 Identity Server.
+    Please follow [Configuring Identity Server as IDP for SSO]({{base_path}}/develop/extending-api-manager/saml2-sso/configuring-identity-server-as-idp-for-sso) to configure WSO2 Identity Server.
     This guide will assume you have already followed the above tutorial and configured the Identity Server as IDP for SSO.
 
 1. Add a new Identity Provider in WSO2 Identity Server. For more details on configuring external IDPs in WSO2 IS, see [Adding and Configuring an Identity Provider](https://is.docs.wso2.com/en/5.10.0/learn/adding-and-configuring-an-identity-provider/) .

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -340,7 +340,7 @@ nav:
                 - SAML2 SSO:
                       - Configuring Single Sign On with SAML2: develop/extending-api-manager/saml2-sso/configuring-single-sign-on-with-saml2.md
                       - Configuring External IDP Through Identity Server for SSO: develop/extending-api-manager/saml2-sso/configuring-external-idp-through-identity-server-for-sso.md
-                      - Configure Identity Server as IDP for SSO: develop/extending-api-manager/saml2-sso/configuring-identity-server-as-idp-for-sso.md
+                      - Configuring Identity Server as IDP for SSO: develop/extending-api-manager/saml2-sso/configuring-identity-server-as-idp-for-sso.md
                       - Multi Factor Authentication for Publisher and Developer Portals: develop/extending-api-manager/saml2-sso/multi-factor-authentication-mfa-for-publisher-and-developer-portals.md
           - Customizations:
                 - Customizing the Developer Portal:


### PR DESCRIPTION
## Purpose
There is a broken link in [1].

## Goals
Changing the broken link in [1].

## Approach
- Changed **Configuring WSO2 API Manager apps as SAML 2.0 SSO service providers** to **Configuring Identity Server as IDP for SSO** in [1].
- Updated the broken link to point to [2].
- Improved the title **Configuring Identity Server as IDP for SSO** in mkdocs.yaml.

[1] https://apim.docs.wso2.com/en/next/develop/extending-api-manager/saml2-sso/configuring-external-idp-through-identity-server-for-sso/
[2] https://apim.docs.wso2.com/en/next/develop/extending-api-manager/saml2-sso/configuring-identity-server-as-idp-for-sso/