### PR TITLE
[3.2.0] Update the tenants windows migration scripts

### DIFF
--- a/en/docs/assets/attachments/install-and-setup/apim210_to_apim320_gateway_artifact_migrator_for_tenants.ps1
+++ b/en/docs/assets/attachments/install-and-setup/apim210_to_apim320_gateway_artifact_migrator_for_tenants.ps1
@@ -15,6 +15,7 @@ foreach ($file in $configFiles)
     Foreach-Object { $_ -replace "org.wso2.carbon.mediator.cache.digest.DOMHASHGenerator", "org.wso2.carbon.mediator.cache.digest.REQUESTHASHGenerator" } |
     Foreach-Object { $_ -replace "org.wso2.caching.digest.REQUESTHASHGenerator", "org.wso2.carbon.mediator.cache.digest.REQUESTHASHGenerator" } |
     Foreach-Object { $_ -replace "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`"/>", "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`">`n`t`t<property name=`"RemoveOAuthHeadersFromOutMessage`" value=`"true`"/>`n`t</handler>" } |
+    Foreach-Object { $_ -replace "org.wso2.carbon.apimgt.usage.publisher.APIMgtResponseHandler", "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtResponseHandler" } |
     Set-Content $file.PSPath
 }
 

--- a/en/docs/assets/attachments/install-and-setup/apim220_to_apim320_gateway_artifact_migrator_for_tenants.ps1
+++ b/en/docs/assets/attachments/install-and-setup/apim220_to_apim320_gateway_artifact_migrator_for_tenants.ps1
@@ -13,6 +13,7 @@ foreach ($file in $configFiles)
 {
     (Get-Content $file.PSPath) |    
     Foreach-Object { $_ -replace "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`"/>", "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`">`n`t`t<property name=`"RemoveOAuthHeadersFromOutMessage`" value=`"true`"/>`n`t</handler>" } |
+    Foreach-Object { $_ -replace "org.wso2.carbon.apimgt.usage.publisher.APIMgtResponseHandler", "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtResponseHandler" } |
     Set-Content $file.PSPath
 }
 


### PR DESCRIPTION
As $subject this pr will update the windows tenants migration scripts to address the following issue

Fixes wso2/product-apim#9391

Related PRs  https://github.com/wso2/docs-apim/pull/2191