### PR TITLE
[3.1.0] Add sample api.yaml to use as the definition for apictl init and fix minor issues

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -101,12 +101,12 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                         --apim <API-Manager-endpoint> \
                         --token <token-endpoint> \
                         --admin <admin-REST-API-endpoint> \
-                        --publisher <Publisher-endpoint> \
-                        --devportal <DevPortal-endpoint>
+                        --publisher <publisher-portal-endpoint> \
+                        --devportal <developer-portal-endpoint>
         ```
 
         ``` bash tab="Mac/Windows"
-        apictl add-env -e <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <Publisher-endpoint> --devportal <DevPortal-endpoint>
+        apictl add-env -e <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <publisher-portal-endpoint> --devportal <developer-portal-endpoint>
         ```
 
         !!! info
@@ -122,7 +122,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                 `--registration` : Registration endpoint for the environment 
                 `--admin` : Admin endpoint for the environment  
                 `--publisher` : Publisher endpoint for the environment  
-                `--devportal` : DevPortal endpoint for the environment 
+                `--devportal` : Developer Portal endpoint for the environment 
             
         !!! tip
             When adding an environment, when the optional flags are not given, CTL will automatically derive those from `--apim` flag value.
@@ -323,11 +323,17 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             apictl logout dev
             ```
 
+## Add APIs/Applications in an environment
+
+You can add APIs and Applications via the Publisher Portal and Developer Portal accordingly.
+However, **apictl** allows you to create and deploy APIs without using the Publisher Portal. For more information on adding APIs, see [Importing APIs Via Dev First Approach]({{base_path}}/learn/api-controller/importing-apis-via-dev-first-approach).
+
 ## List APIs/Applications in an environment
+
 Follow the instructions below to display a list of APIs/API Products/Applications in an environment using CTL:
 
 1.  Make sure that the WSO2 API Manager 3.1.0 version is started and that the 3.1.0 version of APTCTL is running.   
-For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
+    For more information, see [Download and Initialize the CTL Tool](#download-and-initialize-the-ctl-tool).
 2.  Log in to the API Manager in the environment by following the instructions in [Login to an Environment](#login-to-an-environment).
 3.  Run the corresponding CTL command below to list APIs/API Products/Applications in an environment.
 
@@ -378,7 +384,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                 search for APIs.
                 You can search in attributes by using a `:` modifier. Supported attribute modifiers are **name**, 
                 **version**, **provider**, **context**, **status**, **description**, **subcontext**, **doc** and 
-                **label**.  Also you can use combined modifiers.  
+                **label**.  You can also use combined modifiers.    
                 **Example:**
                    
                 -  `provider:wso2` will match an API if the provider of the API contains `wso2`.
@@ -555,10 +561,10 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             **Flags:**  
             
             -   Required :  
-                `--environment` or `-e` : Environment of which the API state should be changed  
-                `--name` or `-n` : Name of the API to be state changed  
-                `--version` or `-v` : Version of the API to be state changed  
-                `--action` or `-a` : Action to be taken to change the status of the API
+                `--environment` or `-e` : The environment of which the API state should be changed  
+                `--name` or `-n` : The name of the API to be state changed  
+                `--version` or `-v` : The version of the API that its state needs to be changed
+                `--action` or `-a` : The action to be taken to change the status of the API
             -   Optional :  
                 `--provider` or `-r` : Provider of the API to be state changed  
 
@@ -585,7 +591,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
 
 ## Formatting the outputs of list
 
-Output of ```list envs```, ```list apis``` and ```list apps``` can be formatted with Go Templates. 
+Output of `list envs`, `list apis` and `list apps` can be formatted with Go Templates. 
 
 #### Available formatting options
 
@@ -738,7 +744,7 @@ Run the following CTL command to change the default location of the export direc
             Default : `/home/.wso2apictl/exported`
             
             
-## Import SSL Certificate for Secure HTTP Communication with API Manager
+## Import the SSL Certificate for Secure HTTP Communication with API Manager
 
 Different environments of API Manager can have different SSL certificates for secure HTTP communications. The default
 certificate of WSO2 API Manager is a self-signed certificate and in production environments, it is advised to use a

--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -561,12 +561,12 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             **Flags:**  
             
             -   Required :  
-                `--environment` or `-e` : The environment of which the API state should be changed  
-                `--name` or `-n` : The name of the API to be state changed  
-                `--version` or `-v` : The version of the API that its state needs to be changed
+                `--environment` or `-e` : The environment that the command is executed on  
+                `--name` or `-n` : The name of the respective API
+                `--version` or `-v` : The version of the respective API
                 `--action` or `-a` : The action to be taken to change the status of the API
             -   Optional :  
-                `--provider` or `-r` : Provider of the API to be state changed  
+                `--provider` or `-r` : The provider of the respective API 
 
         !!! example
             ```bash
@@ -744,7 +744,7 @@ Run the following CTL command to change the default location of the export direc
             Default : `/home/.wso2apictl/exported`
             
             
-## Import the SSL Certificate for Secure HTTP Communication with API Manager
+## Import SSL Certificates for Secure HTTP Communication with API Manager
 
 Different environments of API Manager can have different SSL certificates for secure HTTP communications. The default
 certificate of WSO2 API Manager is a self-signed certificate and in production environments, it is advised to use a

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -1,11 +1,11 @@
 # Importing APIs Via Dev First Approach
 
-WSO2 API Controller, **apictl** allows to create and deploy APIs without using WSO2 API Publisher Portal. You can use this feature to create an API **from scratch** or **using an existing Swagger or Open API specification** and then deploy it to the desired API Manager environment.
+WSO2 API Controller (**apictl**) allows you to create and deploy APIs without using WSO2 API Publisher Portal. You can use this feature to create an API **from scratch** or **using an existing Swagger or Open API specification** and then deploy it to the desired API Manager environment.
 
 !!! info
     **Before you begin** 
 
-    -   Make sure WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure that the WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
     -   Make sure you already have added an environment using the CTL tool for the API Manager environment you plan to import the API to. 
 
@@ -33,6 +33,96 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                 ```bash 
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
+
+            !!! note
+                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
+
+                !!! example
+                       ```yaml
+                        id:
+                          providerName: admin
+                          apiName: PizzaShackAPI
+                          version: 1.0.0
+                        uuid: 852464c8-a53a-45f9-9ef1-0e532fbd0767
+                        description: This is a simple API for Pizza Shack online pizza delivery store.
+                        type: HTTP
+                        context: /pizzashack/1.0.0
+                        contextTemplate: /pizzashack/{version}
+                        tags:
+                         - pizza
+                        documents: []
+                        lastUpdated: Dec 21, 2020 11:00:28 AM
+                        availableTiers:
+                         -
+                          name: Unlimited
+                          displayName: Unlimited
+                          description: Allows unlimited requests
+                          requestsPerMin: 2147483647
+                          requestCount: 2147483647
+                          unitTime: 0
+                          timeUnit: ms
+                          tierPlan: FREE
+                          stopOnQuotaReached: true
+                        availableSubscriptionLevelPolicies: []
+                        uriTemplates: []
+                        apiHeaderChanged: false
+                        apiResourcePatternsChanged: false
+                        status: PUBLISHED
+                        technicalOwner: John Doe
+                        technicalOwnerEmail: architecture@pizzashack.com
+                        businessOwner: Jane Roe
+                        businessOwnerEmail: marketing@pizzashack.com
+                        visibility: public
+                        gatewayLabels: []
+                        endpointSecured: false
+                        endpointAuthDigest: false
+                        transports: http,https
+                        advertiseOnly: false
+                        apiOwner: admin
+                        subscriptionAvailability: all_tenants
+                        corsConfiguration:
+                          corsConfigurationEnabled: false
+                          accessControlAllowOrigins:
+                           - '*'
+                          accessControlAllowCredentials: false
+                          accessControlAllowHeaders:
+                           - authorization
+                           - Access-Control-Allow-Origin
+                           - Content-Type
+                           - SOAPAction
+                           - apikey
+                          accessControlAllowMethods:
+                           - GET
+                           - PUT
+                           - POST
+                           - DELETE
+                           - PATCH
+                           - OPTIONS
+                        endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
+                        responseCache: Disabled
+                        cacheTimeout: 300
+                        implementation: ENDPOINT
+                        authorizationHeader: Authorization
+                        scopes: []
+                        isDefaultVersion: false
+                        isPublishedDefaultVersion: false
+                        environments:
+                         - Production and Sandbox
+                        createdTime: "1608528625313"
+                        additionalProperties: {}
+                        monetizationProperties: {}
+                        isMonetizationEnabled: false
+                        environmentList:
+                         - SANDBOX
+                         - PRODUCTION
+                        apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
+                        endpoints: []
+                        enableSchemaValidation: false
+                        apiCategories: []
+                        accessControl: all
+                        rating: 0.0
+                        isLatest: true
+                       ```
 
         -   Response    
             ```go
@@ -84,7 +174,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                 -   Optional :  
                         `--definition` or `-d` : Provide a YAML definition of API  
                         `--oas` : Provide an OpenAPI specification file/URL for the API   
-                        `--force` or `-f` : To overwrite directory and create project 
+                        `--force` or `-f` : To overwrite the directory and create the project 
 
             !!! note
                 You can define scopes for a resource when defining a Swagger2 or OpenAPI3 specification to generate an API.
@@ -95,7 +185,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                     info:
                     title: Online-Store
                     version: v1.0.0
-                    description: This API contains operations related to online shopping store.
+                    description: This API contains operations related to the online shopping store.
                     x-wso2-basePath: /store/{version}
                     x-wso2-production-endpoints:
                     urls:
@@ -267,7 +357,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
                     <p><span style="font-weight: 400;">x-wso2-transports</span></p>
                     </td>
                     <td>
-                    <p><span style="font-weight: 400;">Specify the transport security for the API(HTTP, HTTPS and Mutual SSL)</span></p>
+                    <p><span style="font-weight: 400;">Specify the transport security for the API (HTTP, HTTPS, and Mutual SSL)</span></p>
                     </td>
                     <td>
                     <p><span style="font-weight: 400;">API level&nbsp;</span></p>
@@ -321,7 +411,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
             </tr>
             <tr class="even">
                 <td><code>swagger.yaml</code></td>
-                <td>The Swagger file generated when the API is created.</td>
+                <td>The Swagger file that is generated when the API is created.</td>
             </tr>
             <tr class="odd">
                 <td><code>api_params.yaml</code></td>
@@ -339,7 +429,7 @@ WSO2 API Controller, **apictl** allows to create and deploy APIs without using W
         <td><pre><code>Docs
       |── FileContents</code></pre>
         </td>
-        <td>Contains the documents. To add a documentation, add them to the <code>Docs/FileContents/</code>directory.</td>
+        <td>Contains the documents. To add a new document, add the document in the <code>Docs/FileContents/</code>directory.</td>
         </tr>
         </tbody>
     </table>
@@ -436,11 +526,11 @@ After editing the mandatory fields in the API Project, you can import the API to
             `--file` or `-f` : The file path of the API project to import.  
             `--environment` or `-e` : Environment to which the API should be imported.   
         -   Optional :  
-            `--preserve-provider` : Preserve the existing provider of API after importing. Default value is `true`. 
+            `--preserve-provider` : Preserve the existing provider of API after importing. The default value is `true`. 
             `--update` : Update an existing API or create a new API in the importing environment.  
-            `--params` : Provide a API Manager environment params file (default "api_params.yaml").   
-            For more information, see [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) .  
-            `--skipCleanup` : Leave all temporary files created in the CTL during import process. Default value is `false`.  
+            `--params` : Provide a API Manager environment params file (The default file is `api_params.yaml`.).   
+            For more information, see [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters). 
+            `--skipCleanup` : Leave all temporary files created in the CTL during import process. The default value is `false`.  
 
     !!! example
         ```bash
@@ -454,11 +544,12 @@ After editing the mandatory fields in the API Project, you can import the API to
         ```
         
     !!! tip
-        When using `--update` flag with `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
+        When using the `--update` flag with the `import-api` command, the CTL tool will check if the given API exists in the targeted environment. If the API exists, it will update the existing API. If not, it will create a new API in the imported environment. 
 
        
 -   **Response**
     ``` bash
     Successfully imported API!
     ```
+
     

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -5,7 +5,7 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
 !!! info
     **Before you begin** 
 
-    -   Make sure that the WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure that the WSO2 API Manager CTL Tool is downloaded and initialized, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
     -   Make sure you already have added an environment using the CTL tool for the API Manager environment you plan to import the API to. 
 
@@ -34,95 +34,94 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
 
-            !!! note
-                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
+            The following is a sample API definition that can be used to generate an API Project.
 
-                !!! example
-                       ```yaml
-                        id:
-                          providerName: admin
-                          apiName: PizzaShackAPI
-                          version: 1.0.0
-                        uuid: 852464c8-a53a-45f9-9ef1-0e532fbd0767
-                        description: This is a simple API for Pizza Shack online pizza delivery store.
-                        type: HTTP
-                        context: /pizzashack/1.0.0
-                        contextTemplate: /pizzashack/{version}
-                        tags:
-                         - pizza
-                        documents: []
-                        lastUpdated: Dec 21, 2020 11:00:28 AM
-                        availableTiers:
-                         -
-                          name: Unlimited
-                          displayName: Unlimited
-                          description: Allows unlimited requests
-                          requestsPerMin: 2147483647
-                          requestCount: 2147483647
-                          unitTime: 0
-                          timeUnit: ms
-                          tierPlan: FREE
-                          stopOnQuotaReached: true
-                        availableSubscriptionLevelPolicies: []
-                        uriTemplates: []
-                        apiHeaderChanged: false
-                        apiResourcePatternsChanged: false
-                        status: PUBLISHED
-                        technicalOwner: John Doe
-                        technicalOwnerEmail: architecture@pizzashack.com
-                        businessOwner: Jane Roe
-                        businessOwnerEmail: marketing@pizzashack.com
-                        visibility: public
-                        gatewayLabels: []
-                        endpointSecured: false
-                        endpointAuthDigest: false
-                        transports: http,https
-                        advertiseOnly: false
-                        apiOwner: admin
-                        subscriptionAvailability: all_tenants
-                        corsConfiguration:
-                          corsConfigurationEnabled: false
-                          accessControlAllowOrigins:
-                           - '*'
-                          accessControlAllowCredentials: false
-                          accessControlAllowHeaders:
-                           - authorization
-                           - Access-Control-Allow-Origin
-                           - Content-Type
-                           - SOAPAction
-                           - apikey
-                          accessControlAllowMethods:
-                           - GET
-                           - PUT
-                           - POST
-                           - DELETE
-                           - PATCH
-                           - OPTIONS
-                        endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
-                        responseCache: Disabled
-                        cacheTimeout: 300
-                        implementation: ENDPOINT
-                        authorizationHeader: Authorization
-                        scopes: []
-                        isDefaultVersion: false
-                        isPublishedDefaultVersion: false
-                        environments:
-                         - Production and Sandbox
-                        createdTime: "1608528625313"
-                        additionalProperties: {}
-                        monetizationProperties: {}
-                        isMonetizationEnabled: false
-                        environmentList:
-                         - SANDBOX
-                         - PRODUCTION
-                        apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
-                        endpoints: []
-                        enableSchemaValidation: false
-                        apiCategories: []
-                        accessControl: all
-                        rating: 0.0
-                        isLatest: true
-                       ```
+            !!! example
+                ```yaml
+                id:
+                  providerName: admin
+                  apiName: PizzaShackAPI
+                  version: 1.0.0
+                uuid: 852464c8-a53a-45f9-9ef1-0e532fbd0767
+                description: This is a simple API for Pizza Shack online pizza delivery store.
+                type: HTTP
+                context: /pizzashack/1.0.0
+                contextTemplate: /pizzashack/{version}
+                tags:
+                 - pizza
+                documents: []
+                lastUpdated: Dec 21, 2020 11:00:28 AM
+                availableTiers:
+                 -
+                  name: Unlimited
+                  displayName: Unlimited
+                  description: Allows unlimited requests
+                  requestsPerMin: 2147483647
+                  requestCount: 2147483647
+                  unitTime: 0
+                  timeUnit: ms
+                  tierPlan: FREE
+                  stopOnQuotaReached: true
+                availableSubscriptionLevelPolicies: []
+                uriTemplates: []
+                apiHeaderChanged: false
+                apiResourcePatternsChanged: false
+                status: PUBLISHED
+                technicalOwner: John Doe
+                technicalOwnerEmail: architecture@pizzashack.com
+                businessOwner: Jane Roe
+                businessOwnerEmail: marketing@pizzashack.com
+                visibility: public
+                gatewayLabels: []
+                endpointSecured: false
+                endpointAuthDigest: false
+                transports: http,https
+                advertiseOnly: false
+                apiOwner: admin
+                subscriptionAvailability: all_tenants
+                corsConfiguration:
+                  corsConfigurationEnabled: false
+                  accessControlAllowOrigins:
+                   - '*'
+                  accessControlAllowCredentials: false
+                  accessControlAllowHeaders:
+                   - authorization
+                   - Access-Control-Allow-Origin
+                   - Content-Type
+                   - SOAPAction
+                   - apikey
+                  accessControlAllowMethods:
+                   - GET
+                   - PUT
+                   - POST
+                   - DELETE
+                   - PATCH
+                   - OPTIONS
+                endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
+                responseCache: Disabled
+                cacheTimeout: 300
+                implementation: ENDPOINT
+                authorizationHeader: Authorization
+                scopes: []
+                isDefaultVersion: false
+                isPublishedDefaultVersion: false
+                environments:
+                 - Production and Sandbox
+                createdTime: "1608528625313"
+                additionalProperties: {}
+                monetizationProperties: {}
+                isMonetizationEnabled: false
+                environmentList:
+                 - SANDBOX
+                 - PRODUCTION
+                apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
+                endpoints: []
+                enableSchemaValidation: false
+                apiCategories: []
+                accessControl: all
+                rating: 0.0
+                isLatest: true
+                ```
 
         -   Response    
             ```go


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/1886

## Goals
Backporting https://github.com/wso2/docs-apim/pull/1891

## Approach
- Fixed minor issues in the pages **Getting Started with WSO2 API Controller** and **Importing APIs Via Dev First Approach**.
- Added a sample api.yaml to be used as the definition for **apictl init** command.

## Related PRs
https://github.com/wso2/docs-apim/pull/1891