### PR TITLE
[Docs][Master] Adding a missing Tip when configuring Okta as Keymanager

### DIFF
--- a/en/docs/administer/key-managers/configure-okta-connector.md
+++ b/en/docs/administer/key-managers/configure-okta-connector.md
@@ -122,8 +122,8 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
 
           <table>
           <tr class="header">
-          <th>Configuration</th>
-          <th>Description</th>
+          <th><b>Configuration</b></th>
+          <th><b>Description</b></th>
           <th> </th>
           </tr>
         
@@ -152,13 +152,13 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
           <td><p>The well-known URL of the Authorization Server (Key Manager).
           <br/>
           If the well-known URL is provided, other endpoints can be imported. 
-          <br/> e.g., https://dev-599740.okta.com/oauth2/default/.well-known/oauth-authorization-server</p>
+          <br/> Example:</br> https://dev-599740.okta.com/oauth2/default/.well-known/oauth-authorization-server</p>
           </td>
           <td>Optional</td>
           </tr>
           <tr class="even">
           <td>Issuer</td>
-          <td>The issuer that consumes or validates access tokens. <br/>e.g., https://dev-599740.okta.com/oauth2/default</td>
+          <td>The issuer that consumes or validates access tokens. <br/>Example:</br> https://dev-599740.okta.com/oauth2/default</td>
           <td>Optional</td>
           </tr>
           <tr class="odd">
@@ -228,12 +228,12 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
           </tr>
           <tr class="even">
           <td>Consumer Key Claim URI</td>
-          <td>The claim URI for consumer key e.g., cid</td>
+          <td>The claim URI for consumer key </br>Example:</br> cid</td>
           <td>Mandatory</td>
           </tr>
           <tr class="odd">
           <td>Scopes Claim URI</td>
-          <td>The claim URI for scopes e.g., scp</td>
+          <td>The claim URI for scopes </br>Example:</br> scp</td>
           <td>Mandatory</td>
           </tr>
           <tr class="even">
@@ -256,7 +256,7 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
           <td>The JSON Web Key Set (JWKS) endpoint is a read-only endpoint. This URL returns the Okta's public key set in JSON web key set format.
           This contains the signing key(s) the Relying Party (RP) uses to validate signatures from the Okta.
           </br>
-          e.g., https://dev-599740.okta.com/oauth2/default/v1/keys
+          Example:</br> https://dev-599740.okta.com/oauth2/default/v1/keys
           </td>
           <td>Optional</td>
           </tr>
@@ -296,8 +296,8 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
           <td>The JWKS endpoint is used to validate the JWT token signature.
           If this option is used to validate the tokens it is mandatory to add a Token Handling Option
                For Okta it should be <b>JWT</b> and it is required to specify a claim mapping as a unique identifier.
-          </b>e.g., Claim Key : iss
-          </b>Claim Value : https://dev-599740.okta.com/oauth2/default
+          </br>Example:</br> Claim Key : iss</br> 
+          Claim Value : https://dev-599740.okta.com/oauth2/default
           </td>
           <td>Optional</td>
           </tr>
@@ -330,7 +330,7 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
         </table>
 
 !!! tip
-     Once the authorization URL that generates when you create an application in Okta is provided as **"Well-known-url"** that can be found under the parameter **Metadata URI** in the settings related to the Authorization server and click the **Import** button, and set of the required information in the key-manager configurations will be filled automatically.
+     After the authorization URL, which is generated when you create an application in Okta, is provided as a **"Well-known-url"**, it can be found under the parameter **Metadata URI** in the settings related to the Authorization server. When you click the **Import** button under the latter mentioned settings, the required information in the Key Manager configurations will be filled automatically.
 
 ## Step 3 - Generate keys using the Okta Key Manager
 
@@ -344,12 +344,11 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
 3. Create a new application or use the default application.
 4. Click **Sandbox Keys**.
 
-     ![Okta Developer Portal generate keys]({{base_path}}/assets/img/administer/okta-devportal-generate-keys.png)
+     [![Okta Developer Portal generate keys]({{base_path}}/assets/img/administer/okta-devportal-generate-keys.png)]({{base_path}}/assets/img/administer/okta-devportal-generate-keys.png)
 
 5. Select the **Response Type**.
 
 6. Click **Generate Keys**.
 
-!!! tip
-     If you want to generate the tokens with scopes, those scopes should have been defined in Okta as mentioned in the <a href="#step12c">Step 1 - (2) c</a>.
-
+    !!! tip
+        If you want to generate the tokens with scopes, those scopes should have been defined in Okta as mentioned in the <a href="#step12c">Step 1 - (2) c</a>.

--- a/en/docs/administer/key-managers/configure-okta-connector.md
+++ b/en/docs/administer/key-managers/configure-okta-connector.md
@@ -329,6 +329,9 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
           </tr>
         </table>
 
+!!! tip
+     Once the authorization URL that generates when you create an application in Okta is provided as **"Well-known-url"** and click the **Import** button set of the required information in the key-manager configurations will be filled automatically.
+
 ## Step 3 - Generate keys using the Okta Key Manager
 
 1. Sign in to the Developer Portal.

--- a/en/docs/administer/key-managers/configure-okta-connector.md
+++ b/en/docs/administer/key-managers/configure-okta-connector.md
@@ -330,7 +330,7 @@ Follow the instructions below to configure Okta as a third-party Key Manager:
         </table>
 
 !!! tip
-     Once the authorization URL that generates when you create an application in Okta is provided as **"Well-known-url"** and click the **Import** button set of the required information in the key-manager configurations will be filled automatically.
+     Once the authorization URL that generates when you create an application in Okta is provided as **"Well-known-url"** that can be found under the parameter **Metadata URI** in the settings related to the Authorization server and click the **Import** button, and set of the required information in the key-manager configurations will be filled automatically.
 
 ## Step 3 - Generate keys using the Okta Key Manager
 


### PR DESCRIPTION
## Purpose
Adding a missing Tip when configuration OKTA as key manager. 
Include a section in the documentation explaining that, a user just has to provide the authorization URL extracted from octa application as the well-known endpoint then, Click import to fill the required information (should fix, Step 2 - Configure WSO2 API Manager -> b)

## Goals
Fixes https://github.com/wso2/product-apim/issues/9332 
fixes https://github.com/wso2/docs-apim/issues/2111
(For master branch)

## Approach
![t](https://user-images.githubusercontent.com/42435576/95324455-5dc58900-08bd-11eb-953d-46925a039f76.png)


## User stories
Configuring Okta as key manager
