### PR TITLE
Add missing initial steps when building customisations

### DIFF
--- a/en/docs/develop/customizations/customizing-the-developer-portal/advanced-customization.md
+++ b/en/docs/develop/customizations/customizing-the-developer-portal/advanced-customization.md
@@ -9,14 +9,21 @@ Follow the instructions below to add advanced UI customizations to the Developer
 !!! note "Prerequisites"
     - **NodeJS** - This is a platform required for ReactJS development.
     - **NPM**
-
 1. Navigate to the `<API-M_HOME>/repository/deployment/server/jaggeryapps` directory in a terminal and run the following command.
 
      ```js
-     lerna bootstrap
+     npm install
      ```
+     This will install the dependencies for `lerna` package manager
+     
+2. Then run the following command from the same directory in a terminal.
 
-2. Run the command given below in the relevant app.
+     ```js
+     npm run bootstrap
+     ```
+     This will install the local package dependencies in `Publisher` and `Devportal` applications
+
+3. Run the command given below in the relevant app.
 
      If it is a Developer Portal, run `npm run build:dev` from the `devportal` folder or else run the command from the `publisher` folder), to start the npm build. Note that it will continuously watch for any changes and rebuild the project.
 

--- a/en/docs/develop/customizations/customizing-the-developer-portal/advanced-customization.md
+++ b/en/docs/develop/customizations/customizing-the-developer-portal/advanced-customization.md
@@ -9,21 +9,24 @@ Follow the instructions below to add advanced UI customizations to the Developer
 !!! note "Prerequisites"
     - **NodeJS** - This is a platform required for ReactJS development.
     - **NPM**
+
 1. Navigate to the `<API-M_HOME>/repository/deployment/server/jaggeryapps` directory in a terminal and run the following command.
 
      ```js
      npm install
      ```
-     This will install the dependencies for `lerna` package manager
+
+     This will install the dependencies for the `lerna` package manager.
      
-2. Then run the following command from the same directory in a terminal.
+2. Run the following command from the same directory in a terminal.
 
      ```js
      npm run bootstrap
      ```
-     This will install the local package dependencies in `Publisher` and `Devportal` applications
 
-3. Run the command given below in the relevant app.
+     This will install the local package dependencies in the Publisher and Developer Portal applications.
+
+3. Run the command given below in the relevant application.
 
      If it is a Developer Portal, run `npm run build:dev` from the `devportal` folder or else run the command from the `publisher` folder), to start the npm build. Note that it will continuously watch for any changes and rebuild the project.
 


### PR DESCRIPTION
## Purpose

Initial two steps for building the customizations were missing in the documentation
Related 3.2.0 PR https://github.com/wso2/docs-apim/pull/2255

## Goals

Update the UI customization steps for portal apps

## Documentation

- Doc [link](https://apim.docs.wso2.com/en/latest/develop/customizations/customizing-the-developer-portal/advanced-customization/#advanced-customization)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/~no~
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/~no~
