### PR TITLE
[3.1.0] Modifying the documentation on apictl set --mode command

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -65,16 +65,16 @@ Run the following CTL command to set the mode of the CTL. The allowed modes are 
 -   **Command**
 
     ```go
-    apictl set mode <mode>
+    apictl set --mode <mode>
     ```
 
     !!! example
 
         ``` go
-        apictl set mode default
+        apictl set --mode default
         ```
         ``` go
-        apictl set mode kubernetes
+        apictl set --mode kubernetes
         ```
 
 ## Add an environment


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/517

## Goals
Correct the apictl set --mode command

## Approach
- Modify the command "apictl set mode <mode>" to "apictl set --mode <mode>"
![image](https://user-images.githubusercontent.com/25246848/97340673-19b91900-18aa-11eb-916d-d9a6f524c0ee.png)

## User stories
Users can refer the correct command to set the mode.