### PR TITLE
Fixing - Default search in publisher and devportal is not the API name search

### DIFF
--- a/en/docs/learn/consume-api/discover-apis/search.md
+++ b/en/docs/learn/consume-api/discover-apis/search.md
@@ -17,7 +17,7 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
 </thead>
 <tbody>
 <tr class="even">
-<td>Full text search</td>
+<td>Unified search</td>
 <td><p>As this is the default option, simply enter any attribute value 
 of the API and search.</p>
 <p>For example, PizzaShackAPI will search for PizzaShackAPI in API name, context, version, documents, etc.</p>
@@ -26,7 +26,7 @@ of the API and search.</p>
 <tr class="odd">
 <td>By the API's name</td>
 <td><p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
-<p>Provider is the user who created the API.</p></td>
+<p>Name is the API name.</p></td>
 </tr>
 <tr class="even">
 <td>By the API provider</td>

--- a/en/docs/learn/consume-api/discover-apis/search.md
+++ b/en/docs/learn/consume-api/discover-apis/search.md
@@ -16,9 +16,17 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
 </tr>
 </thead>
 <tbody>
+<tr class="even">
+<td>Full text search</td>
+<td><p>As this is the default option, simply enter any attribute value 
+of the API and search.</p>
+<p>For example, PizzaShackAPI will search for PizzaShackAPI in API name, context, version, documents, etc.</p>
+</td>
+</tr>
 <tr class="odd">
 <td>By the API's name</td>
-<td>As this is the default option, simply enter the API's name and search.</td>
+<td><p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
+<p>Provider is the user who created the API.</p></td>
 </tr>
 <tr class="even">
 <td>By the API provider</td>


### PR DESCRIPTION
## Purpose
Fixing issue https://github.com/wso2/docs-apim/issues/2288

<img width="726" alt="Screen Shot 2020-12-21 at 1 17 06 PM" src="https://user-images.githubusercontent.com/3424539/102752366-778c4d80-438f-11eb-8a22-a00bd399e874.png">
