### PR TITLE
[3.1.0] Add required steps when enabling user signup workflow for multi tenants

### DIFF
--- a/en/docs/develop/customizations/adding-a-user-signup-workflow.md
+++ b/en/docs/develop/customizations/adding-a-user-signup-workflow.md
@@ -182,6 +182,10 @@ This section explains how to attach a custom workflow to the user signup operati
 
 #### Engaging the WS Workflow Executor in the API Manager
 
+!!! important
+    When there are multiple tenants, first enable self sign up for tenant admin for each tenant by following the steps mentioned in [Enabling self signup]({{base_path}}/develop/customizations/customizing-the-developer-portal/enabling-or-disabling-self-signup/#enabling-self-signup). 
+    Then to add a user sign-up workflow with regard to the Developer Portal, follow the below instructions from step 1 after sign in to the API-M Management Console as tenant admin for each tenant.
+
 1.  Log in to API-M management console ( `https://<Server-Host>:9443/carbon` ) and select **Browse** under **Resources**.
 
     ![Browse resources](../../assets/img/learn/browse-resources.png)
@@ -204,13 +208,9 @@ This section explains how to attach a custom workflow to the user signup operati
         All workflow process services of the EI/BPS run on port 9765 because you changed its default port (9763) with an offset of 2.
 
 3.  Go to the Developer Portal Web interface of API Manager and sign up / register as a new user.
-<html>
-    <body>
-        <div>
-            <img src="../../../../assets/img/learn/register-now.png" alt="Register now option" width="600"/>
-        </div>
-    </body>
-</html>
+
+    ![Register now option](../../assets/img/learn/register-now.png)
+    
     It invokes the signup process and creates a Human Task instance that holds the execution of the BPEL until some action is performed on it.
 
 4.  Note the message that appears if the BPEL is invoked correctly, saying that the request is successfully submitted.


### PR DESCRIPTION
## Purpose

- This PR fixes #2130
- Add a note providing steps that need to be performed when there are multiple tenants.
- Corrects "Register now" image