### PR TITLE
[Doc] [3.2.0] Modify docs for publish API to a cloud cluster in private jet mode

### DIFF
--- a/en/docs/learn/design-api/publish-api/publish-an-api-to-a-cloud-cluster-in-privatejet-mode.md
+++ b/en/docs/learn/design-api/publish-api/publish-an-api-to-a-cloud-cluster-in-privatejet-mode.md
@@ -4,13 +4,13 @@ In an age where more and more applications are adopting the microservice archite
 Automating computer application deployment, scaling, and management are a few of such functionalities to name. WSO2 API Manager provides cloud-native API management, where a user is able to expose microservices as managed APIs in cloud environment such as Kubernetes. 
 This could be done with the support of WSO2-Kubernetes API Operator. 
 
- ![Architecture](https://github.com/wso2/k8s-api-operator/blob/master/docs/HowToGuide/working-with-deployment-modes.md#private-jet-mode)
+ ![Architecture]({{base_path}}/assets/img/learn/privatejet-mode/architecture.png)
 
 Microservices will be exposed as managed APIs in cloud clusters in the PrivetJet mode. Here, each microservice wll have a dedicated [WSO2 API Microgateway](https://wso2.com/api-management/api-microgateway/). This will provide maximum security and guaranteed resource allocation for API execution. As depicted in the above diagram, When the APIs published via API-Manager in cloud environments, deployment, scaling, and management tasks will handle by the WSO2 -Kubernetes API Operator itself.
 
 !!! attention "Before you Begin"
-    1. Follow the document [Enabling PrivateJet Mode for Microgateways]({{base_path}}/learn/kubernetes-operators/K8s API Operator/enabling-privatejet-mode-to-deploy-apis/) to enable deploying APIs to cloud clusters in PrivateJet mode.
-    2. Follow the document [Securing APIs deployed in cloud clusters]({{base_path}}/learn/api-security/api-authentication/securing-apis-deployed-in-cloud-clusters.md) to secure the API using any other [authentication mechanisms](https://github.com/wso2/k8s-api-operator/blob/v1.2.0-alpha/docs/HowToGuide/OverviewOfCrds/apply-security-to-api.md) other than JWT authentication. 
+    1. Follow the document [Enabling PrivateJet Mode for Microgateways]({{base_path}}/learn/kubernetes-operators/k8s-api-operator/enabling-privatejet-mode-to-deploy-apis/) to enable deploying APIs to cloud clusters in PrivateJet mode.
+    2. Follow the document [Securing APIs deployed in cloud clusters]({{base_path}}/learn/api-security/api-authentication/securing-apis-deployed-in-cloud-clusters/) to secure the API using any other [authentication mechanisms](https://github.com/wso2/k8s-api-operator/blob/v1.2.0-alpha/docs/HowToGuide/OverviewOfCrds/apply-security-to-api.md) other than JWT authentication.
 
 ## Publish an API to a Cloud Cluster in PrivateJet Mode  
  
@@ -20,7 +20,7 @@ Microservices will be exposed as managed APIs in cloud clusters in the PrivetJet
 
 3. Click on an API that is in the **CREATED** state.
    
-        <img src="{{base_path}}/assets/img/learn/select-created-api.png" alt="Select API" title="Select API" width="35%" />
+     <img src="{{base_path}}/assets/img/learn/select-created-api.png" alt="Select API" title="Select API" width="35%" />
 
     
 3. Click the *Environments* tab and select the cluster(s) to deploy the API.

--- a/en/docs/learn/design-api/publish-api/publish-an-api-to-a-cloud-cluster-in-privatejet-mode.md
+++ b/en/docs/learn/design-api/publish-api/publish-an-api-to-a-cloud-cluster-in-privatejet-mode.md
@@ -4,7 +4,7 @@ In an age where more and more applications are adopting the microservice archite
 Automating computer application deployment, scaling, and management are a few of such functionalities to name. WSO2 API Manager provides cloud-native API management, where a user is able to expose microservices as managed APIs in cloud environment such as Kubernetes. 
 This could be done with the support of WSO2-Kubernetes API Operator. 
 
- ![Architecture]({{base_path}}/assets/img/learn/privatejet-mode/architecture.png)
+ [![Architecture]({{base_path}}/assets/img/learn/privatejet-mode/architecture.png)]({{base_path}}/assets/img/learn/privatejet-mode/architecture.png)
 
 Microservices will be exposed as managed APIs in cloud clusters in the PrivetJet mode. Here, each microservice wll have a dedicated [WSO2 API Microgateway](https://wso2.com/api-management/api-microgateway/). This will provide maximum security and guaranteed resource allocation for API execution. As depicted in the above diagram, When the APIs published via API-Manager in cloud environments, deployment, scaling, and management tasks will handle by the WSO2 -Kubernetes API Operator itself.
 
@@ -20,7 +20,7 @@ Microservices will be exposed as managed APIs in cloud clusters in the PrivetJet
 
 3. Click on an API that is in the **CREATED** state.
    
-     <img src="{{base_path}}/assets/img/learn/select-created-api.png" alt="Select API" title="Select API" width="35%" />
+     <a href="{{base_path}}/assets/img/learn/select-created-api.png"><img src="{{base_path}}/assets/img/learn/select-created-api.png" alt="Select API" title="Select API" width="35%" /></a>
 
     
 3. Click the *Environments* tab and select the cluster(s) to deploy the API.
@@ -31,4 +31,4 @@ Microservices will be exposed as managed APIs in cloud clusters in the PrivetJet
  
      ![API LifeCycle]({{base_path}}/assets/img/learn/privatejet-mode/lifecycle_publish.png)
      
-Now, you have successfully published your API to a cloud cluster. Next, you can [test your API by invoking it from the developer portal]({{base_path}}/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console/#invoke-an-api-deployed-on-a-cloud-cluster). 
+Now, you have successfully published your API to a cloud cluster. Next, you can [test your API by invoking it from the developer portal]({{base_path}}/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console/#invoke-an-api-deployed-on-a-cloud-cluster).


### PR DESCRIPTION
## Purpose
This PR will include:

- Adding the architecture diagram image.
- Modifying the Enabling PrivateJet Mode for Microgateways and Securing APIs deployed in cloud clusters redirecting links.
- Adding the image with an API that is in the CREATED state.

## Approach

- Adding the architecture diagram image.
![privatejet1](https://user-images.githubusercontent.com/35601987/96870058-f6e3ca80-148d-11eb-8ab2-64635bf4c345.png)

- Modifying the Enabling PrivateJet Mode for Microgateways and Securing APIs deployed in cloud clusters redirecting links.
- Adding the image with an API that is in the CREATED state.

![privatejetdoc2](https://user-images.githubusercontent.com/35601987/96870110-0a8f3100-148e-11eb-80c6-388a4f4eac55.png)
