### PR TITLE
Fix incorrect wording for jdbc log filtering

### DIFF
--- a/en/docs/administer/logging-and-monitoring/monitoring/working-with-observability.md
+++ b/en/docs/administer/logging-and-monitoring/monitoring/working-with-observability.md
@@ -707,7 +707,7 @@ This will give the time consumed by each method in ascending order. If a method 
 
 ``` java
 cat correlation.log | grep “correlationID” | grep “|HTTP” | cut -d “|” -f4 | sort -n
-cat correlation.log | grep “correlationID” | grep “|DB_CALL|” | cut -d “|” -f4 | sort -n
+cat correlation.log | grep “correlationID” | grep “|jdbc|” | cut -d “|” -f4 | sort -n
 cat correlation.log | grep “correlationID” | grep “|ldap|” | cut -d “|” -f4 | sort -n
 ```
 


### PR DESCRIPTION
The term DB_CALL should actually be jdbc.
Fixes https://github.com/wso2/docs-apim/issues/1988