### PR TITLE
[Docs][Master] Fix for #1568 (Update the API controller CI/CD example API definition with new OpenAPI 3.0 definition.)

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/ci-cd-with-wso2-api-management.md
+++ b/en/docs/install-and-setup/setup/api-controller/ci-cd-with-wso2-api-management.md
@@ -77,7 +77,7 @@ Let us check out the basic building blocks for creating a CI/CD pipeline with WS
 Now, you have added two different environments. Our end goal is to automate the API migration between the `dev` and `prod` environments. Therefore, first, the API should be published in the `dev` environment using the API Publisher in WSO2 API Manager. 
 For more information on deploying an API in the API Manager, see the [Quick Start Guide](http://localhost:8000/getting-started/quick-start-guide/).   
 
-For this example, let's use the [Swagger Petstore API](https://petstore.swagger.io/). 
+For this example, let's use the [Swagger Petstore - OpenAPI 3.0](https://petstore3.swagger.io/). 
 
   1.  Sign in to the API Publisher.
        

--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -161,12 +161,12 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                        --apim <API-Manager-endpoint> \
                        --token <token-endpoint> \
                        --admin <admin-REST-API-endpoint> \
-                       --publisher <Publisher-endpoint> \
+                       --publisher <publisher-portal-endpoint> \
                        --devportal <developer-portal-endpoint>
         ```
 
         ``` bash tab="Mac/Windows"
-        apictl add env <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <Publisher-endpoint> --devportal <developer-portal-endpoint>
+        apictl add env <environment-name> --registration <client-registration-endpoint> --apim <API-Manager-endpoint> --token <token-endpoint> --admin <admin-REST-API-endpoint> --publisher <publisher-portal-endpoint> --devportal <developer-portal-endpoint>
         ```
 
         !!! info
@@ -178,7 +178,7 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
                 OR (the following 4)     
                 `--registration` : Registration endpoint for the environment     
                 `--admin` : Admin endpoint for the environment     
-                `--publisher` : Publisher endpoint for the environment     
+                `--publisher` : Publisher Portal endpoint for the environment     
                 `--devportal` : Developer Portal endpoint for the environment 
             -   Optional :     
                 `--token` : Token endpoint for the environment


### PR DESCRIPTION
## Purpose
1. Update the API controller CI/CD example API definition with new OpenAPI 3.0 definition.
2. Adding the missing keyword in the add-env example  in /learn/api-controller/getting-started-with-wso2-api-controller/ page

## Goals
Fixes #1568 for master branch

## Approach
**Update the API controller CI/CD example API definition with new OpenAPI 3.0 definition.**

![Screenshot from 2020-12-21 11-23-55](https://user-images.githubusercontent.com/42435576/102744663-5f610200-4380-11eb-8968-db33b36f5b9b.png)


**Update the add-env example in getting started page with a missing keyword**

![Screenshot from 2020-12-21 11-27-21](https://user-images.githubusercontent.com/42435576/102744718-7a337680-4380-11eb-805b-5be84e2bc84d.png)

