### PR TITLE
[3.0.0] Add sample api.yaml to use as the definition for apictl init and fix minor issues

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -309,11 +309,16 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             apictl logout dev
             ```
 
+## Add APIs/Applications in an environment
+
+You can add APIs and Applications via the Publisher Portal and Developer Portal accordingly.
+However, **apictl** allows you to create and deploy APIs without using the Publisher Portal. For more information on adding APIs, see [Importing APIs Via Dev First Approach]({{base_path}}/learn/api-controller/importing-apis-via-dev-first-approach).
+
 ## List APIs of an environment
 Follow the instructions below to display a list of APIs in an environment using CTL:
 
 1.  Make sure that WSO2 API Manager is started and the CTL tool is running.   
-For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
+    For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
 3.  Run any of the following CTL commands to list the APIs.
 

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -1,11 +1,11 @@
 # Importing APIs Via Dev First Approach
 
-WSO2 API Controller, **apictl** allows to create and deploy APIs without using WSO2 API Publisher Portal. You can use this feature to create an API **from scratch** or **using an existing Swagger or Open API specification** and then deploy it to the desired API Manager environment.
+WSO2 API Controller (**apictl**) allows you to create and deploy APIs without using WSO2 API Publisher Portal. You can use this feature to create an API **from scratch** or **using an existing Swagger or Open API specification** and then deploy it to the desired API Manager environment.
 
 !!! info
     **Before you begin...** 
 
-    -   Make sure WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure that the WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
     -   Make sure you already have added an environment using the CTL tool for the API Manager environment you plan to import the API to. 
 
@@ -33,6 +33,95 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                 ```bash 
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
+
+            !!! note
+                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
+
+                !!! example
+                       ```yaml
+                        id:
+                          providerName: admin
+                          apiName: PizzaShackAPI
+                          version: 1.0.0
+                        uuid: febac429-0387-42d3-aec0-fb4ba9511260
+                        description: This is a simple API for Pizza Shack online pizza delivery store.
+                        type: HTTP
+                        context: /pizzashack/1.0.0
+                        contextTemplate: /pizzashack/{version}
+                        tags:
+                         - pizza
+                        documents: []
+                        lastUpdated: Dec 21, 2020 11:44:29 AM
+                        availableTiers:
+                         -
+                          name: Unlimited
+                          displayName: Unlimited
+                          description: Allows unlimited requests
+                          requestsPerMin: 2147483647
+                          requestCount: 2147483647
+                          unitTime: 0
+                          timeUnit: ms
+                          tierPlan: FREE
+                          stopOnQuotaReached: true
+                        availableSubscriptionLevelPolicies: []
+                        apiLevelPolicy: Unlimited
+                        uriTemplates: []
+                        apiHeaderChanged: false
+                        apiResourcePatternsChanged: false
+                        status: PUBLISHED
+                        technicalOwner: John Doe
+                        technicalOwnerEmail: architecture@pizzashack.com
+                        businessOwner: Jane Roe
+                        businessOwnerEmail: marketing@pizzashack.com
+                        visibility: public
+                        gatewayLabels: []
+                        endpointSecured: false
+                        endpointAuthDigest: false
+                        transports: http,https
+                        advertiseOnly: false
+                        apiOwner: admin
+                        subscriptionAvailability: all_tenants
+                        corsConfiguration:
+                          corsConfigurationEnabled: false
+                          accessControlAllowOrigins:
+                           - '*'
+                          accessControlAllowCredentials: false
+                          accessControlAllowHeaders:
+                           - authorization
+                           - Access-Control-Allow-Origin
+                           - Content-Type
+                           - SOAPAction
+                          accessControlAllowMethods:
+                           - GET
+                           - PUT
+                           - POST
+                           - DELETE
+                           - PATCH
+                           - OPTIONS
+                        endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"},"production_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"}}'
+                        responseCache: Disabled
+                        cacheTimeout: 300
+                        implementation: ENDPOINT
+                        authorizationHeader: Authorization
+                        scopes: []
+                        isDefaultVersion: false
+                        isPublishedDefaultVersion: false
+                        environments:
+                         - Production and Sandbox
+                        createdTime: "1608531265115"
+                        additionalProperties: {}
+                        monetizationProperties: {}
+                        isMonetizationEnabled: false
+                        environmentList:
+                         - SANDBOX
+                         - PRODUCTION
+                        apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
+                        endpoints: []
+                        enableSchemaValidation: false
+                        accessControl: all
+                        rating: 0.0
+                        isLatest: true
+                       ```
 
         -   Response    
             ```go
@@ -84,7 +173,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                 -   Optional :  
                         `--definition` or `-d` : Provide a YAML definition of API  
                         `--oas` : Provide an OpenAPI specification file/URL for the API   
-                        `--force` or `-f` : To overwrite directory and create project 
+                        `--force` or `-f` : To overwrite the directory and create project 
 
 
      A project folder with the following default structure will be created in the given directory.
@@ -118,7 +207,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
             </tr>
             <tr class="even">
                 <td><code>swagger.yaml</code></td>
-                <td>The Swagger file generated when the API is created.</td>
+                <td>The Swagger file that is generated when the API is created.</td>
             </tr>
             <tr class="odd">
                 <td><code>api_params.yaml</code></td>
@@ -130,8 +219,8 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
         ├── in-sequence
         └── out-sequence</code></pre>
             </td>
-            <td>To add custom sequences, save them in XML format and add them to the corresponding folder. For example, to add a custom in-sequence, save the custom sequence as <code>       SampleSequence.xml</code> and add it to the <code>Sequences/in-sequence/</code>directory.</td>
-        </tr>
+            <td>Contains the documents. To add a new document, add the document in the <code>Docs/FileContents/</code>directory.</td>
+            </tr>
         <tr class="even">
         <td><pre><code>Docs
       |── FileContents</code></pre>
@@ -251,12 +340,12 @@ After editing the mandatory fields in the API Project, you can import the API to
             `--file` or `-f` : The file path of the API project to import.  
             `--environment` or `-e` : Environment to which the API should be imported.   
         -   Optional :  
-            `--preserve-provider` : Preserve the existing provider of API after importing. Default value is `true`. 
+            `--preserve-provider` : Preserve the existing provider of API after importing. The default value is `true`. 
             `--update` : Update an existing API or create a new API in the importing environment.  
-            `--params` : Provide a API Manager environment params file (default "api_params.yaml").   
-            For more information, see [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters).  
-            `--skipCleanup` : Leave all temporary files created in the CTL during import process. Default value is `false`.  
-
+            `--params` : Provide a API Manager environment params file (The default file is `api_params.yaml`.).   
+                        For more information, see [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters). 
+            `--skipCleanup` : Leave all temporary files created in the CTL during import process. The default value is `false`.  
+            
     !!! example
         ```bash
         apictl import-api -f ~/myapi -e production -k
@@ -269,10 +358,11 @@ After editing the mandatory fields in the API Project, you can import the API to
         ```
         
     !!! tip
-        When using `--update` flag with `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
+        When using the `--update` flag with the `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
 
        
 -   **Response**
     ``` bash
     Successfully imported API!
     ```  
+

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -5,7 +5,7 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
 !!! info
     **Before you begin...** 
 
-    -   Make sure that the WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure that the WSO2 API Manager CTL Tool is downloaded and initialized, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
     -   Make sure you already have added an environment using the CTL tool for the API Manager environment you plan to import the API to. 
 
@@ -33,95 +33,94 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
                 ```bash 
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
-
-            !!! note
-                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
-
-                !!! example
-                       ```yaml
-                        id:
-                          providerName: admin
-                          apiName: PizzaShackAPI
-                          version: 1.0.0
-                        uuid: febac429-0387-42d3-aec0-fb4ba9511260
-                        description: This is a simple API for Pizza Shack online pizza delivery store.
-                        type: HTTP
-                        context: /pizzashack/1.0.0
-                        contextTemplate: /pizzashack/{version}
-                        tags:
-                         - pizza
-                        documents: []
-                        lastUpdated: Dec 21, 2020 11:44:29 AM
-                        availableTiers:
-                         -
-                          name: Unlimited
-                          displayName: Unlimited
-                          description: Allows unlimited requests
-                          requestsPerMin: 2147483647
-                          requestCount: 2147483647
-                          unitTime: 0
-                          timeUnit: ms
-                          tierPlan: FREE
-                          stopOnQuotaReached: true
-                        availableSubscriptionLevelPolicies: []
-                        apiLevelPolicy: Unlimited
-                        uriTemplates: []
-                        apiHeaderChanged: false
-                        apiResourcePatternsChanged: false
-                        status: PUBLISHED
-                        technicalOwner: John Doe
-                        technicalOwnerEmail: architecture@pizzashack.com
-                        businessOwner: Jane Roe
-                        businessOwnerEmail: marketing@pizzashack.com
-                        visibility: public
-                        gatewayLabels: []
-                        endpointSecured: false
-                        endpointAuthDigest: false
-                        transports: http,https
-                        advertiseOnly: false
-                        apiOwner: admin
-                        subscriptionAvailability: all_tenants
-                        corsConfiguration:
-                          corsConfigurationEnabled: false
-                          accessControlAllowOrigins:
-                           - '*'
-                          accessControlAllowCredentials: false
-                          accessControlAllowHeaders:
-                           - authorization
-                           - Access-Control-Allow-Origin
-                           - Content-Type
-                           - SOAPAction
-                          accessControlAllowMethods:
-                           - GET
-                           - PUT
-                           - POST
-                           - DELETE
-                           - PATCH
-                           - OPTIONS
-                        endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"},"production_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"}}'
-                        responseCache: Disabled
-                        cacheTimeout: 300
-                        implementation: ENDPOINT
-                        authorizationHeader: Authorization
-                        scopes: []
-                        isDefaultVersion: false
-                        isPublishedDefaultVersion: false
-                        environments:
-                         - Production and Sandbox
-                        createdTime: "1608531265115"
-                        additionalProperties: {}
-                        monetizationProperties: {}
-                        isMonetizationEnabled: false
-                        environmentList:
-                         - SANDBOX
-                         - PRODUCTION
-                        apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
-                        endpoints: []
-                        enableSchemaValidation: false
-                        accessControl: all
-                        rating: 0.0
-                        isLatest: true
-                       ```
+             
+            The following is a sample API definition that can be used to generate an API Project.
+             
+            !!! example
+                ```yaml
+                id:
+                  providerName: admin
+                  apiName: PizzaShackAPI
+                  version: 1.0.0
+                uuid: febac429-0387-42d3-aec0-fb4ba9511260
+                description: This is a simple API for Pizza Shack online pizza delivery store.
+                type: HTTP
+                context: /pizzashack/1.0.0
+                contextTemplate: /pizzashack/{version}
+                tags:
+                 - pizza
+                documents: []
+                lastUpdated: Dec 21, 2020 11:44:29 AM
+                availableTiers:
+                 -
+                  name: Unlimited
+                  displayName: Unlimited
+                  description: Allows unlimited requests
+                  requestsPerMin: 2147483647
+                  requestCount: 2147483647
+                  unitTime: 0
+                  timeUnit: ms
+                  tierPlan: FREE
+                  stopOnQuotaReached: true
+                availableSubscriptionLevelPolicies: []
+                apiLevelPolicy: Unlimited
+                uriTemplates: []
+                apiHeaderChanged: false
+                apiResourcePatternsChanged: false
+                status: PUBLISHED
+                technicalOwner: John Doe
+                technicalOwnerEmail: architecture@pizzashack.com
+                businessOwner: Jane Roe
+                businessOwnerEmail: marketing@pizzashack.com
+                visibility: public
+                gatewayLabels: []
+                endpointSecured: false
+                endpointAuthDigest: false
+                transports: http,https
+                advertiseOnly: false
+                apiOwner: admin
+                subscriptionAvailability: all_tenants
+                corsConfiguration:
+                  corsConfigurationEnabled: false
+                  accessControlAllowOrigins:
+                   - '*'
+                  accessControlAllowCredentials: false
+                  accessControlAllowHeaders:
+                   - authorization
+                   - Access-Control-Allow-Origin
+                   - Content-Type
+                   - SOAPAction
+                  accessControlAllowMethods:
+                   - GET
+                   - PUT
+                   - POST
+                   - DELETE
+                   - PATCH
+                   - OPTIONS
+                endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"},"production_endpoints":{"url":"https://localhost:9443/am/sample/pizzashack/v1/api/"}}'
+                responseCache: Disabled
+                cacheTimeout: 300
+                implementation: ENDPOINT
+                authorizationHeader: Authorization
+                scopes: []
+                isDefaultVersion: false
+                isPublishedDefaultVersion: false
+                environments:
+                 - Production and Sandbox
+                createdTime: "1608531265115"
+                additionalProperties: {}
+                monetizationProperties: {}
+                isMonetizationEnabled: false
+                environmentList:
+                 - SANDBOX
+                 - PRODUCTION
+                apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
+                endpoints: []
+                enableSchemaValidation: false
+                accessControl: all
+                rating: 0.0
+                isLatest: true
+                ```
 
         -   Response    
             ```go


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/1886

## Goals
Backporting https://github.com/wso2/docs-apim/pull/1891

## Approach
- Fixed minor issues in the pages **Getting Started with WSO2 API Controller** and **Importing APIs Via Dev First Approach**.
- Added a sample api.yaml to be used as the definition for **apictl init** command.

## Related PRs
https://github.com/wso2/docs-apim/pull/1891