### PR TITLE
Updated  config for allowed scopes

### DIFF
--- a/en/docs/learn/api-security/oauth2/oauth2-scopes/scope-allowlisting.md
+++ b/en/docs/learn/api-security/oauth2/oauth2-scopes/scope-allowlisting.md
@@ -5,7 +5,7 @@ A scope is not always used for controlling access to a resource. You can also us
 If you do not want a role validation for a scope in an API's request, add the scope as `allowed_scopes` in the `<API-M_HOME>/repository/conf/deployment.toml` file and restart the server. It will be allowlisted. For example,
 
 ```
-[apim.oauth_config]
+[oauth]
 allowed_scopes = ["^device_.*", "openid", "some_random_scope"]
 ```
 


### PR DESCRIPTION
## Purpose
> The configurations for allowed scopes is changed as the above config have been moved to identity.xml from api-mgt.xml. The above change is done to move the implementation of allowlisting the scopes to identity component level. 