### PR TITLE
[3.1.0] Removing custom throttling link

### DIFF
--- a/en/docs/learn/rate-limiting/blacklisting-whitelisting.md
+++ b/en/docs/learn/rate-limiting/blacklisting-whitelisting.md
@@ -7,7 +7,6 @@ This section guides you through the following areas:
     -   [Engage the policy with an API](#engage-the-policy-with-an-api)
 -   [Blacklisting requests](#blacklisting-requests)
     -   [Blacklisting PhoneVerification API](#blacklisting-phoneverification-api)
--   [Custom throttling](#custom-throttling)
 
 ### IP Whitelisting
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/1200

## Goals
Removing the link to Custom throttling since docs do not contain any details about it.

## Approach
Remove the **Custom Throttling** link from **Blacklisting and Whitelisting Requests** page.