### PR TITLE
Change Note message in Add an Environment section in Getting Started with WSO2 API Controller

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -134,7 +134,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
         !!! note
             The `--environment (-e)` flag is mandatory.
-            You can either provide only the flag `--apim` , or all the other 5 flags (`--registration`, `--publisher`, `--devportal`, `--admin`, `--token`) without providing `--apim` flag.
+            You can either provide only the flag `--apim` , or all the other 4 flags (`--registration`, `--publisher`, `--devportal`, `--admin`) without providing `--apim` flag.
             If you are omitting any of `--registration`, `--publisher`, `--devportal`, `--admin` flags, you need to specify `--apim` flag with the API Manager endpoint.
             In both of the above cases `--token`  flag is optional and can be used to provide an user preferred token endpoint.
 


### PR DESCRIPTION
## Purpose
Changing a small error in Note message at the section of  **Add an Environment** in Getting Started with WSO2 API Controller page.

## Approach
![Screenshot from 2020-08-26 09-13-32](https://user-images.githubusercontent.com/42435576/91253352-3c7d6300-e77d-11ea-9a82-37419564e031.png)

