### PR TITLE
Update changing-to-mysql.md

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -11,7 +11,7 @@ The following sections describe how to set up a MySQL database to replace the de
 
 -   [Setting up the database and users](#setting-up-the-database-and-users)
 -   [Setting up the drivers](#setting-up-the-drivers)
--   [Executing db scripts to create tables on MySQL database](#executing-db-scripts-to-create-tables-on-mysql-database)
+-   [Executing DB scripts to create tables on MySQL database](#executing-db-scripts-to-create-tables-on-mysql-database)
 
 ### Setting up the database and users
 
@@ -20,7 +20,7 @@ Follow the  instructions below to set up a MySQL database:
 !!! note
     WSO2 recommends that you use Failover configuration over Load Balanced configuration with the MySQL clusters.
 
-1.  Define the hostname for configuring permissions for the new database by opening the `/etc/hosts` file and adding the following:
+1.  Define the hostname for configuring permissions for the new database in the `/etc/hosts` file.
 
     !!! warning
         Do this step only if your database is not on your local machine and on a separate server.
@@ -36,7 +36,7 @@ Follow the  instructions below to set up a MySQL database:
 1.  Enter the following command in a command prompt, where `USER_NAME` is the username that you will use to access the databases and `MYSQL_HOST_IP` is the IP of the host.
 
     !!! tip
-        User should have the database creation privileges.
+        The user should have database creation privileges.
 
     ``` java
     $ mysql -h <MYSQL_HOST_IP> -u <USER_NAME> -p
@@ -44,7 +44,7 @@ Follow the  instructions below to set up a MySQL database:
 
 1.  When prompted, specify the password that will be used to access the databases with the username you specified.
 
-1.  In the MySQL command prompt, create the database using the following command:
+1.  In the MySQL command prompt, create the database.
 
     ``` java
     mysql> create database <DATABASE_NAME>;
@@ -58,12 +58,12 @@ Follow the  instructions below to set up a MySQL database:
           mysql> create database <DATABASE_NAME> character set latin1;
           ```
 
-        - If you are using MySQL to configure your datasource, we recommend that you use a case sensitive database collation. For more information, see the [MySQL Official Manual](https://dev.mysql.com/doc/refman/5.7/en/charset-mysql.html). The default database collation, which is `latin1_swedish_ci`, is case insensitive. However, you need to maintain case sensitivity for database collation, because when the database or table has a case-insensitive collation in MySQL 5.6 or 5.7, if a user creates an API with letters using mixed case, deletes the API, and then creates another API with the same name, but in lower case letters, then the later created API loses its permission information, because when deleting the API, it keeps the Registry collection left behind.
+        - If you are using MySQL to configure your datasource, we recommend that you use a case sensitive database collation. For more information, see the [MySQL Official Manual](https://dev.mysql.com/doc/refman/5.7/en/charset-mysql.html). The default database collation, which is `latin1_swedish_ci`, is case insensitive. However, you need to maintain case sensitivity for database collation, because when the database or table has a case-insensitive collation in MySQL 5.6 or 5.7, if a user creates an API with letters using mixed case, deletes the API, and then creates another API with the same name, but in lower case letters, then the later created API loses its permission information because when deleting the API, it keeps the Registry collection left behind.
         
         - This issue could be avoided if you use a case sensitive collation for database and tables. In that case, when creating the second API (which has the same name, but is entirely in lowercase letters), it will create a new record with the lowercase name in the `UM_PERMISSION` table.
     
 
-1.  Give authorization to the user you use to access the databases as follows. 
+1.  Provide authorization to the user that you use to access the databases. 
 
      For example, let's consider `apimadmin` as the user.
 
@@ -72,7 +72,7 @@ Follow the  instructions below to set up a MySQL database:
     ```
 
     !!! info
-        If you are using MySQL version - 8.0.x, use following commands to create the user and grant authorization:
+        If you are using MySQL version - 8.0.x, use the following commands to create the user and the grant authorization:
 
         ``` java
         mysql> CREATE USER 'apimadmin'@'localhost' IDENTIFIED BY 'apimadmin';
@@ -82,13 +82,13 @@ Follow the  instructions below to set up a MySQL database:
         mysql> GRANT ALL ON APIM.* TO 'apimadmin'@'localhost';
         ```
 
-1.  After you have finalized the permissions, reload all the privileges by executing the following command:
+1.  After you have finalized the permissions, reload all the privileges.
 
     ``` java
     mysql> FLUSH PRIVILEGES;
     ```
 
-1.  Log out from the MySQL command prompt by executing the following command:
+1.  Log out from the MySQL command prompt.
 
     ``` java
     mysql> quit;
@@ -105,28 +105,28 @@ Follow the  instructions below to set up a MySQL database:
 !!! tip
     Be sure to use the connector version that is supported by the MySQL version you use. If you come across any issues due to version incompatibility, follow the  instructions below:
 
-    1.  Shut down the server and remove all existing connectors from the `<API-M_HOME>/repository/components/lib` and `<API-M_HOME>/repository/components/dropins` directories.
+    1.  Shut down the server and remove all the existing connectors from the `<API-M_HOME>/repository/components/lib` and `<API-M_HOME>/repository/components/dropins` directories.
     2.  Download the connector JAR that is compatible with your current MySQL version.
     3.  Copy the JAR file **only to** the `<API-M_HOME>/repository/components/lib` location.
     
-        Files will be copied automatically to the dropins folder during the server startup.
+        Files will be copied automatically to the `dropins` folder during the server startup.
 
-### Executing db scripts to create tables on MySQL database
+### Executing DB scripts to create tables on MySQL database
 
-1.  To create tables in the registry and user manager database (`WSO2_SHARED_DB`), execute the relevant script as shown below.
+1.  Execute the relevant scrip to create tables in the registry and user manager database (`WSO2_SHARED_DB`).
 
     ```sh
     $ mysql -u regadmin -p -Dshared_db < '<API-M_HOME>/dbscripts/mysql.sql';
     ```
 
-2.  To create tables in the apim database (`WSO2AM_DB`), execute the relevant script as shown below.
+2. Execute the relevant script to create tables in the apim database (`WSO2AM_DB`).
 
     ```sh
     $ mysql -u apimadmin -p -Dapim_db < '<API-M_HOME>/dbscripts/apimgt/mysql.sql';
     ```
 
 !!! note
-    `<API-M_HOME>/dbscripts/mb-store/mysql-mb.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to MySQL, then you need to have seperate databases for each API-M Traffic Manager node.
+    `<API-M_HOME>/dbscripts/mb-store/mysql-mb.sql` is the script that should be used when creating the tables in `WSO2_MB_STORE_DB` database. You can use H2 as the MB database even when working in production. However, if you need to change the MB database to MySQL, then you need to have separate databases for each API-M Traffic Manager node.
 
 !!! note
     Additional notes
@@ -144,7 +144,7 @@ Follow the  instructions below to set up a MySQL database:
     ```
 
 !!! note
-    In the sample commands above, its assumed that the username and password defined in the datasource configurations in `<API-M_HOME>/repository/conf/deployment.toml` file is **wso2user** and **wso2123** respectively.
+    In the sample commands above, it is assumed that the username and password defined in the datasource configurations in the `<API-M_HOME>/repository/conf/deployment.toml` file are **wso2user** and **wso2123** respectively.
 
 ## Changing the Carbon database to MySQL
 
@@ -152,7 +152,7 @@ Follow the  instructions below to set up a MySQL database:
 
 ### Creating the datasource connection to MySQL
 
-A datasource is used to establish the connection to a database. By default, `WSO2_SHARED_DB` and `WSO2AM_DB` datasources are configured in the `deployment.toml` file for the purpose of connecting to the default H2 databases.
+A datasource is used to establish a connection to a database. By default, `WSO2_SHARED_DB` and `WSO2AM_DB` datasources are configured in the `deployment.toml` file to connect to the default H2 databases.
 
 After setting up the MySQL database to replace the default H2 database, either change the default configurations of the `WSO2_SHARED_DB` and `WSO2AM_DB` datasources, or configure a new datasource to point it to the new database as explained below.
 
@@ -163,9 +163,9 @@ Follow the  instructions below to change the type of the default datasources.
 
 1.  Open the `<API-M_HOME>/repository/conf/deployment.toml` configuration file and locate the `[database.shared_db]` and `[database.apim_db]` configuration elements.
 
-2.  You simply have to update the URL pointing to your MySQL database, the username, and password required to access the database and the MySQL driver details as shown below.
+2.  You simply have to update the URL pointing to your MySQL database, the username, and password required to access the database, and the MySQL driver details as shown below.
 
-    | Element                       | Description                                                 |
+    | **Element**                       | **Description**                                                 |
     |-------------------------------|-------------------------------------------------------------|
     | **type**                      | The database type used                                      |
     | **url**                       | The URL of the database. The default port for MySQL is 3306 |
@@ -203,7 +203,7 @@ Follow the  instructions below to change the type of the default datasources.
 
 3.  You can update the configuration elements given below for your database connection.
 
-    | Element                | Description                                                                                                                                                                                                                                                                                                                                  |
+    | **Element**                | **Description**                                                                                                                                                                                                                                                                                                                                  |
     |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | **maxActive**          | The maximum number of active connections that can be allocated at the same time from this pool. Enter any negative value to denote an unlimited number of active connections.                                                                                                                                                                |
     | **maxWait**            | The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned before throwing an exception. You can enter zero or a negative value to wait indefinitely.                                                                                                              |
@@ -211,7 +211,7 @@ Follow the  instructions below to change the type of the default datasources.
     | **testOnBorrow**       | The indication of whether objects will be validated before being borrowed from the pool. If the object fails to validate, it will be dropped from the pool, and another attempt will be made to borrow another.                                                                                                                              |
     | **validationQuery**    | The SQL query that will be used to validate connections from this pool before returning them to the caller.                                                                                                                                                                                                                                  |
     | **validationInterval** | The indication to avoid excess validation, and only run validation at the most, at this frequency (time in milliseconds). If a connection is due for validation but has been validated previously within this interval, it will not be validated again.                                                                                      |
-    | **defaultAutoCommit**  | This property is **not** applicable to the Carbon database in WSO2 products because auto committing is usually handled at the code level, i.e., the default auto commit configuration specified for the RDBMS driver will be effective instead of this property element. Typically, auto committing is enabled for RDBMS drivers by default. When auto committing is enabled, each SQL statement will be committed to the database as an individual transaction, as opposed to committing multiple statements as a single transaction.|                                                              
+    | **defaultAutoCommit**  | This property is **not** applicable to the Carbon database in WSO2 products because auto-committing is usually handled at the code level, i.e., the default auto-commit configuration specified for the RDBMS driver will be effective instead of this property element. Typically, auto-committing is enabled for RDBMS drivers by default. When auto-committing is enabled, each SQL statement will be committed to the database as an individual transaction, as opposed to committing multiple statements as a single transaction.|                                                              
     | **commitOnReturn**     | If `defaultAutoCommit =false`, then you can set `commitOnReturn =true`, so that the pool can complete the transaction by calling the commit on the connection as it is returned to the pool. However, If `rollbackOnReturn =true` then this attribute is ignored. The default value is false.|
     | **rollbackOnReturn**   | If `defaultAutoCommit =false`, then you can set `rollbackOnReturn =true` so that the pool can terminate the transaction by calling rollback on the connection as it is returned to the pool. The default value is false.|
 
@@ -252,4 +252,4 @@ Follow the  instructions below to change the type of the default datasources.
 1.  Restart the server.
 
     !!! note
-        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, refer [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).
+        To give the Key Manager, Publisher, and Developer Portal components access to the user management data with shared permissions, JDBCUserStoreManager has been configured by default. For more information, see [Configuring Userstores]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store).

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -184,13 +184,13 @@ Follow the  instructions below to change the type of the default datasources.
     ``` tab="Example"
     [database.shared_db]
     type = "mysql"
-    url = "jdbc:mysql://localhost:3306/shared_db"
+    url = "jdbc:mysql://localhost:3306/shared_db?useSSL=false"
     username = "regadmin"
     password = "regadmin"
 
     [database.apim_db]
     type = "mysql"
-    url = "jdbc:mysql://localhost:3306/apim_db"
+    url = "jdbc:mysql://localhost:3306/apim_db?useSSL=false"
     username = "apimadmin"
     password = "apimadmin"
     ```
@@ -230,7 +230,7 @@ Follow the  instructions below to change the type of the default datasources.
     ``` tab="Example"
     [database.shared_db]
     type = "mysql"
-    url = "jdbc:mysql://localhost:3306/shared_db"
+    url = "jdbc:mysql://localhost:3306/shared_db?useSSL=false"
     username = "regadmin"
     password = "regadmin"
     pool_options.maxActive = 100
@@ -239,7 +239,7 @@ Follow the  instructions below to change the type of the default datasources.
 
     [database.apim_db]
     type = "mysql"
-    url = "jdbc:mysql://localhost:3306/apim_db"
+    url = "jdbc:mysql://localhost:3306/apim_db?useSSL=false"
     username = "apimadmin"
     password = "apimadmin"
     pool_options.maxActive = 50


### PR DESCRIPTION
Added useSSL=false to the url in the [database.shared_db] and [database.apim_db] configuration elements in the deployment.toml examples. Without this setting, the server was failing to start due to mutual SSL connection failure issue.

![image](https://user-images.githubusercontent.com/66669898/94473697-26cee380-01ea-11eb-99b8-e78ab6e1cff3.png)
