### PR TITLE
[3.2.0] Correcting the examples of 'apictl import api-product' command

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -115,18 +115,16 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
         !!! info
             **Flags:**  
             
-            -    Required :  
-
+            -    Required :     
                 `--environment` or `-e` : Name of the environment to be added   
-                AND (either)
-                `--apim` : API Manager endpoint for the environments
-                OR (the following 4)
-                `--registration` : Registration endpoint for the environment 
-                `--admin` : Admin endpoint for the environment  
-                `--publisher` : Publisher endpoint for the environment  
+                AND (either)     
+                `--apim` : API Manager endpoint for the environments     
+                OR (the following 4)     
+                `--registration` : Registration endpoint for the environment     
+                `--admin` : Admin endpoint for the environment     
+                `--publisher` : Publisher endpoint for the environment     
                 `--devportal` : Developer Portal endpoint for the environment 
-            -   Optional :
-
+            -   Optional :     
                 `--token` : Token endpoint for the environment
             
         !!! tip

--- a/en/docs/learn/api-controller/migrating-api-products-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-api-products-to-different-environments.md
@@ -152,16 +152,16 @@ You can use the API Product archive exported from the previous section (or you c
             apictl import api-product -f dev/LeasingAPIProduct_1.0.0.zip -e production -k
             ```
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production -k
             ``` 
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-apis=true -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-apis=true -k
             ``` 
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-api-product=true -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-api-product=true -k
             ```    
             ``` go
-            apictl import-api -f dev/LeasingAPIProduct_1.0.0.zip -e production --preserve-provider=false --update-apis=true -k 
+            apictl import api-product -f dev/LeasingAPIProduct_1.0.0.zip -e production --preserve-provider=false --update-apis=true -k 
             ```
         !!! tip
             If your file path is `/Users/kim/.wso2apictl/exported/api-products/dev/LeasingAPIProduct_1.0.0.zip.`, then you need to enter `dev/LeasingAPIProduct_1.0.0.zip` as the value for `--file` or `-f` flag.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/519

## Goals
Correct the examples of the **import api-product** API Controller command

## Approach
- Changed the examples with **import-api** to "import api-product" as below.
![image](https://user-images.githubusercontent.com/25246848/97473513-1177e100-1971-11eb-970f-183ea69f065c.png)
- Corrected the flag description of add-env command.
Earlier:
![image](https://user-images.githubusercontent.com/25246848/97477012-1a6ab180-1975-11eb-9190-ed5eb1a93873.png)
Now: 
![image](https://user-images.githubusercontent.com/25246848/97477124-3b330700-1975-11eb-9b9d-5a5a08196d65.png)

## User stories
Users can refer the correct examples of the **import api-product** command.