### PR TITLE
[3.2.0] Add docs for masking logs

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/masking-sensitive-information-in-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/masking-sensitive-information-in-logs.md
@@ -1,5 +1,3 @@
-## Rewrite
-
 # Masking Sensitive Information in Logs
 
 There can be business sensitive information that are added to logs in the WSO2 product console and/or WSO2 Carbon log files. When these logs are analyzed, the information is exposed to those who check this.
@@ -10,50 +8,30 @@ To configure this feature, follow the instructions below.
 
 ### Enabling log masking
 
-1.  Open the `<PRODUCT_HOME>/repository/conf/log4j.properties` file in a text editor.
+1. Log masking in not enabled by default in API Manager 3.2.0. Therefore, you need to manaully enable it and configure the required masking patterns.
 
-2.  Uncomment or add the following property under `CarbonConsoleAppender` or `CarbonDailyRollingFileAppender` .
-
-    ``` java
-        log4j.appender.CARBON_CONSOLE.maskingPatternFile=path-to-masking-patterns
+2. To enable log masking, navigate to `<APIM-HOME>/repository/conf/log4j2.properties` and do the necessary changes. The masking feature can be enabled by adding an additional `m` after the `%m` in the `layout.pattern`. Therefore you can add an additional `m` to the log files in which you want the values to be masked as shown below.
     ```
+    appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %mm%n
+    ```
+ 
+3. The masking patterns are configured in `<APIM-HOME>/repository/conf/wso2-log-masking.properties`. You can change its default configurations in `<APIM-HOME>/repository/conf/deployment.toml` 
 
-The `path-to-masking-patterns` value must be a absolute path to the masking patterns file. In this file, each pattern is defined as key, value pairs (patten-name=pattern). Please refer to the next section for information on this file.
-
-The following is a sample configuration for the above property.
-
-``` java
-    log4j.appender.CARBON_CONSOLE.maskingPatternFile=/home/conf/masking-patterns.properties
-```
-
-For the `DailyRollingFileAppender` value, the above property would be similar to the following.
-
-``` java
-    log4j.appender.CARBON_LOGFILE.maskingPatternFile=path-to-masking-patterns
-```
-
-In this case, you can define separate masking pattern files for console appender and file appender. (or configure only one property.)
 
 ### The masking pattern file
 
 The masking pattern file is a property file that can contain one or more masking patterns. The following is a sample configuration that showcases how to mask the credit card numbers from the logs.
 
-``` java
-    masking.pattern.sample.CREDIT_CARD_VISA=4[0-9]{6,}$
-    masking.pattern.sample.CREDIT_CARD_MASTER=(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}
-    masking.pattern.sample.CREDIT_CARD_AMEX=[34|37][0-9]{14}$
+Navigate to `<APIM-HOME>/repository/conf/deployment.toml` and add the following configuration.
+
+``` Properties
+[masking_pattern.properties]
+"CREDIT_CARD_VISA" = "4[0-9]{6,}$"
+"CREDIT_CARD_MASTER" = "(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}"
+"CREDIT_CARD_AMEX" = "[34|37][0-9]{14}$"
 ```
 
 With this configuration, each log line is checked for all the configured patterns. If any match is found, it is masked with ‘\*\*\*\*\*’.
 
-!!! note
-**Note** :
-
--   If the pattern file that is configured in the log4j.properties file is not found, a default property file will be used ( `wso2-log-masking.properties` ).
-
--   If there are no any patterns defined in the file, no masking happens.
-
 !!! warning
-**Important** : There can be a performance impact when using this feature with many masking patterns since each log line is matched with each of the patterns. So it is highly advisable to only use the most necessary patterns.
-
-
+    There can be a performance impact when using this feature with many masking patterns since each log line is matched with each of the patterns. So it is highly advisable to only use the most necessary patterns.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -499,6 +499,7 @@ nav:
                       - Monitoring HTTP access logs: administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
                       - Monitoring audit Logs: administer/logging-and-monitoring/logging/monitoring-audit-logs.md
                       - Managing log growth: administer/logging-and-monitoring/logging/managing-log-growth.md
+                      - Masking sensitive information in logs: administer/logging-and-monitoring/logging/masking-sensitive-information-in-logs.md
                 - Working with Observability: administer/logging-and-monitoring/monitoring/working-with-observability.md
                 - Enabling Tracing with OpenTracing: administer/logging-and-monitoring/monitoring//monitoring-with-opentracing.md
                 - JMX-Based Monitoring: administer/logging-and-monitoring/monitoring//jmx-based-monitoring.md
@@ -657,6 +658,7 @@ plugins:
               'administer/product-administration/monitoring/logging/monitoring-http-access-logs.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/logging/monitoring-http-access-logs/'
               'administer/product-administration/monitoring/logging/monitoring-audit-logs.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/logging/monitoring-audit-logs/'
               'administer/product-administration/monitoring/logging/managing-log-growth.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/logging/managing-log-growth/'
+              'administer/product-administration/monitoring/logging/masking-sensitive-information-in-logs.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/logging//masking-sensitive-information-in-logs.md/'
               'administer/product-administration/monitoring/working-with-observability.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/monitoring/working-with-observability/'
               'administer/product-administration/monitoring/monitoring-with-opentracing.md': 'https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/monitoring/monitoring-with-opentracing/'
               'administer/product-administration/monitoring/capturing-system-data-in-error-situations.md': 'https://apim.docs.wso2.com/en/3.2.0/troubleshooting/capturing-system-data-in-error-situations/'


### PR DESCRIPTION
## Purpose

This PR adds docs for masking logs in APIM 3.2.0.
As mentioned in https://github.com/wso2/product-apim/issues/9377, log masking is not enabled by default in APIM. The docs have been updated on how to manually enable log masking.

Related doc issue: https://github.com/wso2/docs-apim/issues/1606