### PR TITLE
Updating the file structure and schemas of APIs and API Products in APICTL documentation

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects.md
@@ -11,11 +11,12 @@ Follow the instructions below to initialize an API Project with environment vari
 1.  Create a file `api-env-config.yaml` with the below content.
 
     ```bash
-    id:
-        apiName: $APINAME
+    type: api
+    version: v4
+    data:
+        name: $APINAME
+        context: /petstore/$APIVERSION
         version: $APIVERSION
-    context: /petstore/$APIVERSION
-    contextTemplate: /petstore/{version}
     ```
 
 2.  Export the environment variables with required values.
@@ -38,17 +39,18 @@ Follow the instructions below to initialize an API Project with environment vari
 
     !!! tip
 
-        Upon successful completion of the above command, the CTL will automatically inject the environment variable values to the API artifact in the API project. Open `PetstoreProject/Meta-information/api.yaml` and check the above values are correctly injected.
+        Upon successful completion of the above command, the CTL will automatically inject the environment variable values to the API artifact in the API project. Open `PetstoreProject/api.yaml` and check the above values are correctly injected.
 
         ```
-        id:
-            providerName: admin
-            apiName: Petstore
+        type: api
+        version: v4
+        data:
+            name: Petstore
+            description: 'This is a sample server Petstore server.  You can find out more about
+                Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+                this sample, you can use the api key `special-key` to test the authorization filters.'
+            context: /petstore/1.0.0
             version: 1.0.0
-        description: 'This is a sample server Petstore server.  You can find out more ..'
-        type: HTTP
-        context: /petstore/1.0.0
-        contextTemplate: /petstore/{version}
         ...
         ```
 
@@ -143,24 +145,36 @@ For example, consider we need to send a special header to the backend when calli
     </sequence>
     ```
 
-2. Open `PetstoreProject/Meta-information/api.yaml` and change below settings.
+2. Open `PetstoreProject/api.yaml` and change below settings.
 
-    1. Replace `status` value from `CREATED` to `PUBLISHED`. This is to ensure that the API will be Published once imported.
-    2. Add `inSequence: custom-header-in`
+    1. Replace `lifeCycleStatus` value from `CREATED` to `PUBLISHED`. This is to ensure that the API will be Published once imported.
+    2. Add the mediation policy under the field (list) `mediationPolicies` as shown below. (Since you are adding an `IN` sequence the `type` should be specified as `IN`)
+
+       ```yaml
+       mediationPolicies:
+       -
+            name: custom-header-in
+            type: IN
+            shared: false
+       ```
 
     A sample configuration after applying the above changes is shown below.
 
     ```yaml
-    id:
-        providerName: admin
-        apiName: Petstore
+    type: api
+    version: v4
+    data:
+        name: Petstore
+        description: 'This is a sample server Petstore server.  You can find out more about
+            Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+            this sample, you can use the api key `special-key` to test the authorization filters.'
+        context: /petstore/1.0.0
         version: 1.0.0
-    description: 'This is a sample server Petstore server...'
-    type: HTTP
-    context: /petstore/1.0.0
-    contextTemplate: /petstore/{version}
-    inSequence: custom-header-in
-    status: PUBLISHED
+        mediationPolicies:
+        -
+            name: custom-header-in
+            type: IN
+            shared: false
     ...
     ```
 

--- a/en/docs/install-and-setup/setup/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach.md
@@ -16,11 +16,11 @@ in your Jenkins server.
 
      [![install node-npm-jenkins]({{base_path}}/assets/img/learn/api-controller/install-node-npm-jenkins.png)]({{base_path}}/assets/img/learn/api-controller/install-node-npm-jenkins.png)   
 
-3.  Download and setup [WSO2 API-M 3.2.0](https://wso2.com/api-management/) in Development and Production environment servers. 
+3.  Download and setup [WSO2 API-M 4.0.0](https://wso2.com/api-management/) in Development and Production environment servers. 
      
      For more information, see [installation-prerequisites]({{base_path}}/install-and-setup/installation-guide/installation-prerequisites/).
 
-4. Download and setup [WSO2 API Controller 3.2.0 version](https://wso2.com/api-management/tooling/) to the Jenkins server and the
+4. Download and setup [WSO2 API Controller 4.0.0 version](https://wso2.com/api-management/tooling/) to the Jenkins server and the
 developer machines. 
      
      For more information, see [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).  

--- a/en/docs/install-and-setup/setup/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/install-and-setup/setup/api-controller/ci-cd-with-wso2-api-management.md
@@ -41,11 +41,11 @@ Let us check out the basic building blocks for creating a CI/CD pipeline with WS
 <a name="A"></a>
 ### (A.) - Prepare the environments
 
-1.  Download and install WSO2 API Manager 3.2.0 in your environments.
+1.  Download and install WSO2 API Manager 4.0.0 in your environments.
      
      For more information, see [installation Prerequisites]({{base_path}}/install-and-setup/installation-guide/installation-prerequisites/).
 
-2.  Download and setup WSO2 API Controller 3.2.0 version, `apictl`. 
+2.  Download and setup WSO2 API Controller 4.0.0 version, `apictl`. 
 
      For more information, see [Download and initialize the ctl tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).  
 

--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -65,8 +65,8 @@ Run the following CTL command to check the version of the CTL.
 -   **Response**
 
     ```bash
-    Version: 3.2.0
-    Build Date: 2020-06-12 13:22:12 UTC
+    Version: 4.0.0
+    Build Date: 2020-12-11 13:22:12 UTC
     ```
 
 !!!note
@@ -149,7 +149,7 @@ You can add environments by either manually editing the `<USER_HOME>/.wso2apictl
 apictl add env <environment-name>
 ```
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.     
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.     
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Run the following CTL command to add an environment.
 
@@ -245,7 +245,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
 ## Remove an environment
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.  
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.  
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Run the following CTL command to remove an environment.
 
@@ -274,7 +274,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
 ## Get environments
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.    
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.    
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Run the following CTL command to list the environments.  
 
@@ -311,7 +311,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
 After adding an environment, you can log in to the API Manager instance in that environment using credentials.
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.   
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.   
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Run any of the following CTL commands to log in to the environment.
 
@@ -371,7 +371,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
 ## Logout from an environment
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.   
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.   
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 
 2.  Run the following command to log out from the current session of the API Manager environment.
@@ -396,7 +396,7 @@ However, **apictl** allows you to create and deploy APIs without using the Publi
 
 Follow the instructions below to display a list of APIs/API Products/Applications in an environment using CTL:
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.   
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.   
      For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
@@ -561,7 +561,7 @@ Follow the instructions below to display a list of APIs/API Products/Application
 ## Delete an API/API Product/Application in an environment
 Follow the instructions below to delete an API/API Product/Application in an environment using CTL:
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.   
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.   
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
 3.  Run the corresponding CTL command below to delete an API/API Product/Application in an environment.
@@ -687,7 +687,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 ## Change status of an API in an environment
 Follow the instructions below to change the status of an API in an environment using CTL:
 
-1.  Make sure that the WSO2 API Manager 3.2.0 version is started and that the 3.2.0 version of APTCTL is running.   
+1.  Make sure that the WSO2 API Manager 4.0.0 version is started and that the 4.0.0 version of APTCTL is running.   
 For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
 3.  Run the corresponding CTL command below to change the status of an API in an environment.

--- a/en/docs/install-and-setup/setup/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/importing-apis-via-dev-first-approach.md
@@ -425,12 +425,23 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
         ├── in-sequence
         └── out-sequence</code></pre>
             </td>
-            <td>To add custom sequences, save them in XML format and add them to the corresponding folder. For example, to add a custom in-sequence, save the custom sequence as <code>       SampleSequence.xml</code> and add it to the <code>Sequences/in-sequence/</code>directory.</td>
+            <td>To add custom sequences, save them in XML format and add them to the corresponding folder. For example, to add a custom in-sequence, save the custom sequence as <code>       SampleSequence.xml</code> and add it to the <code>Sequences/in-sequence/Custom</code>directory.</td>
         </tr>
         <tr class="even">
-        <td><pre><code>Docs</code></pre>
-        </td>
+        <td>Client-certificates</td>
+        <td>Contains the client certificates for Mutual SSL enabled APIs.</td>
+        </tr>
+        <tr class="odd">
+        <td>Docs</td>
         <td>Contains the documents.</td>
+        </tr>
+        <tr class="even">
+        <td>Endpoint-certificates</td>
+        <td>Contains the endpoint certificates for endpoint security enabled APIs.</td>
+        </tr>
+        <tr class="odd">
+        <td><Image</td>
+        <td>Contains the thumbnail image of the API.</td>
         </tr>
         </tbody>
     </table>

--- a/en/docs/install-and-setup/setup/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/importing-apis-via-dev-first-approach.md
@@ -34,73 +34,109 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
             !!! note
-                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
+                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition that can be used to generate an API Project.
     
                 !!! example
                        ```yaml
-                       id:
-                         providerName: admin
-                         apiName: PizzaShackAPI
-                         version: 1.0.0
-                       uuid: 8d87e646-f7c5-4dc2-9f45-64903ecccca4
-                       description: This is a simple API for Pizza Shack online pizza delivery store.
-                       type: HTTP
-                       context: /pizzashack/1.0.0
-                       contextTemplate: /pizzashack/{version}
-                       tags:
-                       - pizza
-                       availableTiers:
-                       - name: Unlimited
-                         displayName: Unlimited
-                         description: Allows unlimited requests
-                         requestsPerMin: 2147483647
-                         requestCount: 2147483647
-                         timeUnit: ms
-                         tierPlan: FREE
-                         stopOnQuotaReached: true
-                       status: PUBLISHED
-                       technicalOwner: John Doe
-                       technicalOwnerEmail: architecture@pizzashack.com
-                       businessOwner: Jane Roe
-                       businessOwnerEmail: marketing@pizzashack.com
-                       visibility: public
-                       transports: http,https
-                       corsConfiguration:
-                         accessControlAllowOrigins:
-                         - '*'
-                         accessControlAllowHeaders:
-                         - authorization
-                         - Access-Control-Allow-Origin
-                         - Content-Type
-                         - SOAPAction
-                         - apikey
-                         - testKey
-                         accessControlAllowMethods:
-                         - GET
-                         - PUT
-                         - POST
-                         - DELETE
-                         - PATCH
-                         - OPTIONS
-                       productionUrl: http://localhost:8080
-                       sandboxUrl: http://localhost:8081
-                       endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
-                       responseCache: Disabled
-                       cacheTimeout: 300
-                       implementation: ENDPOINT
-                       authorizationHeader: Authorization
-                       environments:
-                       - Production and Sandbox
-                       createdTime: "1599638524995"
-                       environmentList:
-                       - SANDBOX
-                       - PRODUCTION
-                       apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
-                       accessControl: all
-                       isLatest: true
-                       enableStore: true
-                       keyManagers:
-                       - all
+                        type: api
+                        version: v4
+                        data:
+                            name: PizzaShackAPI
+                            description: This is a simple API for Pizza Shack online pizza delivery store.
+                            context: /pizzashack
+                            version: 1.0.0
+                            provider: admin
+                            lifeCycleStatus: PUBLISHED
+                            cacheTimeout: 300
+                            enableStore: true
+                            type: HTTP
+                            transport:
+                            - http
+                            - https
+                            tags:
+                            - pizza
+                            policies:
+                            - Unlimited
+                            authorizationHeader: Authorization
+                            securityScheme:
+                            - oauth2
+                            - oauth_basic_auth_api_key_mandatory
+                            visibility: PUBLIC
+                            gatewayEnvironments:
+                            - Production and Sandbox
+                            subscriptionAvailability: CURRENT_TENANT
+                            accessControl: NONE
+                            businessInformation:
+                                businessOwner: Jane Roe
+                                businessOwnerEmail: marketing@pizzashack.com
+                                technicalOwner: John Doe
+                                technicalOwnerEmail: architecture@pizzashack.com
+                            corsConfiguration:
+                                accessControlAllowCredentials: false
+                                accessControlAllowHeaders:
+                                - authorization
+                                - Access-Control-Allow-Origin
+                                - Content-Type
+                                - SOAPAction
+                                - apikey
+                                - testKey
+                                accessControlAllowMethods:
+                                - GET
+                                - PUT
+                                - POST
+                                - DELETE
+                                - PATCH
+                                - OPTIONS
+                                accessControlAllowOrigins:
+                                - '*'
+                                corsConfigurationEnabled: false
+                            createdTime: Dec 14, 2020 3:52:06 PM
+                            lastUpdatedTime: Dec 14, 2020 3:52:28 PM
+                            endpointConfig:
+                                endpoint_type: http
+                                production_endpoints:
+                                    url: https://localhost:9443/am/sample/pizzashack/v1/api/
+                                sandbox_endpoints:
+                                    url: https://localhost:9443/am/sample/pizzashack/v1/api/
+                            endpointImplementationType: ENDPOINT
+                            operations:
+                            - authType: Application & Application User
+                                id: ""
+                                scopes: []
+                                target: /order
+                                throttlingPolicy: Unlimited
+                                usedProductIds: []
+                                verb: POST
+                            - authType: Application & Application User
+                                id: ""
+                                scopes: []
+                                target: /menu
+                                throttlingPolicy: Unlimited
+                                usedProductIds: []
+                                verb: GET
+                            - authType: Application & Application User
+                                id: ""
+                                scopes: []
+                                target: /order/{orderId}
+                                throttlingPolicy: Unlimited
+                                usedProductIds: []
+                                verb: GET
+                            - authType: Application & Application User
+                                id: ""
+                                scopes: []
+                                target: /order/{orderId}
+                                throttlingPolicy: Unlimited
+                                usedProductIds: []
+                                verb: PUT
+                            - authType: Application & Application User
+                                id: ""
+                                scopes: []
+                                target: /order/{orderId}
+                                throttlingPolicy: Unlimited
+                                usedProductIds: []
+                                verb: DELETE
+                            keyManagers:
+                            - all
                        ```
 
             
@@ -354,14 +390,13 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
      A project folder with the following default structure will be created in the given directory.
 
     ``` java
-    ├── api_params.yaml
+    ├── api.yaml
+    ├── Client-certificates
+    ├── Definitions
+    │   └── swagger.yaml
     ├── Docs
-    │    └── FileContents
+    ├── Endpoint-certificates
     ├── Image
-    ├── Meta-information
-    │    ├── api.yaml
-    │    └── swagger.yaml
-    ├── README.md
     └── Sequences
         ├── fault-sequence
         ├── in-sequence
@@ -384,11 +419,7 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
                 <td><code>swagger.yaml</code></td>
                 <td>The Swagger file that is generated when the API is created.</td>
             </tr>
-            <tr class="odd">
-                <td><code>api_params.yaml</code></td>
-                <td>Contains environment-specific details.</td>
-            </tr>
-        <tr class="even">
+        <tr class="odd">
             <td><pre><code>Sequences
         ├── fault-sequence
         ├── in-sequence
@@ -397,10 +428,9 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
             <td>To add custom sequences, save them in XML format and add them to the corresponding folder. For example, to add a custom in-sequence, save the custom sequence as <code>       SampleSequence.xml</code> and add it to the <code>Sequences/in-sequence/</code>directory.</td>
         </tr>
         <tr class="even">
-        <td><pre><code>Docs
-      |── FileContents</code></pre>
+        <td><pre><code>Docs</code></pre>
         </td>
-        <td>Contains the documents. To add a new document, add the document in the <code>Docs/FileContents/</code>directory.</td>
+        <td>Contains the documents.</td>
         </tr>
         </tbody>
     </table>
@@ -411,22 +441,32 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
         When you create an API Project, APIs are generated using the default template specified in `<USER_HOME>/.wso2apictl/default_api.yaml` file. Following is the default template used to generate API Projects.  
 
         ```bash
-        id:
-            providerName: admin
+        type: api
+        version: v4
+        data:
+            name : null
             version: 1.0.0
-            apiName:
-        context:
-        type: HTTP
-        availableTiers:
-            - name: Unlimited
-        status: CREATED
-        visibility: public
-        transports: http,https
-        productionUrl: http://localhost:8080
-        sandboxUrl: http://localhost:8081
+            context: null
+            enableStore: true
+            endpointConfig:
+                endpoint_type: http
+                production_endpoints:
+                    url: http://localhost:8080
+                sandbox_endpoints:
+                    url: http://localhost:8081
+            endpointImplementationType: ENDPOINT
+            lifeCycleStatus: CREATED
+            policies:
+            - Unlimited
+            provider: admin
+            transport:
+            - http
+            - https
+            type: HTTP
+            visibility: PUBLIC
         ```
 
-        This file contains the same notation as the `<API-Project>/Meta-information/api.yaml`. Organization-specific common API related details can be put into this template file and shared across developers.
+        This file contains the same notation as the `<API-Project>/api.yaml`. Organization-specific common API related details can be put into this template file and shared across developers.
 
         To further finetune API creation, a custom API Definition file can be used. If you need to use a specific definition file when generating a certain API project, use the `--definition` or `-d` flag along with `apictl init` command. The custom definition file should be in YAML format only.
 
@@ -434,33 +474,43 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
 
         When initializing an API Project, the CTL is capable of detecting environment variables in the default definition file or in the provided custom definition file. For more information on using dynamic data, see [Initialize API Projects with Dynamic Data]({{base_path}}/learn/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects/#initialize-api-projects-with-dynamic-data).
 
-4. Open the `<API Project>/Meta-information/api.yaml` file. You can edit the mandatory configurations listed below.
+4. Open the `<API Project>/api.yaml` file. You can edit the **mandatory configurations** in the field named `data` as listed below.
 
     | Field                                        | Description                                             |
     |----------------------------------------------|---------------------------------------------------------|
-    | `apiName`| The name of API without spaces.                         |
+    | `name`| The name of API without spaces.                         |
     | `context`| Context of the API in API Manager with a leading slash. |
-    | `productionUrl` | Production endpoint for API.                            |
-    | `sandboxUrl`| Sandbox endpoint for API.                               |
+    | `production_endpoints` | Production endpoints for API.                            |
+    | `sandbox_endpoints`| Sandbox endpoint for API.                               |
 
     For more information about the configurations, see the [Sample_Api.yaml](https://github.com/wso2/product-apim-tooling/blob/master/import-export-cli/box/resources/init/sample_api.yaml).
 
     **api.yaml**
 
     ``` bash
-    id:
-        providerName: admin
-        apiName: "SampleAPI"
-        version: 1.0.0
-    type: HTTP
-    context: "/samplecontext"
-    availableTiers:
-        - name: Unlimited
-    status: PUBLISHED
-    visibility: public
-    transports: http,https
-    productionUrl: http://localhost:8080
-    sandboxUrl: http://localhost:8081
+        type: api
+        version: v4
+        data:
+            name : SampleAPI
+            version: 1.0.0
+            context: /sampleapi
+            enableStore: true
+            endpointConfig:
+                endpoint_type: http
+                production_endpoints:
+                    url: http://prod.wso2.com
+                sandbox_endpoints:
+                    url: http://sand.wso2.com
+            endpointImplementationType: ENDPOINT
+            lifeCycleStatus: CREATED
+            policies:
+            - Unlimited
+            provider: admin
+            transport:
+            - http
+            - https
+            type: HTTP
+            visibility: PUBLIC
     ```
 
 

--- a/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
@@ -9,12 +9,6 @@ WSO2 API Controller, **apictl** allows you to maintain multiple environments run
 
     -  Make sure to add an environment before you start working with the following CTL commands, because all API Products need to be imported or exported to/from a specific environment.      
     For more information, visit [Add an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller#add-an-environment).
-    
-!!! tip
-    -  Only the following types of users are allowed to export and import API Products.  
-        -   A user with the `admin` role.
-        -   A user with a role having `apim:api_product_import_export` Admin REST API scope with `API Create` and `API Publish` permissions.
-    - Refer [Creating Custom Users to Perform API Controller Operations]({{base_path}}/learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations) for more information.
 
 ### Export an API Product
 
@@ -75,30 +69,121 @@ The exported ZIP file has the following structure:
 
 ``` java
 <APIProductName>-version
+├── api.yaml
+├── Client-certificates
+│   ├── Alias1.crt
+│   ├── Alias2.crt
+│   └── client_certificates.yaml
 ├── APIs
 │    ├── <1stAPIName>_version
 │    |── <2ndAPIName>_version
 |    |── 
 |    └── <NthAPIName>_version
-├── Meta-information
-│    ├── api.yaml
+├── Definitions
 |    └── swagger.yaml
 ├── Docs
-|    |── FileContents
-│    |── InlineContents
-|    └── docs.yaml
+│   ├── Doc1
+│   │   ├── document-file.pdf
+│   │   └── document.yaml
+│   ├── Doc2
+│   │   ├── Doc2
+│   │   └── document.yaml
+│   ├── Doc3
+│   │   ├── Doc3
+│   │   └── document.yaml
+│   └── Doc4
+│       └── document.yaml
 └── Image
-     └── icon.extension   
+     └── <imageName>.extension 
 ```
 
 The structure of an exported API Product ZIP file is explained below:
-                                                                                                                  
-| Sub Directory/File | Description                                                                                                                                                                                                                                                                                                                                                                       |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| APIs   | Dependent APIs (the APIs which the resources of the API Product belong to) will be exported into subfolders with the name format <APIName\>_version. |
-| Meta-information   | **api.yaml**: It contains all the basic information required for an API Product to be imported to another environment. <br/> **swagger.yaml**: It contains the API Product Swagger definition. |
-| Docs               | **docs.yaml**: It contains the summary of all the documents available for the API Product <br/> **FileContents**: It contains the uploaded file type documents available for the API Product <br/> **InlineContents**: It contains inline and Markdown type documents available for the API Product.                                                                                                                                        |
-| Image              | Thumbnail image of the API Product                                                                                                                                                                                                   |    
+
+<table>
+    <thead>
+        <tr class="header">
+            <th>Sub Directory/File</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="odd">
+            <td><code>api.yaml</code></td>
+            <td>It contains all the basic information required for an API Product to be imported to another environment.</td>
+        </tr>
+        <tr class="even">
+            <td>APIs</td>
+            <td>Dependent APIs (the APIs which the resources of the API Product belong to) will be exported into subfolders with the name format <code>&lt;APIName&gt;_version</code>.</td>
+        </tr>
+        <tr class="odd">
+            <td>Client-certificates</td>
+            <td>If the API Product is secured using MutualSSL, this folder will contain the information related to those.
+                <ul>
+                    <li>
+                        <code>client_certificates.yaml</code>: This will contain the information such as alias, certificate file name, tier name and the API Identifier (with the API Product name, version which is 1.0.0 by default and the provider name). 
+                    </li>
+                </ul>
+            Apart from the above <code>client_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
+            <pre><code>
+type: client_certificates
+version: v4
+data:
+-
+alias: Alias1
+certificate: Alias1.crt
+tierName: Bronze
+apiIdentifier:
+    providerName: admin
+    apiName: LeasingAPIProduct
+    version: 1.0.0
+    id: 0
+-
+alias: Alias2
+certificate: Alias2.crt
+tierName: Gold
+apiIdentifier:
+    providerName: admin
+    apiName: LeasingAPIProduct
+    version: 1.0.0
+    id: 0
+            </code></pre>
+            </td>
+        </tr>
+        <tr class="even">
+            <td>Definitions</td>
+            <td> This folder will contain the definition file associated to a particular API Product.
+                <ul>
+                    <li><code>swagger.yaml</code>: It contains the API Product Swagger definition.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr class="odd">
+            <td>Docs</td>
+            <td> This folder will contain documentation attached to a particular API Product. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <pre><code>
+type: document
+version: v4
+data:
+  documentId: 7be89b14-6b7c-4e1f-8bee-f72295dd65cb
+  name: Doc1
+  type: HOWTO
+  summary: This is the sample summary
+  sourceType: FILE
+  fileName: document-file.pdf
+  visibility: API_LEVEL
+            </pre></code>
+            The above example denotes a document for a <b>FILE</b> named <code>document-file.pdf</code>. The corresponding file will be inside the individual folder of the <b>Docs</b> directory. 
+            <br>If the user have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc2</code>).
+            <br> Similarly if the user have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc3</code>).
+            <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            </td>
+        </tr>
+        <tr class="even">
+            <td>Image</td>
+            <td>Thumbnail image of the API Product.</td>
+        </tr>
+    </tbody>
+</table>
 
 ### Import an API Product
 

--- a/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
@@ -211,11 +211,11 @@ You can use the API Product archive exported from the previous section (or you c
         
     After importing, if the API Products or the dependent APIs are not visible in the API Publisher UI, do the following to re-index the artifacts in the registry.
 
-    1.  Shut down the API Manager 3.2.0, backup and delete the `<API-M_3.2.0_HOME>/solr` directory.
+    1.  Shut down the API Manager 4.0.0, backup and delete the `<API-M_4.0.0_HOME>/solr` directory.
         
-    2.  Rename the `<lastAccessTimeLocation>` element in the `<API-M_3.2.0_HOME>/repository/conf/registry.xml` file. If you use a **distributed API Manager setup**, change the file in the API Publisher node. For example, change the `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime` registry path to `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime_1 `
+    2.  Rename the `<lastAccessTimeLocation>` element in the `<API-M_4.0.0_HOME>/repository/conf/registry.xml` file. If you use a **distributed API Manager setup**, change the file in the API Publisher node. For example, change the `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime` registry path to `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime_1 `
 
-    3.  Restart API Manager 3.2.0 server.
+    3.  Restart API Manager 4.0.0 server.
 
 ### Import/Export API Products in Tenanted Environments 
 The environments that you create will be common to the admin and the tenants. Therefore, you do not need to create environments again when exporting and importing API Products between tenanted environments.

--- a/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-api-products-to-different-environments.md
@@ -109,7 +109,7 @@ The structure of an exported API Product ZIP file is explained below:
     <tbody>
         <tr class="odd">
             <td><code>api.yaml</code></td>
-            <td>It contains all the basic information required for an API Product to be imported to another environment.</td>
+            <td>Contains all the basic information required for an API Product to be imported to another environment.</td>
         </tr>
         <tr class="even">
             <td>APIs</td>
@@ -117,13 +117,13 @@ The structure of an exported API Product ZIP file is explained below:
         </tr>
         <tr class="odd">
             <td>Client-certificates</td>
-            <td>If the API Product is secured using MutualSSL, this folder will contain the information related to those.
+            <td>If the API Product is secured using MutualSSL, this folder will contain the information related to the API Product.
                 <ul>
                     <li>
-                        <code>client_certificates.yaml</code>: This will contain the information such as alias, certificate file name, tier name and the API Identifier (with the API Product name, version which is 1.0.0 by default and the provider name). 
+                        <code>client_certificates.yaml</code>: Contains the information such as alias, certificate file name, tier name and the API Identifier (with the API Product name, version which is 1.0.0 by default and the provider name). 
                     </li>
                 </ul>
-            Apart from the above <code>client_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
+            Apart from the above <code>client_certificates.yaml</code> file, this folder contains the certificate files (.crt). These file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
             <pre><code>
 type: client_certificates
 version: v4
@@ -173,8 +173,8 @@ data:
   visibility: API_LEVEL
             </pre></code>
             The above example denotes a document for a <b>FILE</b> named <code>document-file.pdf</code>. The corresponding file will be inside the individual folder of the <b>Docs</b> directory. 
-            <br>If the user have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc2</code>).
-            <br> Similarly if the user have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc3</code>).
+            <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
+            <br> Similarly if you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
             </td>
         </tr>

--- a/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
@@ -77,23 +77,39 @@ The exported ZIP file has the following structure:
 
 ``` java
 <APIName>-version
-├── Meta-information
-│    ├── api.yaml
+├── api.yaml
+├── Client-certificates
+│   ├── Alias1.crt
+│   ├── Alias2.crt
+│   └── client_certificates.yaml
+├── Definitions
 │    |── swagger.yaml
-|    |── endpoint_certificates.yaml
 |    └── schema.graphql 
 ├── Docs
-|    |── FileContents
-│    |── InlineContents
-|    └── docs.yaml
+│   ├── Doc1
+│   │   ├── document-file.pdf
+│   │   └── document.yaml
+│   ├── Doc2
+│   │   ├── Doc2
+│   │   └── document.yaml
+│   ├── Doc3
+│   │   ├── Doc3
+│   │   └── document.yaml
+│   └── Doc4
+│       └── document.yaml
+├── Endpoint-certificates
+│   ├── Alias3.crt
+│   ├── Alias4.crt
+│   └── endpoint_certificates.yaml
 ├── Image
-|    └── icon.extension
+|    └── <imageName>.extension
 ├── WSDL   
 |    └── <APIName>-<version>.wsdl  
 └── Sequences
     ├── fault-sequence
     |    |── Custom 
-    |    |    └── <custom-sequence-name.xml>      
+    |    |    |── <custom-sequence-1-name.xml>     
+    |    |    └── <custom-sequence-2-name.xml>   
     |    └── <sequence-name.xml> 
     ├── in-sequence
     |    |── Custom
@@ -106,14 +122,127 @@ The exported ZIP file has the following structure:
 ```
 
 The structure of an exported API ZIP file is explained below:
-                                                                                                                  
-| Sub Directory/File | Description                                                                                                                                                                                                                                                                                                                                                                       |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Meta-information   | **api.yaml**: It contains all the basic information required for an API to be imported to another environment. <br/> **swagger.yaml**: It contains the API Swagger definition. <br/> **endpoint_certificates.yaml**: If the API is secured using backend certificates, this file contains all endpoint certificates information. <br> **schema.graphql**: If API is a GraphQL API, this contains the GraphQL schema definition. |
-| Docs               | **docs.yaml**: It contains the summary of all the documents available for the API <br/> **FileContents**: It contains the uploaded file type documents available for the API <br/> **InlineContents**: It contains inline and Markdown type documents available for the API.                                                                                                                                        |
-| Image              | Thumbnail image of the API                                                                                                                                                                                                                                                                                                                                                        |
-| WSDL               | WSDL file of the API                                                                                                                                                                                                                                                                                                                                                              |
-| Sequences          | **fault-sequence**: It contains the specific API fault sequence. <br/> **in-sequence**: It contains the specific API in sequence. <br/> **out-sequence**: It contains the specific API out sequence.                                                                                                                                                                                                                  |    
+
+<table>
+    <thead>
+        <tr class="header">
+            <th>Sub Directory/File</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="odd">
+            <td><code>api.yaml</code></td>
+            <td>It contains all the basic information required for an API to be imported to another environment.</td>
+        </tr>
+        <tr class="even">
+            <td>Client-certificates</td>
+            <td>If the API is secured using MutualSSL, this folder will contain the information related to those.
+                <ul>
+                    <li>
+                        <code>client_certificates.yaml</code>: This will contain the information such as alias, certificate file name, tier name and the API Identifier (with the API name, version and the provider name). 
+                    </li>
+                </ul>
+            Apart from the above <code>client_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
+            <pre><code>
+type: client_certificates
+version: v4
+data:
+-
+alias: Alias1
+certificate: Alias1.crt
+tierName: Bronze
+apiIdentifier:
+    providerName: admin
+    apiName: PizzaShackAPI
+    version: 1.0.0
+    id: 0
+-
+alias: Alias2
+certificate: Alias2.crt
+tierName: Gold
+apiIdentifier:
+    providerName: admin
+    apiName: PizzaShackAPI
+    version: 1.0.0
+    id: 0
+            </code></pre>
+            </td>
+        </tr>
+        <tr class="odd">
+            <td>Definitions</td>
+            <td> This folder will contain the definition file associated to a particular API.
+                <ul>
+                    <li><code>swagger.yaml</code>: It contains the API Swagger definition.</li>
+                    <li><code>schema.graphql</code>: If API is a GraphQL API, this contains the GraphQL schema definition.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr class="even">
+            <td>Docs</td>
+            <td> This folder will contain documentation attached to a particular API. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <pre><code>
+type: document
+version: v4
+data:
+  documentId: 7be89b14-6b7c-4e1f-8bee-f72295dd65cb
+  name: Doc1
+  type: HOWTO
+  summary: This is the sample summary
+  sourceType: FILE
+  fileName: document-file.pdf
+  visibility: API_LEVEL
+            </pre></code>
+            The above example denotes a document for a <b>FILE</b> named <code>document-file.pdf</code>. The corresponding file will be inside the individual folder of the <b>Docs</b> directory. 
+            <br>If the user have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc2</code>).
+            <br> Similarly if the user have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc3</code>).
+            <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            </td>
+        </tr>
+        <tr class="odd">
+            <td>Endpoint-certificates</td>
+            <td>If the API is secured using endpoint certificates, this folder will contain the information related to those.
+                <ul>
+                    <li>
+                        <code>endpoint_certificates.yaml</code>: This will contain the information such as alias, certificate file name and the endpoint to which the certificate is attached to. 
+                    </li>
+                </ul>
+            Apart from the above <code>endpoint_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>endpoint_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>endpoint_certificates.yaml</code> file which has mapped the certificates Alias3.crt and Alias4.crt to the corresponding aliases Alias3 and Alias4 accordingly. 
+            <pre><code>
+type: endpoint_certificates
+version: v4
+data:
+ -
+  alias: Alias4
+  endpoint: https://prod.wso2.com
+  certificate: Alias4.crt
+ -
+  alias: Alias3
+  endpoint: https://sand.wso2.com
+  certificate: Alias3.crt
+            </code></pre>
+            </td>
+        </tr>
+        <tr class="odd">
+            <td>Image</td>
+            <td>Thumbnail image of the API.</td>
+        </tr>
+        <tr class="even">
+            <td>WSDL</td>
+            <td>WSDL file of the API.</td>
+        </tr>
+        <tr class="odd">
+            <td>Sequences</td>
+            <td>
+                <ul>
+                    <li><b>fault-sequence</b>: It contains the specific API fault sequence.</li>
+                    <li><b>in-sequence</b>: It contains the specific API in sequence.</li>
+                    <li><b>out-sequence</b>: It contains the specific API out sequence.</li>
+                </ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
 
 ### Export all the APIs of a tenant at once
 

--- a/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
@@ -277,11 +277,11 @@ You can use the API archive exported from the previous section (or you can extra
         
     After importing, if the APIs are not visible in the API Publisher UI, do the following to re-index the artifacts in the registry.
 
-    1.  Shut down the API Manager 3.2.0, backup and delete the `<API-M_3.2.0_HOME>/solr` directory.
+    1.  Shut down the API Manager 4.0.0, backup and delete the `<API-M_4.0.0_HOME>/solr` directory.
         
-    2.  Rename the `<lastAccessTimeLocation>` element in the `<API-M_3.2.0_HOME>/repository/conf/registry.xml` file. If you use a **distributed API Manager setup**, change the file in the API Publisher node. For example, change the `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime` registry path to `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime_1 `
+    2.  Rename the `<lastAccessTimeLocation>` element in the `<API-M_4.0.0_HOME>/repository/conf/registry.xml` file. If you use a **distributed API Manager setup**, change the file in the API Publisher node. For example, change the `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime` registry path to `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime_1 `
 
-    3.  Restart API Manager 3.2.0 server.
+    3.  Restart API Manager 4.0.0 server.
 
 !!! warning
     If you have enabled Secure Endpoint (Refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information), the endpoint password will be removed when exporting an API causing an error when you try to import the same API to an environment. There are 2 solutions for this.

--- a/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
@@ -3,11 +3,11 @@
 WSO2 API Controller, **apictl** allows you to maintain multiple environments running on the same WSO2 API-M version. This allows you to import and export APIs between your environments. For example, if you have an API running in the development environment, you can export it and import it to the production environment. Thereby, APIs do not have to be created from scratch in different environments.
 
 !!! info
-    **Before you begin** 
+    **Before you begin**
 
-    -   Make sure WSO2 API CTL Tool is initialized and running, if not follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure the WSO2 API CTL Tool is initialized and running, if not follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
-    -  Make sure to add an environment before you start working with the following CTL commands, because all APIs need to be imported or exported to/from a specific environment.      
+    -  Add an environment before you start working with the following CTL commands, because all APIs need to be imported or exported to/from a specific environment.      
     For more information, visit [Add an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller#add-an-environment).
     
 !!! tip
@@ -137,13 +137,13 @@ The structure of an exported API ZIP file is explained below:
         </tr>
         <tr class="even">
             <td>Client-certificates</td>
-            <td>If the API is secured using MutualSSL, this folder will contain the information related to those.
+            <td>If the API is secured using MutualSSL, this folder contains the information related to those.
                 <ul>
                     <li>
-                        <code>client_certificates.yaml</code>: This will contain the information such as alias, certificate file name, tier name and the API Identifier (with the API name, version and the provider name). 
+                        <code>client_certificates.yaml</code>: This contains the information such as alias, certificate file name, tier name and the API Identifier (with the API name, version and the provider name). 
                     </li>
                 </ul>
-            Apart from the above <code>client_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
+            Apart from the above <code>client_certificates.yaml</code> file, this folder contains the certificate files (.crt). Those file names should be included in the  <code>client_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>client_certificates.yaml</code> file which has mapped the certificates Alias1.crt and Alias2.crt to the corresponding aliases Alias1 and Alias2 accordingly. 
             <pre><code>
 type: client_certificates
 version: v4
@@ -171,7 +171,7 @@ apiIdentifier:
         </tr>
         <tr class="odd">
             <td>Definitions</td>
-            <td> This folder will contain the definition file associated to a particular API.
+            <td> This folder contains the definition file associated to a particular API.
                 <ul>
                     <li><code>swagger.yaml</code>: It contains the API Swagger definition.</li>
                     <li><code>schema.graphql</code>: If API is a GraphQL API, this contains the GraphQL schema definition.</li>
@@ -180,7 +180,7 @@ apiIdentifier:
         </tr>
         <tr class="even">
             <td>Docs</td>
-            <td> This folder will contain documentation attached to a particular API. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <td> This folder contains documentation attached to a particular API. Each document will have a seperate folder by its name. Each folder contains a file named <code>document.yaml</code> which contains the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
             <pre><code>
 type: document
 version: v4
@@ -194,20 +194,20 @@ data:
   visibility: API_LEVEL
             </pre></code>
             The above example denotes a document for a <b>FILE</b> named <code>document-file.pdf</code>. The corresponding file will be inside the individual folder of the <b>Docs</b> directory. 
-            <br>If the user have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc2</code>).
-            <br> Similarly if the user have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (Example:- <code>Doc3</code>).
+            <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
+            <br> Similarly if the you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
             </td>
         </tr>
         <tr class="odd">
             <td>Endpoint-certificates</td>
-            <td>If the API is secured using endpoint certificates, this folder will contain the information related to those.
+            <td>If the API is secured using endpoint certificates, this folder contains the information related to those.
                 <ul>
                     <li>
-                        <code>endpoint_certificates.yaml</code>: This will contain the information such as alias, certificate file name and the endpoint to which the certificate is attached to. 
+                        <code>endpoint_certificates.yaml</code>: This contains the information such as alias, certificate file name and the endpoint to which the certificate is attached to. 
                     </li>
                 </ul>
-            Apart from the above <code>endpoint_certificates.yaml</code> file, this folder will contain the certificate files (.crt). Those file names should be included in the  <code>endpoint_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>endpoint_certificates.yaml</code> file which has mapped the certificates Alias3.crt and Alias4.crt to the corresponding aliases Alias3 and Alias4 accordingly. 
+            Apart from the above <code>endpoint_certificates.yaml</code> file, this folder contains the certificate files (.crt). Those file names should be included in the  <code>endpoint_certificates.yaml</code> by mapping to the corresponding alias name. Below is an example file for a  <code>endpoint_certificates.yaml</code> file which has mapped the certificates Alias3.crt and Alias4.crt to the corresponding aliases Alias3 and Alias4 accordingly. 
             <pre><code>
 type: endpoint_certificates
 version: v4

--- a/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-apis-to-different-environments.md
@@ -309,18 +309,6 @@ You can use the below command to export all the APIs belong to the currently log
 
 You can use the API archive exported from the previous section (or you can extract it and use the extracted folder) and import it to the API Manager instance in the target environment. When importing the API, you can either **deploy the API as a new API** or **seamlessly update an existing API** in the environment with it.   
 
-!!! warning
-    **For Secure Endpoint Enabled APIs:**
-
-    If you have enabled secure endpoints when creating the API and your username or/and password differs in the two environments, please follow the steps below before importing the API.    
-
-    1. Unzip the .zip archive created in the previous section.
-    2. Go to the `<API-name-version>/Meta-information` directory and open the `api.<json/yaml>` file.  
-    For example, go to `PhoneVerification_1.0.0/Meta-information` directory and open the `api.yaml` file.  
-    3. Modify the `endpointUTPassword` with your endpoint password and save the `api.yaml` file.
-    4. Compress the `<API-name-version>` directory. (or you can import the extracted folder)
-    For example, compress the `PhoneVerification_1.0.0` directory.
-
 1.  Log in to the API Manager in the importing environment by following steps in [Login to an Environment]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller#login-to-an-environment).
     
     !!! tip
@@ -411,15 +399,6 @@ You can use the API archive exported from the previous section (or you can extra
     2.  Rename the `<lastAccessTimeLocation>` element in the `<API-M_4.0.0_HOME>/repository/conf/registry.xml` file. If you use a **distributed API Manager setup**, change the file in the API Publisher node. For example, change the `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime` registry path to `/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime_1 `
 
     3.  Restart API Manager 4.0.0 server.
-
-!!! warning
-    If you have enabled Secure Endpoint (Refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information), the endpoint password will be removed when exporting an API causing an error when you try to import the same API to an environment. There are 2 solutions for this.
-
-    1.  If Secure Endpoint is enabled and if the endpoint password should be exposed;
-    `ExposeEndpointPassword` should be set to `true` in the `/_system/config/apimgt/applicationdata/tenant-conf.json` in the registry so that the exported API will contain the endpoint password.
-
-    2.  Or else, if Secure Endpoint is enabled and if the endpoint password should not be exposed;
-    `ExposeEndpointPassword` should be set to `false` in the `/_system/config/apimgt/applicationdata/tenant-conf.json` in the registry (by default this is set to `false`). Here, the secure endpoint password is removed while exporting the API, since it may cause security issues. Hence, the password needs to be added manually when importing the API.
 
 ### Import/Export APIs in Tenanted Environments 
 The environments that you create will be common to the admin and the tenants. Therefore, you do not need to create environments again when exporting and importing APIs between tenanted environments.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/544

## Goals
Update the new file structure and the schema structures of APIs and API Products in the documentation.

## Approach
- Updated the page **Importing APIs Via Dev First Approach**.
  ![image](https://user-images.githubusercontent.com/25246848/102320550-754a7d80-3fa2-11eb-945e-422f6c042de5.png)
- Updated the page **Migrating APIs to Different Environments**.
  ![image](https://user-images.githubusercontent.com/25246848/102313949-922d8380-3f97-11eb-8712-29a4be87c6de.png)
- Updated the page **Migrating API Products (with or without dependent APIs) to Different Environments**.
  ![image](https://user-images.githubusercontent.com/25246848/102314005-a96c7100-3f97-11eb-9427-93cf61e9301b.png)
- Updated the page **Using Dynamic Data in API Controller Projects**.
  ![image](https://user-images.githubusercontent.com/25246848/102319080-5ea32700-3fa0-11eb-9d88-92bd80956ad4.png)

- Updated the APICTL and APIM version to 4.0.0 in the APICTL documentation
- Removed warnings about preserving security credentials when exporting an API, since there are no restrictions from 4.0.0 onwards.

## User stories
Users can refer to the documentation to have an understanding of the new folder structure and the schema definitions related to APIs and API Products.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/9406
- https://github.com/wso2/carbon-apimgt/pull/9464