### PR TITLE
[3.2.0] Simplify the description of the sample API definition in APICTL docs

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -641,9 +641,9 @@ For more information, see [Download and Initialize the CTL Tool](#download-and-i
             **Flags:**  
             
             -   Required :  
-                `--environment` or `-e` : The environment of which the API state should be changed  
-                `--name` or `-n` : The name of the API to be state changed  
-                `--version` or `-v` : The version of the API that its state needs to be changed
+                `--environment` or `-e` : The environment that the command is executed on  
+                `--name` or `-n` : The name of the respective API
+                `--version` or `-v` : The version of the respective API
                 `--action` or `-a` : The action to be taken to change the status of the API
             -   Optional :  
                 `--provider` or `-r` : Provider of the API to be state changed  
@@ -800,7 +800,7 @@ Run the following CTL command to change the default location of the export direc
             Default : `/home/.wso2apictl/exported`
             
             
-## Import the SSL certificate for Secure HTTP Communication with API Manager
+## Import SSL certificates for Secure HTTP Communication with API Manager
 
 Different environments of API Manager can have different SSL certificates for secure HTTP communications. The default
 certificate of WSO2 API Manager is a self-signed certificate and in production environments, it is advised to use a

--- a/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
+++ b/en/docs/learn/api-controller/importing-apis-via-dev-first-approach.md
@@ -5,7 +5,7 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
 !!! info
     **Before you begin** 
 
-    -   Make sure that the WSO2 API Manager CTL Tool is initialized and running, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
+    -   Make sure that the WSO2 API Manager CTL Tool is downloaded and initialized, if not, follow the steps in [Download and Initialize the CTL Tool]({{base_path}}/learn/api-controller/getting-started-with-wso2-api-controller/#download-and-initialize-the-ctl-tool).
 
     -   Make sure you already have added an environment using the CTL tool for the API Manager environment you plan to import the API to. 
 
@@ -33,76 +33,75 @@ WSO2 API Controller (**apictl**) allows you to create and deploy APIs without us
                 ```bash 
                 apictl init SampleAPI --definition definition.yaml --force=true                
                 ```
-            !!! note
-                Note that API definition is different from Swagger2 or OpenAPI3 specification. The following is a sample API definition used to generate an API Project.
-    
-                !!! example
-                       ```yaml
-                       id:
-                         providerName: admin
-                         apiName: PizzaShackAPI
-                         version: 1.0.0
-                       uuid: 8d87e646-f7c5-4dc2-9f45-64903ecccca4
-                       description: This is a simple API for Pizza Shack online pizza delivery store.
-                       type: HTTP
-                       context: /pizzashack/1.0.0
-                       contextTemplate: /pizzashack/{version}
-                       tags:
-                       - pizza
-                       availableTiers:
-                       - name: Unlimited
-                         displayName: Unlimited
-                         description: Allows unlimited requests
-                         requestsPerMin: 2147483647
-                         requestCount: 2147483647
-                         timeUnit: ms
-                         tierPlan: FREE
-                         stopOnQuotaReached: true
-                       status: PUBLISHED
-                       technicalOwner: John Doe
-                       technicalOwnerEmail: architecture@pizzashack.com
-                       businessOwner: Jane Roe
-                       businessOwnerEmail: marketing@pizzashack.com
-                       visibility: public
-                       transports: http,https
-                       corsConfiguration:
-                         accessControlAllowOrigins:
-                         - '*'
-                         accessControlAllowHeaders:
-                         - authorization
-                         - Access-Control-Allow-Origin
-                         - Content-Type
-                         - SOAPAction
-                         - apikey
-                         - testKey
-                         accessControlAllowMethods:
-                         - GET
-                         - PUT
-                         - POST
-                         - DELETE
-                         - PATCH
-                         - OPTIONS
-                       productionUrl: http://localhost:8080
-                       sandboxUrl: http://localhost:8081
-                       endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
-                       responseCache: Disabled
-                       cacheTimeout: 300
-                       implementation: ENDPOINT
-                       authorizationHeader: Authorization
-                       environments:
-                       - Production and Sandbox
-                       createdTime: "1599638524995"
-                       environmentList:
-                       - SANDBOX
-                       - PRODUCTION
-                       apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
-                       accessControl: all
-                       isLatest: true
-                       enableStore: true
-                       keyManagers:
-                       - all
-                       ```
-
+            
+            The following is a sample API definition that can be used to generate an API Project.
+  
+            !!! example
+                ```yaml
+                id:
+                 providerName: admin
+                 apiName: PizzaShackAPI
+                 version: 1.0.0
+                uuid: 8d87e646-f7c5-4dc2-9f45-64903ecccca4
+                description: This is a simple API for Pizza Shack online pizza delivery store.
+                type: HTTP
+                context: /pizzashack/1.0.0
+                contextTemplate: /pizzashack/{version}
+                tags:
+                - pizza
+                availableTiers:
+                - name: Unlimited
+                 displayName: Unlimited
+                 description: Allows unlimited requests
+                 requestsPerMin: 2147483647
+                 requestCount: 2147483647
+                 timeUnit: ms
+                 tierPlan: FREE
+                 stopOnQuotaReached: true
+                status: PUBLISHED
+                technicalOwner: John Doe
+                technicalOwnerEmail: architecture@pizzashack.com
+                businessOwner: Jane Roe
+                businessOwnerEmail: marketing@pizzashack.com
+                visibility: public
+                transports: http,https
+                corsConfiguration:
+                 accessControlAllowOrigins:
+                 - '*'
+                 accessControlAllowHeaders:
+                 - authorization
+                 - Access-Control-Allow-Origin
+                 - Content-Type
+                 - SOAPAction
+                 - apikey
+                 - testKey
+                 accessControlAllowMethods:
+                 - GET
+                 - PUT
+                 - POST
+                 - DELETE
+                 - PATCH
+                 - OPTIONS
+                productionUrl: http://localhost:8080
+                sandboxUrl: http://localhost:8081
+                endpointConfig: '{"endpoint_type":"http","sandbox_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"},"production_endpoints":{"url":"https:\/\/localhost:9443\/am\/sample\/pizzashack\/v1\/api\/"}}'
+                responseCache: Disabled
+                cacheTimeout: 300
+                implementation: ENDPOINT
+                authorizationHeader: Authorization
+                environments:
+                - Production and Sandbox
+                createdTime: "1599638524995"
+                environmentList:
+                - SANDBOX
+                - PRODUCTION
+                apiSecurity: oauth2,oauth_basic_auth_api_key_mandatory
+                accessControl: all
+                isLatest: true
+                enableStore: true
+                keyManagers:
+                - all
+                ```
             
         -   Response    
             ```go


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/1886

## Goals
Reducing the confusions that may arise due to https://github.com/wso2/docs-apim/pull/1891

## Approach
- Made the description of change-status API command to make it less verbose
- Simplified the description on --definition flag on apictl init command with the relevant example for api.yaml

## Related PRs
https://github.com/wso2/docs-apim/pull/1891