### PR TITLE
Fixed description of supported Swagger extension for CORS

### DIFF
--- a/en/docs/learn/design-api/advanced-topics/enabling-cors-for-apis.md
+++ b/en/docs/learn/design-api/advanced-topics/enabling-cors-for-apis.md
@@ -50,7 +50,7 @@ Follow the instructions below to enable CORS response headers globally. Once thi
      After you enable CORS, you will be able to see the CORS response header configuration section. 
 
     !!! note
-        When creating a new API by using a Swagger or Open API definition, response caching can be set up by defining an API-M supported Open API extension **“x-wso2-cors”**.
+        When creating a new API by using a Swagger or Open API definition, CORS can be set up by defining an API-M supported Open API extension **“x-wso2-cors”**.
 
         !!! example
             ```yaml


### PR DESCRIPTION
## Purpose
> Discription statement in the document about Swagger extension for CORS seems to say "response caching" instead of "CORS"

## Goals
> Fixed the corresponding statement to reflect "CORS" instead of "response caching"

