### PR TITLE
[3.2.0] Change referring swagger instead of OAS

### DIFF
--- a/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
+++ b/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
@@ -1,12 +1,10 @@
 # Invoke an API using the Integrated API Console
 
-WSO2 API Manager (WSO2 API-M) has an integrated Swagger UI, which renders OpenAPI specification as interactive API documentation.
+WSO2 API Manager has an integrated API Console, which allows you to visualize the API contract and interact with API's resources without being aware of the backend logic.
 
-[OpenAPI Specification (OAS)](https://swagger.io/specification/) is a 100% open source, standard, language-agnostic specification for RESTful APIs. OpenAPI specification allows consumers to understand the capabilities of a remote service without accessing its source code. OpenAPI specification helps describe a service in the same way that interfaces describe lower-level programming code.
+The API Console generates interactive and consumer-focused documentation for API Contracts which are compliant with OpenAPI specification. OpenAPI specification-compliant APIs help you to make interactive documentation, client SDK generation and more discoverability using [Swagger UI](https://github.com/swagger-api/swagger-ui). The Swagger UI has JSON code and its UI facilitates easier code indentation, keyword highlighting, and shows syntax errors on the fly. You can add resource parameters, summaries, and descriptions to your APIs using the Swagger UI.
 
-The [Swagger UI](https://github.com/swagger-api/swagger-ui) is a dependency-free collection of HTML, JavaScript, and CSS that dynamically generate documentation from a OpenAPI specification-compliant API. OpenAPI specification-compliant APIs help you to make interactive documentation, client SDK generation and more discoverability using Swagger UI. The Swagger UI has JSON code and its UI facilitates easier code indentation, keyword highlighting, and shows syntax errors on the fly. You can add resource parameters, summaries, and descriptions to your APIs using the Swagger UI.
-
-For more information also, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
+For more information also, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md) and [OpenAPI specification, version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md).
 
 Let's see how to use the API Console in the Developer Portal to invoke an API.
 

--- a/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
+++ b/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
@@ -2,9 +2,9 @@
 
 WSO2 API Manager has an integrated API Console, which allows you to visualize the API contract and interact with API's resources without being aware of the backend logic.
 
-The API Console generates interactive and consumer-focused documentation for API Contracts which are compliant with OpenAPI specification. OpenAPI specification-compliant APIs help you to make interactive documentation, client SDK generation and more discoverability using [Swagger UI](https://github.com/swagger-api/swagger-ui). The Swagger UI has JSON code and its UI facilitates easier code indentation, keyword highlighting, and shows syntax errors on the fly. You can add resource parameters, summaries, and descriptions to your APIs using the Swagger UI.
+The API Console generates interactive and consumer-focused documentation for API Contracts which are compliant with OpenAPI specification.
 
-For more information also, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md) and [OpenAPI specification, version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md).
+For more information, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md) and [OpenAPI specification, version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md).
 
 Let's see how to use the API Console in the Developer Portal to invoke an API.
 

--- a/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
+++ b/en/docs/learn/consume-api/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
@@ -1,12 +1,12 @@
 # Invoke an API using the Integrated API Console
 
-WSO2 API Manager (WSO2 API-M) has an integrated Swagger UI, which is part of the Swagger project.
+WSO2 API Manager (WSO2 API-M) has an integrated Swagger UI, which renders OpenAPI specification as interactive API documentation.
 
-[Swagger](http://swagger.io/) is a 100% open source, standard, language-agnostic specification and a complete framework for describing, producing, consuming, and visualizing RESTful APIs, without the need for a proxy or third-party services. Swagger allows consumers to understand the capabilities of a remote service without accessing its source code and interacts with the service with a minimal amount of implementation logic. Swagger helps describe a service in the same way that interfaces describe lower-level programming code.
+[OpenAPI Specification (OAS)](https://swagger.io/specification/) is a 100% open source, standard, language-agnostic specification for RESTful APIs. OpenAPI specification allows consumers to understand the capabilities of a remote service without accessing its source code. OpenAPI specification helps describe a service in the same way that interfaces describe lower-level programming code.
 
-The [Swagger UI](https://github.com/swagger-api/swagger-ui) is a dependency-free collection of HTML, JavaScript, and CSS that dynamically generate documentation from a Swagger-compliant API. Swagger-compliant APIs give you interactive documentation, client SDK generation and more discoverability. The Swagger UI has JSON code and its UI facilitates easier code indentation, keyword highlighting, and shows syntax errors on the fly. You can add resource parameters, summaries, and descriptions to your APIs using the Swagger UI.
+The [Swagger UI](https://github.com/swagger-api/swagger-ui) is a dependency-free collection of HTML, JavaScript, and CSS that dynamically generate documentation from a OpenAPI specification-compliant API. OpenAPI specification-compliant APIs help you to make interactive documentation, client SDK generation and more discoverability using Swagger UI. The Swagger UI has JSON code and its UI facilitates easier code indentation, keyword highlighting, and shows syntax errors on the fly. You can add resource parameters, summaries, and descriptions to your APIs using the Swagger UI.
 
-For more information also, see the [Swagger 2.0 specification](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
+For more information also, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
 
 Let's see how to use the API Console in the Developer Portal to invoke an API.
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/2092

## Goals
Change content with Swagger to OpenAPI specification.
