### PR TITLE
Change regadmin to sharedadmin

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
@@ -99,7 +99,7 @@ Follow the instructions below to change the type of the default datasource.
     ```
 
     ``` tab="Example"
-    [database.shared_db]
+    [database.apim_db]
     type = "db2"
     url = "jdbc:db2://localhost:50000/apim_db"
     username = "apimadmin"
@@ -107,9 +107,9 @@ Follow the instructions below to change the type of the default datasource.
     driver = "com.ibm.db2.jcc.DB2Driver"
     validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
     
-    [database.apim_db]
+    [database.shared_db]
     type = "db2"
-    url = "jdbc:db2://localhost:50000/reg_db"
+    url = "jdbc:db2://localhost:50000/shared_db"
     username = "sharedadmin"
     password = "sharedadmin"
     driver = "com.ibm.db2.jcc.DB2Driver"
@@ -144,7 +144,7 @@ Follow the instructions below to change the type of the default datasource.
     ```
 
     ``` tab="Example"
-    [database.shared_db]
+    [database.apim_db]
     type = "db2"
     url = "jdbc:db2://localhost:50000/apim_db"
     username = "apimadmin"
@@ -155,9 +155,9 @@ Follow the instructions below to change the type of the default datasource.
     pool_options.maxWait = 10000
     pool_options.validationInterval = 10000
 
-    [database.apim_db]
+    [database.shared_db]
     type = "db2"
-    url = "jdbc:db2://localhost:50000/reg_db"
+    url = "jdbc:db2://localhost:50000/shared_db"
     username = "sharedadmin"
     password = "sharedadmin"
     driver = "com.ibm.db2.jcc.DB2Driver"

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
@@ -30,7 +30,7 @@ Follow the instructions below to set up a IBM DB2 database:
    ```
    For example:
    ```sh
-   $ db2 GRANT DBADM, CREATETAB, BINDADD, CONNECT, CREATE_NOT_FENCED, IMPLICIT_SCHEMA, LOAD ON DATABASE TO USER regadmin
+   $ db2 GRANT DBADM, CREATETAB, BINDADD, CONNECT, CREATE_NOT_FENCED, IMPLICIT_SCHEMA, LOAD ON DATABASE TO USER sharedadmin
    ```
 
 1. Disconnect from the database using the following command:
@@ -110,8 +110,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.apim_db]
     type = "db2"
     url = "jdbc:db2://localhost:50000/reg_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "com.ibm.db2.jcc.DB2Driver"
     validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
     ```
@@ -158,8 +158,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.apim_db]
     type = "db2"
     url = "jdbc:db2://localhost:50000/reg_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "com.ibm.db2.jcc.DB2Driver"
     validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
     pool_options.maxActive = 50

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
@@ -66,13 +66,13 @@ $ pip install mssql-cli
 1.  To create tables in the registry and user manager database (`WSO2_SHARED_DB`), execute the relevant script as shown below.
 
     ```sh
-    $ mssql-cli -U regadmin -P regadmin -d shared_db -i <API-M_HOME>/dbscripts/mssql.sql;
+    $ mssql-cli -U sharedadmin -P sharedadmin -d shared_db -i <API-M_HOME>/dbscripts/mssql.sql;
     ```
 
 1.  To create tables in the apim database (`WSO2AM_DB`), execute the relevant script as shown below.
 
     ```sh
-    $ mssql-cli -U regadmin -P regadmin -d apim_db -i <API-M_HOME>/dbscripts/apimgt/mssql.sql;
+    $ mssql-cli -U sharedadmin -P sharedadmin -d apim_db -i <API-M_HOME>/dbscripts/apimgt/mssql.sql;
     ```
 
 !!! note
@@ -131,8 +131,8 @@ Follow the steps below to change the type of the default datasource.
     [database.shared_db]
     type = "mssql"
     url = "jdbc:sqlserver://localhost:1433;databaseName=shared_db;SendStringParametersAsUnicode=false"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     validationQuery = "SELECT 1"
 
@@ -179,8 +179,8 @@ Follow the steps below to change the type of the default datasource.
     [database.shared_db]
     type = "mssql"
     url = "jdbc:sqlserver://localhost:1433;databaseName=shared_db;SendStringParametersAsUnicode=false"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     validationQuery = "SELECT 1"
     pool_options.maxActive = 100

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
@@ -110,8 +110,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "oracle"
     url = "jdbc:oracle:thin:@(DESCRIPTION=(LOAD_BALANCE=on)(ADDRESS=(PROTOCOL=TCP)(HOST=racnode1) (PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=racnode2) (PORT=1521))(CONNECT_DATA=(SERVICE_NAME=rac)))"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "oracle.jdbc.driver.OracleDriver"
     validationQuery = "SELECT 1 FROM DUAL"
     
@@ -155,8 +155,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "oracle"
     url = "jdbc:oracle:thin:@(DESCRIPTION=(LOAD_BALANCE=on)(ADDRESS=(PROTOCOL=TCP)(HOST=racnode1) (PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=racnode2) (PORT=1521))(CONNECT_DATA=(SERVICE_NAME=rac)))"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "oracle.jdbc.driver.OracleDriver"
     validationQuery = "SELECT 1 FROM DUAL"
     pool_options.maxActive = 100

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
@@ -112,8 +112,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "oracle"
     url = "jdbc:oracle:thin:@localhost:1521/shared_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "oracle.jdbc.driver.OracleDriver"
     validationQuery = "SELECT 1 FROM DUAL"
     
@@ -157,8 +157,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "oracle"
     url = "jdbc:oracle:thin:@localhost:1521/shared_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "oracle.jdbc.driver.OracleDriver"
     validationQuery = "SELECT 1 FROM DUAL"
     pool_options.maxActive = 100

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
@@ -124,8 +124,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "postgre"
     url = "jdbc:postgresql://localhost:5432/shared_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "org.postgresql.Driver"
     validationQuery = "SELECT 1"
     
@@ -169,8 +169,8 @@ Follow the instructions below to change the type of the default datasource.
     [database.shared_db]
     type = "postgre"
     url = "jdbc:postgresql://localhost:5432/shared_db"
-    username = "regadmin"
-    password = "regadmin"
+    username = "sharedadmin"
+    password = "sharedadmin"
     driver = "org.postgresql.Driver"
     validationQuery = "SELECT 1"
     pool_options.maxActive = 100


### PR DESCRIPTION
## Purpose
> regadmin user is used for shared_db. As shared_db contains registry and user db, make sense to change this as sharedadmin.

Issue : https://github.com/wso2/docs-apim/issues/2570