### PR TITLE
Modifying the documentation with the revamped commands of the API Controller

### DIFF
--- a/en/docs/getting-started/quick-start-guide.md
+++ b/en/docs/getting-started/quick-start-guide.md
@@ -248,7 +248,7 @@ Let's look at how you can use the CI/CD command line tool for APIs (API Controll
          (localhost) using the default ports.
     
     ``` bash
-    ./apictl add-env -e dev \
+    ./apictl add env dev \
             --apim https://localhost:9443 \
             --token https://localhost:8243/token 
 
@@ -258,7 +258,6 @@ Let's look at how you can use the CI/CD command line tool for APIs (API Controll
          **Flags:**
 
         - Required :     
-        `--environment` or `-e` : Name of the environment to be added   
         `--apim` : API Manager endpoint for the environments  
 
         - Optional :      
@@ -268,6 +267,8 @@ Let's look at how you can use the CI/CD command line tool for APIs (API Controll
             `--publisher` : Publisher endpoint for the environment 
             `--devportal` : DevPortal endpoint for the environment
    
+    !!!note
+        `apictl add-env` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl add env` as shown above. For further information please refer [Add an environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment).  
 
      On successfully executing this command, you should see the following message.
      
@@ -332,8 +333,11 @@ Let's look at how you can use the CI/CD command line tool for APIs (API Controll
         If you are working with a specific environment for the first time, you will be prompted to enter your account credentials on WSO2 API Manager. You can use the default admin credentials as **`admin/admin`**.
 
      ``` bash
-     ./apictl import-api --file ./PetstoreAPI --environment dev -k 
+     ./apictl import api --file ./PetstoreAPI --environment dev -k 
      ```
+
+    !!!note
+        `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above. For further information please refer [Import an API Project]({{base_path}}/learn/api-controller/importing-apis-via-dev-first-approach/#import-an-api-project).  
 
      You should now see your API deployed successfully on WSO2 API Manager.
 

--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -2,7 +2,7 @@
 
 When there are multiple environments, to allow easily configuring environment-specific details, apictl supports an additional parameter file named `api_params.yaml`. It is recommended to store the parameter file with the API Project; however, it can be stored anywhere as required. 
 
-After the file is placed in the project directory, the tool will auto-detect the parameters file upon running the `import-api` command and create an environment-based artifact for API Manager. If the `api_params.yaml` is not found in the project directory, the tool will lookup in the project’s base path and the current working directory. 
+After the file is placed in the project directory, the tool will auto-detect the parameters file upon running the `import api` command and create an environment-based artifact for API Manager. If the `api_params.yaml` is not found in the project directory, the tool will lookup in the project’s base path and the current working directory. 
 
 The following is the structure of the parameter file.
 
@@ -87,8 +87,11 @@ Instead of the default `api_params.yaml`, you can a provide custom parameter fil
 
 !!! example
     ```go
-    apictl import-api -f dev/PhoneVerification_1.0.zip -e production --params /home/user/custom_params.yaml 
+    apictl import api -f dev/PhoneVerification_1.0.zip -e production --params /home/user/custom_params.yaml 
     ```
+
+!!!note
+    `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
 
 !!! info
     -   Production/Sandbox backends for each environment can be specified in the parameter file with additional configurations, such as timeouts.

--- a/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
+++ b/en/docs/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
@@ -28,17 +28,17 @@ Further, you can create your own custom user with a custom role to perform speci
 </thead>
 <tbody>
 <tr class="odd">
-<td>add-env</td>
+<td>add env</td>
 <td>-</td>
 <td>-</td>
 </tr>
 <tr class="even">
-<td>remove-env</td>
+<td>remove env</td>
 <td>-</td>
 <td>-</td>
 </tr>
 <tr class="odd">
-<td>list env</td>
+<td>get envs</td>
 <td>-</td>
 <td>-</td>
 </tr>
@@ -53,7 +53,7 @@ Further, you can create your own custom user with a custom role to perform speci
 <td>-</td>
 </tr>
 <tr class="even">
-<td>list apis</td>
+<td>get apis</td>
 <td><strong>API Create</strong> or <strong>API Publish</strong> or <strong>API Subscribe</strong></td>
 <td>apim:api_import_export</td>
 </tr>
@@ -68,12 +68,12 @@ Further, you can create your own custom user with a custom role to perform speci
 <td>apim:api_import_export</td>
 </tr>
 <tr class="odd">
-<td>import-api</td>
+<td>import api</td>
 <td><strong>API Create</strong> to import an API in CREATED state,<br> Both <strong>API Create</strong> and <strong>API Publish</strong> to import an API in PUBLISHED state</td>
 <td>apim:api_import_export</td>
 </tr>
 <tr class="odd">
-<td>export-api</td>
+<td>export api</td>
 <td>-</td>
 <td>apim:api_import_export</td>
 </tr>
@@ -83,7 +83,7 @@ Further, you can create your own custom user with a custom role to perform speci
 <td>apim:api_import_export</td>
 </tr>
 <tr class="odd">
-<td>list api-products</td>
+<td>get api-products</td>
 <td>-</strong></td>
 <td>apim:api_product_import_export</td>
 </tr>
@@ -113,17 +113,17 @@ Further, you can create your own custom user with a custom role to perform speci
 <td>apim:app_import_export</td>
 </tr>
 <tr class="even">
-<td>import-app</td>
+<td>import app</td>
 <td><strong>API Subscribe</strong></td>
 <td>apim:app_import_export</td>
 </tr>
 <tr class="odd">
-<td>export-app</td>
+<td>export app</td>
 <td>-</td>
 <td>apim:app_import_export</td>
 </tr>
 <tr class="even">
-<td>get-keys</td>
+<td>get keys</td>
 <td><strong>API Subscribe</strong></td>     
 <td>apim:app_manage, <br>apim:sub_manage, <br>apim:api_product_import_export
 <br><br>or<br>apim:app_manage, <br>apim:sub_manage, <br>apim:api_import_export

--- a/en/docs/learn/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects.md
+++ b/en/docs/learn/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects.md
@@ -52,16 +52,19 @@ Follow the instructions below to initialize an API Project with environment vari
         ...
         ```
 
-    Now you can import the Project using `import-api` command.
+    Now you can import the Project using `import api` command.
 
 4. Import the API
 
     ```bash
-    apictl import-api -f PetstoreProject -e development
+    apictl import api -f PetstoreProject -e development
     ```
 
     !!! warning
         If an environment variable is not set, the command will fail and request a set of required environment variables on the system.
+
+    !!!note
+        `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
 
 Once the project is successfully imported, sign-in to the WSO2 API Publisher and check the newly imported API with the same details specified above.
 
@@ -107,11 +110,14 @@ The file supports detecting environment variables during the API import process.
 3.  Import the API Project
 
     ```bash
-    apictl import-api -f PetstoreProject --environment development --params PetstoreProject/api_params.yaml --update
+    apictl import api -f PetstoreProject --environment development --params PetstoreProject/api_params.yaml --update
     ```
 
     !!! warning
         If an environment variable is not set, the command will fail and request a set of required environment variables on the system. 
+
+    !!!note
+        `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
 
 Once the project is successfully imported, sign-in to the WSO2 API Publisher and check the Endpoints section of the imported API. The URLs specified as environment variables will appear there.
 
@@ -171,18 +177,24 @@ For example, consider we need to send a special header to the backend when calli
 4. Import the API Project
 
     ```bash
-    apictl import-api -f PetstoreProject --environment development --params PetstoreProject/api_params.yaml --update
+    apictl import api -f PetstoreProject --environment development --params PetstoreProject/api_params.yaml --update
     ```
 
+    !!!note
+        `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
+        
 5. Generate a token and invoke the API
 
     ```bash
-    $ apictl get-keys -e dev -n Petstore -v 1.0.0 -r admin
+    $ apictl get keys -e dev -n Petstore -v 1.0.0 -r admin
     eyJ0eXAiOiJKV1QiLCJhbGciOiJSUz....RWrACAUNSFBpxz1lRLqFlDiaVJAg
 
     $ curl -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUz....RWrACAUNSFBpxz1lRLqFlDiaVJAg" https://localhost:8243/petstore/1.0.0/pet/1 -k
     {"id":1,"category":{"id":1001,"name":"Animal"},"name":"doggie","photoUrls":["img/test/dog.jpeg","img/test/dog1.jpeg"],"tags":[{"id":2001,"name":"Pet"},{"id":2002,"name":"Animal"}],"status":"available"}
     ```
+
+    !!!note
+        `apictl get-keys` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get keys` as shown above.
 
 Upon successful invocation, the header `X-ENV-KEY: dev_101` will be sent to the backend of the API. The below log will be printed in the API gateway's terminal.
 

--- a/en/docs/learn/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
+++ b/en/docs/learn/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
@@ -107,7 +107,7 @@ Define environment specific data in API parameter file. In this tutorial as ther
 !!! info
     -   When there are multiple environments, to allow easily configuring environment-specific details, `apictl` supports an additional parameter file.
 
-    -   Once the file is placed in the project directory, the tool will auto-detect the parameters file upon running the `import-api` command and create an environment-based artifact for API Manager. 
+    -   Once the file is placed in the project directory, the tool will auto-detect the parameters file upon running the `import api` command and create an environment-based artifact for API Manager. 
 
     -   If the `api_params.yaml` is not found in the project directory, the tool will lookup in the project’s base path and the current working directory.
 
@@ -148,20 +148,23 @@ Follow the instructions below to use a GitHub Webhook to trigger the Jenkins Pip
 
     !!! example
         ```bash
-        apictl add-env -e dev \
+        apictl add env dev \
         --registration https://dev.apim.wso2.com \
         --apim https://dev.apim.wso2.com \
         --token https://dev.apim.wso2.com/token
         ```
         
         ```bash
-        apictl add-env -e prod \
+        apictl add env prod \
         --registration https://prod.apim.wso2.com \
         --apim https://prod.apim.wso2.com \
         --token https://prod.apim.wso2.com/token
         ```
 
-     For more information, see [Add an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment). 
+     For more information, see [Add an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment).
+
+    !!!note
+        `apictl add-env` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl add env` as shown above. 
     
      You can also add an environment manually beforehand or provide the details as a shell script in the same pipeline.
 
@@ -179,13 +182,13 @@ Follow the instructions below to use a GitHub Webhook to trigger the Jenkins Pip
     !!! info
         -   The `RETRY` variable is defined with 80 milliseconds so that the production and sandbox endpoints of the API deployed in the dev environment has an endpoint retry timeout value of 80 milliseconds. 
         -   As the first step, this will log in to the dev environment using the provided Jenkins credentials and 
-        then deploy the API into the dev environment using the `import-api` command. 
+        then deploy the API into the dev environment using the `import api` command. 
         -   The `preserve-provider` and `update` flags, will preserve the API provider in the given API project and import the API to the development environment seamlessly.
         -   The next stage `Run Tests` will run the test script that you committed to the project in the Git repository using `Newman`. 
         -   If you need to use the same test script to run it against multiple environments, you can maintain a separate 
         environment file and provide that as an argument for the `Newman` run command. For more information, see [Using environments in collection runs](https://learning.getpostman.com/docs/postman/collection-runs/using-environments-in-collection-runs/).
         -   After the tests are passed, the next stage will deploy the API to the prod environment using the 
-        `import-api` command. Similar to the dev environment, you can provide any environment-specific variable 
+        `import api` command. Similar to the dev environment, you can provide any environment-specific variable 
         values here so that they will be injected into the API during the deployment.
     
 

--- a/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/learn/api-controller/ci-cd-with-wso2-api-management.md
@@ -49,24 +49,27 @@ Let us check out the basic building blocks for creating a CI/CD pipeline with WS
 
      For more information, see [Download and initialize the ctl tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).  
 
-3.  Add API Manager environments using the `add-env` command.
+3.  Add API Manager environments using the `add env` command.
 
     !!! example
         ``` bash tab="Linux/Unix"
-        apictl add-env -e dev \
+        apictl add env dev \
                     --apim https://localhost:9443 
 
-        apictl add-env -e prod \
+        apictl add env prod \
                     --apim https://localhost:9444 
         ```
 
         ``` bash tab="Mac/Windows""
-        apictl add-env -e dev --apim https://localhost:9443 
+        apictl add env dev --apim https://localhost:9443 
 
-        apictl add-env -e prod --apim https://localhost:9444 
+        apictl add env prod --apim https://localhost:9444 
         ```    
 
-    For more information, see [Add an environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment). 
+    For more information, see [Add an environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#add-an-environment).
+    
+    !!!note
+        `apictl add-env` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl add env` as shown above. 
 
 <a name="B"></a>
 ### (B.) - Create and Publish an API in a lower environment
@@ -114,14 +117,17 @@ The **apictl** can export an API as an archive from a lower environment (i.e., d
     !!! tip
         A user with `admin` role is allowed to export APIs. To create a custom user who can export APIs, refer [Steps to Create a Custom User who can Perform API Controller Operations]({{base_path}}/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations/#steps-to-create-a-custom-user-who-can-perform-api-controller-operations).
 
-2. Export the API from the lower environment using the `export-api` command.
+2. Export the API from the lower environment using the `export api` command.
 
     !!! example
         ``` bash
-        apictl export-api -e dev -n SwaggerPetstore -v 1.0.0 --provider admin
+        apictl export api -e dev -n SwaggerPetstore -v 1.0.0 --provider admin
         ```
 
      For more information, see [Export an API]({{base_path}}/learn/api-controller/migrating-apis-to-different-environments/#export-an-api).
+
+    !!!note
+        `apictl export-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export api` as shown above.
 
 3.  Extract the content (API will be exported as an archive to the 
 `<USER_HOME>/.wso2apictl/exported/apis/dev/` directory). After extraction, you will find a directory named 
@@ -158,7 +164,7 @@ For more information on initializing an API Project using OpenAPI/Swagger Specif
 
      Define the *prod.wso2.com* and *prod.sandbox.wso2.com* as the backend URLs in this file.
      
-     It is recommended to store the parameter file with the API Project; however, you can store it anywhere as required and provide the location to this file as a flag when using the `import-api` command.
+     It is recommended to store the parameter file with the API Project; however, you can store it anywhere as required and provide the location to this file as a flag when using the `import api` command.
 
     !!! example
         ```bash
@@ -295,7 +301,7 @@ The repository that you committed the project in the above step <a href="#E">E</
         For deploying an API using `vcs deploy` command: 
         
         -   It is mandatory to have your API projects in a Git based version control system.
-        -   It is mandatory to have `api_params.yaml` file inside each API Project. This is created by default when you export an API using `export-api` or initialized an API Project using `init`. The following configuration section in the `api_params.yaml` file is used to deploy the API.
+        -   It is mandatory to have `api_params.yaml` file inside each API Project. This is created by default when you export an API using `export api` or initialized an API Project using `init`. The following configuration section in the `api_params.yaml` file is used to deploy the API.
 
         ```bash
         deploy:
@@ -320,7 +326,7 @@ You can use the following alternative approach to promote a single API via CI/CD
 
     !!! example
         ```bash
-        apictl import-api -f ./SwaggerPetstore -e prod --preserve-provider=false --update=true
+        apictl import api -f ./SwaggerPetstore -e prod --preserve-provider=false --update=true
         ```
     !!! note
         -   When the update flag is present, WSO2 API Manager will attempt to seamlessly update if an existing API is found with the same name and version. 
@@ -328,6 +334,8 @@ You can use the following alternative approach to promote a single API via CI/CD
         - The import command prepares an API Project for WSO2 API Manager by processing the parameter file. It determines which configuration should be processed to create an API Project by detecting the environment that has been used to import it.
 
         - For more information on importing an API to an environment, see [Import an API]({{base_path}}/learn/api-controller/migrating-apis-to-different-environments/#import-an-api).
+        
+        - `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
 
     The above command will detect the target environment and provision the API to it.
 
@@ -360,20 +368,21 @@ Run any of the following CTL commands to get keys for the API/API Product.
 - **Command**
 
     ```bash
-    apictl get-keys -n <API or API Product name> -v <API version> -r <API or API Product provider> -e <environment> -k
+    apictl get keys -n <API or API Product name> -v <API version> -r <API or API Product provider> -e <environment> -k
     ```  
 
     ```bash
-    apictl get-keys --name <API or API Product name> --version <API version> --provider <API or API Product provider> --environment <environment> -k
+    apictl get keys --name <API or API Product name> --version <API version> --provider <API or API Product provider> --environment <environment> -k
     ```
 
     !!! example
         ```bash
-        apictl get-keys -n PizzaShackAPI -e dev -k
+        apictl get keys -n PizzaShackAPI -e dev -k
         ```
+
     !!! example
         ```bash
-        apictl get-keys -n PizzaShackAPI -v 1.0.0 -e dev -k -r admin -t https://localhost:8243/token
+        apictl get keys -n PizzaShackAPI -v 1.0.0 -e dev -k -r admin -t https://localhost:8243/token
         ```
     !!! info
         **Flags:**  
@@ -382,13 +391,16 @@ Run any of the following CTL commands to get keys for the API/API Product.
             `--environment` or `-e` : Key generation environment  
             `--name` or `-n` : API or API Product to enerate keys for   
         -   Optional :  
-            `--token` or `-t` : New token endpoint of the environment (This overrides the previously provided token endpoint that was provided using the add-env command)       
+            `--token` or `-t` : New token endpoint of the environment (This overrides the previously provided token endpoint that was provided using the `add env` command)       
             `--provider` or `-r` : Provider of the API or API Product  
             `--version` or `-v` : Version of the API (Currently API Products do not have versions)
 
     !!! note
-        Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
-        You can override the given token endpoint or the default token endpoint using the `--token` (`-t`) optional flag together with the new token endpoint.
+        - Both the flags (`--name` (`-n`) and `--environment` (`-e`)) are mandatory.
+
+        - You can override the given token endpoint or the default token endpoint using the `--token` (`-t`) optional flag together with the new token endpoint.
+
+        - `apictl get-keys` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get keys` as shown above.
 
 !!! info
     - Upon running the above command, the CTL tool will create a default application in the environment, subscribe to the API, and generate keys based on the token type defined in the `<USER_HOME>/.wso2apictl/main-config.yaml`file. 
@@ -482,11 +494,14 @@ Let's assume that the **PetsApp** application is in the development environment 
 1.  Export the Application using the `export app` command from the development environment (dev). Note that `--withKeys` option is used to export the subscriptions and keys (if any) of the application.
 
     ```bash
-    $ apictl export-app --name PetsApp --owner david -e dev --withKeys
+    $ apictl export app --name PetsApp --owner david -e dev --withKeys
 
     Successfully exported Application!
     Find the exported Application at /home/wso2user/.wso2apictl/exported/apps/dev/david_PetsApp.zip
     ```
+
+    !!!note
+        `apictl export-app` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export app` as shown above.
 
 2.  Extract the exported Application Project.
 3.  Commit the project to the same git repository.
@@ -530,7 +545,7 @@ Let's assume that the **PetsApp** application is in the development environment 
         For deploying an application using `vcs deploy` command:
         
         -   It is mandatory to have your Application projects in a Git based version control system.
-        -   It is mandatory to have `application_params.yaml` file inside each application project. This is created by default when you export an Application using `export-app`. The following configuration section in the `application_params.yaml` file is used to deploy the application.
+        -   It is mandatory to have `application_params.yaml` file inside each application project. This is created by default when you export an Application using `export app`. The following configuration section in the `application_params.yaml` file is used to deploy the application.
 
         ```bash
         deploy:

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -260,12 +260,12 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
         ``` bash tab="Response Format"
         Successfully removed environment '<environment-name>'
-        Execute 'apictl add-env --help' to see how to add a new environment
+        Execute 'apictl add env --help' to see how to add a new environment
         ```
 
         ``` bash tab="Example Response"
         Successfully removed environment 'production'
-        Execute 'apictl add-env --help' to see how to add a new environment
+        Execute 'apictl add env --help' to see how to add a new environment
         ```
 
 ## Get environments

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -65,24 +65,29 @@ Run the following CTL command to check the version of the CTL.
     Build Date: 2020-06-12 13:22:12 UTC
     ```
 
-## Set mode of the CTL
+!!!note
+    **Set mode of the CTL**
 
-Run the following CTL command to set the mode of the CTL. The allowed modes are `default` and `kubernetes`.
-    
--   **Command**
+    From the API Controller 4.0.0 onwards the flag (--mode) which was used to set the mode of the CTL has been deprecated. Now, you do not need to set the mode of the CTL, because if you want to execute Kubernetes based commads, you just need to add the `k8s` keyword after `apictl` keyword. (Example: `apictl k8s add api`). By default the API Controller will execute the commands in the `default` mode (which means if you did not use `k8s` keyword).
 
-    ```go
-    apictl set mode <mode>
-    ```
+    You can still use the `mode` flag as explained below if you need, but it will be removed in future.
+        
+    -   **Command**
 
-    !!! example
-
-        ``` go
-        apictl set mode default
+        ```go
+        apictl set --mode <mode>
         ```
-        ``` go
-        apictl set mode kubernetes
-        ```
+
+        !!! example
+
+            ``` go
+            apictl set --mode default
+            ```
+            ``` go
+            apictl set --mode kubernetes
+            ```
+
+         The allowed modes are `default` and `kubernetes`. 
 
 ## Set proxy environment variables for CTL
 
@@ -137,7 +142,7 @@ You can set proxy related `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, and `https_
 You can add environments by either manually editing the `<USER_HOME>/.wso2apictl/main_config.yaml` file or by running the following CTL command.
 
 ``` go
-apictl add-env
+apictl add env <environment-name>
 ```
 
 1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.     
@@ -147,41 +152,37 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
     -   **Command**
 
         ``` bash tab="Linux/Unix"
-        apictl add-env -e <environment-name> \
-                        --registration <client-registration-endpoint> \
-                        --apim <API-Manager-endpoint> \
-                        --token <token-endpoint> \
-                        --admin <admin-REST-API-endpoint> \
-                        --publisher <Publisher-endpoint> \
-                        --devportal <developer-portal-endpoint>
+        apictl add env <environment-name> \
+                       --registration <client-registration-endpoint> \
+                       --apim <API-Manager-endpoint> \
+                       --token <token-endpoint> \
+                       --admin <admin-REST-API-endpoint> \
+                       --publisher <Publisher-endpoint> \
+                       --devportal <developer-portal-endpoint>
         ```
 
         ``` bash tab="Mac/Windows"
-        apictl add-env -e <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <Publisher-endpoint> --devportal <developer-portal-endpoint>
+        apictl add env <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <Publisher-endpoint> --devportal <developer-portal-endpoint>
         ```
 
         !!! info
             **Flags:**  
             
-            -    Required :  
-
-                `--environment` or `-e` : Name of the environment to be added   
-                AND (either)
-                `--apim` : API Manager endpoint for the environments
-                OR (the following 4)
-                `--registration` : Registration endpoint for the environment 
-                `--admin` : Admin endpoint for the environment  
-                `--publisher` : Publisher endpoint for the environment  
+            -    Required :     
+                (either)     
+                `--apim` : API Manager endpoint for the environments     
+                OR (the following 4)     
+                `--registration` : Registration endpoint for the environment     
+                `--admin` : Admin endpoint for the environment     
+                `--publisher` : Publisher endpoint for the environment     
                 `--devportal` : Developer Portal endpoint for the environment 
-            -   Optional :
-
+            -   Optional :     
                 `--token` : Token endpoint for the environment
             
         !!! tip
             When adding an environment, when the optional flags are not given, CTL will automatically derive those from `--apim` flag value.
 
         !!! note
-            The `--environment (-e)` flag is mandatory.
             You can either provide only the flag `--apim` , or all the other 4 flags (`--registration`, `--publisher`, `--devportal`, `--admin`) without providing `--apim` flag.
             If you are omitting any of `--registration`, `--publisher`, `--devportal`, `--admin` flags, you need to specify `--apim` flag with the API Manager endpoint.
             In both of the above cases `--token`  flag is optional and can be used to provide a user preferred token endpoint.
@@ -189,18 +190,18 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
         !!! example
 
             ``` bash tab="Linux/Unix"
-            apictl add-env -e dev \
+            apictl add env dev \
                         --apim https://localhost:9443 
             ``` 
 
             ``` bash tab="Mac/Windows"
-            apictl add-env -e dev --apim https://localhost:9443 
+            apictl add env dev --apim https://localhost:9443 
             ```               
 
         !!! example
 
             ``` bash tab="Linux/Unix"
-            apictl add-env -e production \
+            apictl add env production \
                         --registration https://idp.com:9444 \
                         --admin https://apim.com:9444 \
                         --publisher https://apim.com:9444 \
@@ -209,21 +210,24 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             ```
 
             ``` bash tab="Mac/Windows"
-            apictl add-env -e production --registration https://idp.com:9444  --admin https://apim.com:9444 --publisher https://apim.com:9444 --devportal https://apps.com:9444 --token https://gw.com:8244/token
+            apictl add env production --registration https://idp.com:9444  --admin https://apim.com:9444 --publisher https://apim.com:9444 --devportal https://apps.com:9444 --token https://gw.com:8244/token
             ```  
     
         !!! example
 
             ``` bash tab="Linux/Unix"
-            apictl add-env -e production \
+            apictl add env production \
                         --registration https://idp.com:9444 \
                         --apim https://apim.com:9444 \
                         --token https://gw.com:8244/token
             ```
 
             ``` bash tab="Mac/Windows"
-            apictl add-env -e production --registration https://idp.com:9444 --apim https://apim.com:9444 --token https://gw.com:8244/token
+            apictl add env production --registration https://idp.com:9444 --apim https://apim.com:9444 --token https://gw.com:8244/token
             ```  
+        
+        !!!note
+            `apictl add-env` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl add env` as shown above. 
 
     -   **Response**
     
@@ -264,7 +268,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
         Execute 'apictl add-env --help' to see how to add a new environment
         ```
 
-## List environments
+## Get environments
 
 1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.    
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
@@ -273,7 +277,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
     -   **Command**
 
         ```bash
-        apictl list envs
+        apictl get envs
         ``` 
 
         !!! info
@@ -295,6 +299,9 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
         production   https://localhost:9444   https://localhost:9444   https://localhost:8244/token    https://localhost:9444   https://localhost:9444   https://localhost:9444
 
         ```
+
+        !!!note
+            `apictl list envs` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get envs` as shown above. 
 
 ## Login to an environment
 
@@ -381,7 +388,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 You can add APIs/API Products/Applications via the Publisher Portal and Developer Portal.
 However, **apictl** allows you to create and deploy APIs without using the Publisher Portal. For more information on adding APIs, see [Importing APIs Via Dev First Approach]({{base_path}}/learn/api-controller/importing-apis-via-dev-first-approach).
 
-## List APIs/API Products/Applications in an environment
+## Get APIs/API Products/Applications in an environment
 
 Follow the instructions below to display a list of APIs/API Products/Applications in an environment using CTL:
 
@@ -389,19 +396,19 @@ Follow the instructions below to display a list of APIs/API Products/Application
      For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
-3.  Run the corresponding CTL command below to list APIs/API Products/Applications in an environment.
+3.  Run the corresponding CTL command below to get (list) APIs/API Products/Applications in an environment.
 
-    1. List APIs in an environment.
+    1. Get APIs in an environment.
 
         -   **Command**
             ``` bash
-            apictl list apis -e <environment> -k
+            apictl get apis -e <environment> -k
             ```
             ``` bash
-            apictl list apis --environment <environment> --insecure
+            apictl get apis --environment <environment> --insecure
             ```
             ``` bash
-            apictl list apis --environment <environment> --query <API search query> --insecure
+            apictl get apis --environment <environment> --query <API search query> --insecure
             ```
 
             !!! info
@@ -416,13 +423,13 @@ Follow the instructions below to display a list of APIs/API Products/Application
 
             !!! example
                 ```bash
-                apictl list apis -e dev -k
+                apictl get apis -e dev -k
                 ```
                 ```bash
-                apictl list apis --environment production --limit 15 --insecure
+                apictl get apis --environment production --limit 15 --insecure
                 ```    
                 ```go
-                apictl list apis --environment production --query provider:Alice name:PizzaShackAPI --insecure
+                apictl get apis --environment production --query provider:Alice name:PizzaShackAPI --insecure
                 ```  
 
         -   **Response**
@@ -434,7 +441,7 @@ Follow the instructions below to display a list of APIs/API Products/Application
             ```
             
             !!! tip 
-                When using the `apictl list apis -e dev` command, `-q` or `--query` optional flag can be used to 
+                When using the `apictl get apis -e dev` command, `-q` or `--query` optional flag can be used to 
                 search for APIs.
                 You can search in attributes by using a `:` modifier. Supported attribute modifiers are **name**, 
                 **version**, **provider**, **context**, **status**, **description**, **subcontext**, **doc** and 
@@ -450,17 +457,20 @@ Follow the instructions below to display a list of APIs/API Products/Application
                 If no advanced attribute modifier has been specified, the API names containing the search term will 
                 be returned as a result.
 
-    2. List API Products in an environment.
+            !!!note
+                `apictl list apis` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get apis` as shown above. 
+
+    2. Get API Products in an environment.
     
         -   **Command**
             ``` bash
-            apictl list api-products -e <environment> -k
+            apictl get api-products -e <environment> -k
             ```
             ``` bash
-            apictl list api-products --environment <environment> --insecure
+            apictl get api-products --environment <environment> --insecure
             ```
             ``` bash
-            apictl list api-products --environment <environment> --query <API search query> --insecure
+            apictl get api-products --environment <environment> --query <API search query> --insecure
             ```
 
             !!! info
@@ -474,13 +484,13 @@ Follow the instructions below to display a list of APIs/API Products/Application
 
             !!! example
                 ```bash
-                apictl list api-products -e dev -k
+                apictl get api-products -e dev -k
                 ```
                 ```bash
-                apictl list api-products --environment production --insecure
+                apictl get api-products --environment production --insecure
                 ```    
                 ```go
-                apictl list api-products --environment production --query provider:Alice name:PizzaShackAPI --limit 25 --insecure
+                apictl get api-products --environment production --query provider:Alice name:PizzaShackAPI --limit 25 --insecure
                 ```  
 
         -   **Response**
@@ -490,18 +500,21 @@ Follow the instructions below to display a list of APIs/API Products/Application
             b39e08d7-caa9-40d0-a430-b8e840dd7c31   LeasingAPIProduct   /leasingapiproduct   PUBLISHED           admin
             ab422af2-b19e-4e6a-a34b-8f45c50db0d5   CreditAPIProduct    /creditapiproduct    PUBLISHED           Alice
             ```
-    
-    3. List Applications in an environment.
+
+            !!!note
+                `apictl list api-products` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get api-products` as shown above.
+
+    3. Get Applications in an environment.
 
         -   **Command**
             ``` bash
-            apictl list apps -e <environment> -k
+            apictl get apps -e <environment> -k
             ```
             ``` bash
-            apictl list apps --environment <environment> --insecure
+            apictl get apps --environment <environment> --insecure
             ```
             ``` bash
-            apictl list apps --environment <environment> --owner <application owner> --insecure
+            apictl get apps --environment <environment> --owner <application owner> --insecure
             ```
 
             !!! info
@@ -515,13 +528,13 @@ Follow the instructions below to display a list of APIs/API Products/Application
 
             !!! example
                 ```bash
-                apictl list apps -e dev -k
+                apictl get apps -e dev -k
                 ```
                 ```bash
-                apictl list apps --environment production --insecure
+                apictl get apps --environment production --insecure
                 ```    
                 ```go
-                apictl list apps --environment production --owner sampleUser --limit 15 --insecure
+                apictl get apps --environment production --owner sampleUser --limit 15 --insecure
                 ```  
 
         -   **Response**
@@ -533,10 +546,13 @@ Follow the instructions below to display a list of APIs/API Products/Application
             ```
 
             !!! tip 
-                When using the `apictl list apps -e dev` command, you can either specify `-o` (`--owner`) flag or not.
+                When using the `apictl get apps -e dev` command, you can either specify `-o` (`--owner`) flag or not.
 
                 - When someone has invoked the command **without specifying the owner flag**, it will list all the applications in that environment which belongs to the tenant that the currently logged in user belongs.
                 - When someone has invoked the command **by specifying the owner flag**, it will list all the applications belongs to that particular owner in that environment.
+
+            !!!note
+                `apictl list apps` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl get apps` as shown above. 
         
 ## Delete an API/API Product/Application in an environment
 Follow the instructions below to delete an API/API Product/Application in an environment using CTL:
@@ -715,9 +731,9 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
         Supported action values : Publish, Deploy as a Prototype, Demote to Created, Demote to Prototyped, Block, Deprecate, Re-Publish, Retire.
         Note that the Re-publish action is available only after calling Block action.
         
-## Formatting the outputs of list
+## Formatting the outputs of get
 
-Output of `list envs`, `list apis` and `list apps` can be formatted with Go Templates. 
+Output of `get envs`, `get apis`, `get api-products` and `get apps` can be formatted with Go Templates. 
 
 #### Available formatting options
 

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -481,13 +481,13 @@ After editing the mandatory fields in the API Project, you can import the API to
 
 -   **Command**
     ``` bash
-    apictl import-api -f <path to API Project> -e <environment> -k
+    apictl import api -f <path to API Project> -e <environment> -k
     ```
     ``` bash
-    apictl import-api --file <path to API Project> --environment <environment> -k
+    apictl import api --file <path to API Project> --environment <environment> -k
     ```
     ``` bash
-    apictl import-api --file <path to API Project> --environment <environment> --params=<environment params file> -k
+    apictl import api --file <path to API Project> --environment <environment> --params=<environment params file> -k
     ```
 
     !!! info
@@ -505,18 +505,20 @@ After editing the mandatory fields in the API Project, you can import the API to
 
     !!! example
         ```bash
-        apictl import-api -f ~/myapi -e production -k
+        apictl import api -f ~/myapi -e production -k
         ```
         ```bash
-        apictl import-api --file ~/myapi --environment production -k
+        apictl import api --file ~/myapi --environment production -k
         ```    
         ``` go
-        apictl import-api --file ~/myapi --environment production --params prod/custom_api_params.yaml -k 
+        apictl import api --file ~/myapi --environment production --params prod/custom_api_params.yaml -k 
         ```
         
     !!! tip
-        When using the `--update` flag with the `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
+        When using the `--update` flag with the `import api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
 
+    !!!note
+        `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
        
 -   **Response**
     ``` bash

--- a/en/docs/learn/api-controller/migrating-api-products-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-api-products-to-different-environments.md
@@ -152,16 +152,16 @@ You can use the API Product archive exported from the previous section (or you c
             apictl import api-product -f dev/LeasingAPIProduct_1.0.0.zip -e production -k
             ```
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production -k
             ``` 
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-apis=true -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-apis=true -k
             ``` 
             ```bash
-            apictl import-api --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-api-product=true -k
+            apictl import api-product --file /home/user/api-products/LeasingAPIProduct_1.0.0.zip --environment production --update-api-product=true -k
             ```    
             ``` go
-            apictl import-api -f dev/LeasingAPIProduct_1.0.0.zip -e production --preserve-provider=false --update-apis=true -k 
+            apictl import api-product -f dev/LeasingAPIProduct_1.0.0.zip -e production --preserve-provider=false --update-apis=true -k 
             ```
         !!! tip
             If your file path is `/Users/kim/.wso2apictl/exported/api-products/dev/LeasingAPIProduct_1.0.0.zip.`, then you need to enter `dev/LeasingAPIProduct_1.0.0.zip` as the value for `--file` or `-f` flag.

--- a/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-apis-to-different-environments.md
@@ -28,14 +28,14 @@ WSO2 API Controller, **apictl** allows you to maintain multiple environments run
     -   **Command**
      
         ```go
-        apictl export-api -n <API-name> -v <version> -r <provider> -e <environment> -k 
+        apictl export api -n <API-name> -v <version> -r <provider> -e <environment> -k 
         ``` 
         ```go
-        apictl export-api --name <API-name> --version <version> --provider <provider> --environment <environment> -k 
+        apictl export api --name <API-name> --version <version> --provider <provider> --environment <environment> -k 
         ```
 
         ```go
-        apictl export-api -n <API-name> -v <version> -r <provider> -e <environment> --preserveStatus=<preserve-status> --format <export-format> -k 
+        apictl export api -n <API-name> -v <version> -r <provider> -e <environment> --preserveStatus=<preserve-status> --format <export-format> -k 
         ``` 
 
         !!! info
@@ -52,11 +52,14 @@ WSO2 API Controller, **apictl** allows you to maintain multiple environments run
             
         !!! example
             ```go
-            apictl export-api -n PhoneVerification -v 1.0.0 -e dev -k
+            apictl export api -n PhoneVerification -v 1.0.0 -e dev -k
             ```
             ```go
-            apictl export-api -n PizzaShackAPI -v 1.0.0 -r Alice -e dev --preserveStatus=true --format JSON -k
+            apictl export api -n PizzaShackAPI -v 1.0.0 -r Alice -e dev --preserveStatus=true --format JSON -k
             ```            
+
+        !!!note
+            `apictl export-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export api` as shown above.
 
     -   **Response**
 
@@ -119,13 +122,13 @@ You can use the below command to export all the APIs belong to the currently log
 - **Command**
 
     ``` go
-    apictl export-apis --environment <environment-from-which-artifacts-should-be-exported> -k
+    apictl export apis --environment <environment-from-which-artifacts-should-be-exported> -k
     ```
     ``` go
-    apictl export-apis --environment <environment-from-which-artifacts-should-be-exported> --force -k
+    apictl export apis --environment <environment-from-which-artifacts-should-be-exported> --force -k
     ```
     ``` go
-    apictl export-apis --environment <environment-from-which-artifacts-should-be-exported> --format <export-format> --preserveStatus --force -k
+    apictl export apis --environment <environment-from-which-artifacts-should-be-exported> --format <export-format> --preserveStatus --force -k
     ```
 
     !!! info
@@ -140,11 +143,14 @@ You can use the below command to export all the APIs belong to the currently log
 
     !!! example
         ```go
-        apictl export-apis -e production -k
+        apictl export apis -e production -k
         ```
         ```go
-        apictl export-apis --environment production --format json  --preserveStatus --force -k
+        apictl export apis --environment production --format json  --preserveStatus --force -k
         ```
+
+    !!!note
+        `apictl export-apis` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export apis` as shown above.
 
 - **Response**
 
@@ -156,7 +162,7 @@ You can use the below command to export all the APIs belong to the currently log
     Total number of APIs exported: <number-of-APIs>
     API export path: <USER_HOME>/.wso2apictl/exported/migration/<environment-name>/tenant-default/apis
 
-    Command: export-apis execution completed !
+    Command: export apis execution completed !
     ```
 
     ``` go tab="Example Response"
@@ -167,7 +173,7 @@ You can use the below command to export all the APIs belong to the currently log
     Total number of APIs exported: 5
     API export path: /Users/kim/.wso2apictl/exported/migration/<environment-name>/tenant-default/apis
 
-    Command: export-apis execution completed !
+    Command: export apis execution completed !
     ```
 
 ### Import an API
@@ -198,13 +204,13 @@ You can use the API archive exported from the previous section (or you can extra
 
     -   **Command**
         ``` bash
-        apictl import-api -f <path-to-API-archive> -e <environment> -k
+        apictl import api -f <path-to-API-archive> -e <environment> -k
         ```
         ``` bash
-        apictl import-api --file <path-to-API-archive> --environment <environment> -k
+        apictl import api --file <path-to-API-archive> --environment <environment> -k
         ```
         ``` bash
-        apictl import-api --file <path-to-API-archive> --environment <environment> --preserve-provider=<preserve_provider> --update=<update_api> --skipCleanup=<skip-cleanup> --params <environment-params-file>  -k
+        apictl import api --file <path-to-API-archive> --environment <environment> --preserve-provider=<preserve_provider> --update=<update_api> --skipCleanup=<skip-cleanup> --params <environment-params-file>  -k
         ```
 
         !!! info
@@ -221,20 +227,22 @@ You can use the API archive exported from the previous section (or you can extra
 
         !!! example
             ```bash
-            apictl import-api -f dev/PhoneVerification_1.0.0.zip -e production -k
+            apictl import api -f dev/PhoneVerification_1.0.0.zip -e production -k
             ```
             ```bash
-            apictl import-api --file /home/user/apis/PhoneVerification_1.0.0.zip --environment production -k
+            apictl import api --file /home/user/apis/PhoneVerification_1.0.0.zip --environment production -k
             ```    
             ``` go
-            apictl import-api -f dev/PhoneVerification_1.0.0.zip -e production --preserve-provider=false --update=true --params dev/api_params.yaml -k 
+            apictl import api -f dev/PhoneVerification_1.0.0.zip -e production --preserve-provider=false --update=true --params dev/api_params.yaml -k 
             ```
         !!! tip
             If your file path is `/Users/kim/.wso2apictl/exported/apis/dev/PhoneVerification_1.0.0.zip.`, then you need to enter `dev/PhoneVerification_1.0.0.zip` as the value for `--file` or `-f` flag.
 
         !!! tip
-            When using `--update` flag with `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
+            When using `--update` flag with `import api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment.
 
+        !!!note
+            `apictl import-api` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import api` as shown above.
        
      -   **Response**
         

--- a/en/docs/learn/api-controller/migrating-applications-to-different-environments.md
+++ b/en/docs/learn/api-controller/migrating-applications-to-different-environments.md
@@ -38,15 +38,15 @@ You can export an application in the Developer Portal and download it as a zippe
 
     -   Command 
         ``` java
-        apictl export-app -n <application-name> -o <owner> -e <environment> -k
+        apictl export app -n <application-name> -o <owner> -e <environment> -k
         ```
 
         ``` java
-        apictl export-app --name <application-name> --owner <owner> --environment <environment> --insecure
+        apictl export app --name <application-name> --owner <owner> --environment <environment> --insecure
         ```
 
         ``` java
-        apictl export-app --name <application-name> --owner <owner> --environment <environment> --withKeys=<with-keys> --insecure
+        apictl export app --name <application-name> --owner <owner> --environment <environment> --withKeys=<with-keys> --insecure
         ```
 
         !!! info
@@ -61,14 +61,17 @@ You can export an application in the Developer Portal and download it as a zippe
 
         !!! example
             ```go
-            apictl export-app -n SampleApp -o admin -e dev -k
+            apictl export app -n SampleApp -o admin -e dev -k
             ```
             ```go
-            apictl export-app --name SampleApp --owner SampleUser --environment dev  -k
+            apictl export app --name SampleApp --owner SampleUser --environment dev  -k
             ```       
             ```go
-            apictl export-app --name SampleApp --owner SampleUser --environment dev --withKeys=true  -k
+            apictl export app --name SampleApp --owner SampleUser --environment dev --withKeys=true  -k
             ```     
+
+        !!!note
+            `apictl export-app` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export app` as shown above.
 
     -   Response
         ``` java
@@ -98,18 +101,18 @@ You can import an application to your environment as a zipped application. When 
 
     -   **Command**
         ```go
-        apictl import-app -f <file> -e <environment> -k         
+        apictl import app -f <file> -e <environment> -k         
         ```
         ```go
-        apictl import-app --file <file> --environment <environment> -k         
-        ```
-
-        ```go
-        apictl import-app -f <file> -e <environment> -s=<skip-subscriptions> -o <owner> --skipKeys=<skip-keys> -k      
+        apictl import app --file <file> --environment <environment> -k         
         ```
 
         ```go
-        apictl import-app --file <file> --environment <environment> --skipSubscriptions=<skip-subscriptions> --skipKeys=<skip-keys> --preserveOwner=<preserve-owner> --update=<update> --insecure
+        apictl import app -f <file> -e <environment> -s=<skip-subscriptions> -o <owner> --skipKeys=<skip-keys> -k      
+        ```
+
+        ```go
+        apictl import app --file <file> --environment <environment> --skipSubscriptions=<skip-subscriptions> --skipKeys=<skip-keys> --preserveOwner=<preserve-owner> --update=<update> --insecure
         ```
 
         !!! info
@@ -128,23 +131,26 @@ You can import an application to your environment as a zipped application. When 
 
         !!! example
             ```go
-            apictl import-app -f dev/admin_SampleApp.zip -e production
+            apictl import app -f dev/admin_SampleApp.zip -e production
             ``` 
             ```go
-            apictl import-app --file dev/admin_SampleApp.zip --environment production
+            apictl import app --file dev/admin_SampleApp.zip --environment production
             ```  
             ```go
-            apictl import-app -f dev/admin_SampleApp.zip -e production -o admin --skipSubscriptions=true --skipKeys=true
+            apictl import app -f dev/admin_SampleApp.zip -e production -o admin --skipSubscriptions=true --skipKeys=true
             ```
             ```go
-            apictl import-app -f dev/admin_SampleApp.zip -e production --preserveOwner=true 
+            apictl import app -f dev/admin_SampleApp.zip -e production --preserveOwner=true 
             ```     
             ```go
-            apictl import-app -f dev/admin_SampleApp.zip -e production --update=true
+            apictl import app -f dev/admin_SampleApp.zip -e production --update=true
             ```  
 
         !!! tip
             If your file path is `/Users/kim/.wso2apictl/exported/apps/dev/admin_SampleApp.zip.`, then you need to enter `dev/admin_SampleApp.zip` as the value for `--file` flag.
+
+        !!!note
+            `apictl import-app` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import app` as shown above.
 
     -   Response
         ``` java


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/516
Fixes: https://github.com/wso2/product-apim-tooling/issues/517
Fixes: https://github.com/wso2/product-apim-tooling/issues/519

## Goals
Modifying the docs with the correct revamped API Controller commands and examples.

## Approach
- Changed all the revamped commands in the below pages.
  - Getting Started with WSO2 API Controller
  - Importing APIs Via Dev First Approach
  - Migrating APIs to Different Environments
  - Migrating Apps to Different Environments
  - CI/CD with WSO2 API Manager
  - Building a Jenkins CI/CD Pipeline for Dev First Approach
  - Creating Custom Users to Perform API Controller Operations
  - Configuring Environment Specific Parameters
  - Using Dynamic Data in API Controller Projects
- Added notes like below to all the revamped and deprecated commands.
![image](https://user-images.githubusercontent.com/25246848/97523058-457df100-19c7-11eb-8a1b-86400483e8cc.png)
- The commands that were revamped are as below. (Note that, the below table contains k8s commands as well, but those are not included in the doc space)
<table>
  <tr>
    <th>Old Command</th>
    <th>Revamped Command</th>
  </tr>
  <tr>
    <td>apictl import-api [flags]</td>
    <td>apictl import api [flags]</td>
  </tr>
  <tr>
    <td>apictl import-app [flags]</td>
    <td>apictl import app [flags]</td>
  </tr>
  <tr>
    <td>apictl export-api [flags]</td>
    <td>apictl export api [flags]</td>
  </tr>
  <tr>
    <td>apictl export-apis [flags]</td>
    <td>apictl export apis [flags]</td>
  </tr>
  <tr>
    <td>apictl export-app [flags]</td>
    <td>apictl export app [flags]</td>
  </tr>
  <tr>
    <td>apictl list apis [flags]</td>
    <td>apictl get apis [flags]</td>
  </tr>
  <tr>
    <td>apictl list api-products [flags]</td>
    <td>apictl get api-products [flags]</td>
  </tr>
  <tr>
    <td>apictl list apps [flags]</td>
    <td>apictl get apps [flags]</td>
  </tr>
  <tr>
    <td>apictl list envs [flags]</td>
    <td>apictl get envs [flags]</td>
  </tr>
  <tr>
    <td>apictl get-keys [flags]</td>
    <td>apictl get keys [flags]</td>
  </tr>
<tr>
    <td>apictl delete api [flags]</td>
    <td>apictl delete api [flags] <br>
           apictl k8s delete api [flags]</td>
  </tr>
  <tr>
    <td>apictl install api-operator [flags]</td>
    <td>apictl k8s install api-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl install wso2am-operator [flags]</td>
    <td>apictl k8s install wso2am-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl uninstall api-operator [flags]</td>
    <td>apictl k8s uninstall api-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl uninstall wso2am-operator [flags]</td>
    <td>apictl k8s uninstall wso2am-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl change registry [flags]</td>
    <td>apictl k8s change registry [flags]</td>
  </tr>
  <tr>
    <td>apictl add api [flags]</td>
    <td>apictl k8s add api [flags]</td>
  </tr>
  <tr>
    <td>apictl update api [flags]</td>
    <td>apictl k8s update api [flags]</td>
  </tr>
  <tr>
    <td>apictl add-env [flags]</td>
    <td>apictl add env [flags]</td>
  </tr>
</table>

## User stories
Users can refer the newly revamped commands and the usage when using the APIC Controller 4.0.0.

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/518
- https://github.com/wso2/product-apim-tooling/pull/518