### PR TITLE
[Docs] [3.2.0] Doc changes for importing Mutual SSL certificates using api_params.yaml file

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -33,6 +33,10 @@ environments:
           - hostName: <endpoint_url>
             alias: <certificate_alias>
             path: <certificate_file_path>
+      mutualSslCerts:
+          - tierName: <subscription_tier_name>
+            alias: <certificate_alias>
+            path: <certificate_file_path>            
 ```
 The following code snippet contains sample configuration of the parameter file.
 
@@ -67,6 +71,17 @@ The following code snippet contains sample configuration of the parameter file.
               type: digest
               username: admin
               password: admin
+        - name: production
+          endpoints:
+            production:
+                  url: 'https://prod.wso2.com'
+            mutualSslCerts:
+                - tierName: Unlimited
+                  alias: Prod1
+                  path: ~/.certs/prod1.crt
+                - tierName: Gold
+                  alias: Prod2
+                  path: ~/.certs/prod2.crt
     ```
 Instead of the default `api_params.yaml`, you can a provide custom parameter file using `--params` flag. A sample command will be as follows.
 
@@ -78,6 +93,6 @@ Instead of the default `api_params.yaml`, you can a provide custom parameter fil
 !!! info
     -   Production/Sandbox backends for each environment can be specified in the parameter file with additional configurations, such as timeouts.
     -   Under the security field, if the `enabled` attribute is `true`, you must specify the `username`, `password` and the `type` (can be either only `basic` or `digest`). If the `enabled` attribute is `false`, then non of the security parameters will be set. If the `enabled` attribute is not set (blank), then the security parameters in api.yaml file will be considered.
-    -   Certificates for each URL can be configured in the parameter file. For certificates, a valid path to the certificate file is required. 
+    -   Certificates (Endpoint certificates and MutualSSL certificates) for each URL can be configured in the parameter file. For certificates, a valid path to the certificate file is required. 
     -   The parameter file supports detecting environment variables during the API import process. You can use the usual notation. For example, `url: $DEV_PROD_URL`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
     - To learn about setting up different endpoint types such as HTTP/REST, HTTP/SOAP (with load balancing and failover), Dynamic and AWS Lambda, refer the section [Configuring Different Endpoint Types]({{base_path}}/learn/api-controller/advanced-topics/configuring-different-endpoint-types).


### PR DESCRIPTION
## Purpose
Add documentation changes for the feature of supporting correctly import endpoint certificates and Mutual SSL certificates using the api_params.yaml file.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/485 for the 3.2.0 branch in docs

## Approach

**Screenshots after the changes are made.**
![d1](https://user-images.githubusercontent.com/42435576/94005752-5c279b80-fdbc-11ea-8c46-385096294b32.png)

![d2](https://user-images.githubusercontent.com/42435576/94005762-5fbb2280-fdbc-11ea-8257-9b540eaeb714.png)

![d3](https://user-images.githubusercontent.com/42435576/94005767-6184e600-fdbc-11ea-8a84-77d8f3ddbc70.png)


## User stories
You can enable Mutual SSL security by importing certificates as shown in the below example api_params.yaml file.
```
environments:
  - name: dev
    endpoints:
      production:
      sandbox:
  - name: production
    endpoints:
      production:
      sandbox:
    mutualSslCerts:
        - tierName: Unlimited
          alias: Alice
          path: /home/myname/Documents/Work/certificates/alice.crt
        - tierName: Gold
          alias: Bob
          path: /home/myname/Documents/Work/certificates/bob.crt
```
After the API is imported to the APIM (3.2.0) the mutualssl certificates will be shown as below.


## Related PRs
https://github.com/wso2/product-apim-tooling/pull/486

## Test environment
Ubuntu 20.04 LTS
Java JDK 1.8_245
APIM 3.2.0
APICTL 3.2.0 
