### PR TITLE
[3.1.0] Modify the configuration to enable notifications

### DIFF
--- a/en/docs/learn/design-api/api-versioning/enabling-notifications.md
+++ b/en/docs/learn/design-api/api-versioning/enabling-notifications.md
@@ -7,7 +7,7 @@ Follow the instructions below to enable notifications for new API versions:
 1.  Add the email server configurations to the `<API-M_HOME>/repository/conf/deployment.toml` file as follows:
 
     ``` toml
-    [output_adapter.email]
+    [apim.notification]
     from_address = "abcd@gmail.com"
     username = "abcd@gmail.com"
     password = "xxxxxx"


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/docs-apim/issues/1545. The default deployment.toml has following commented configs:

``` toml
#[apim.notification]
#from_address = "APIM.com"
#username = "APIM"
#password = "APIM+123"
#hostname = "localhost"
#port = 3025
#enable_start_tls = false
#enable_authentication = true
```

Since we have key-mappings - [1], we can use the above to enable notifications.

[1] https://github.com/wso2/product-apim/blob/v3.1.0/modules/distribution/product/src/main/resources/conf/key-mappings.json#L95-L101