### PR TITLE
Remove Artifact synchronization with rsync section

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster.md
@@ -4,7 +4,6 @@ In an API-M Gateway cluster, artifact synchronization is critical to maintain co
 
 1. [Shared file system (e.g., NFS)]({{base_path}}/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster/#artifact-synchronization-with-a-shared-file-system)
 2. [Inbuilt artifact synchronizer]({{base_path}}/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster/#inbuilt-artifact-synchronization) 
-3. [rsync]({{base_path}}/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster/#artifact-synchronization-with-rsync)
 
 ## Artifact synchronization with a shared file system
 
@@ -147,81 +146,3 @@ password = "wso2carbon"
 
 Add the tables of the `AM_GW_API_ARTIFACTS` and `AM_GW_PUBLISHED_API_DETAILS` to this new database that you are specifying. 
 The scripts to create these tables are in the `<API-M_HOME>/dbscripts/apimgt/` directory.
-
-## Artifact synchronization with rsync
-
-Deployment synchronization can be done using [rsync](https://download.samba.org/pub/rsync/rsync.html), which is a file copying tool. These changes must be done in the manager node and in the same directory.
-
-1.  Create a file named `workers-list.txt`, somewhere in your machine, which lists all the worker nodes in the deployment. The following is a sample of the file where there are two worker nodes.
-
-    !!! tip
-        Different nodes are separated by new lines.
-
-    **workers-list.txt**
-
-    ``` java
-    ubuntu@192.168.1.1:~/setup/192.168.1.1/as/as_worker/repository/deployment/server
-    ubuntu@192.168.1.2:~/setup/192.168.1.2/as/as_worker/repository/deployment/server
-    ```
-
-    !!! note
-        If you have configured tenants in worker nodes, you need to add the `repository/tenants` directory of the worker node to the list in order to synchronize the tenant space. For example, if the `ubuntu@192.168.1.1` node needs to be synced with both the super tenant and the tenant space, you need to add the following two entries to the `workers-list.txt` file.
-
-        **workers-list.txt**
-
-        ``` java
-        ubuntu@192.168.1.1:~/setup/192.168.1.1/apim/apim_worker/repository/deployment/server
-        ubuntu@192.168.1.1:~/setup/192.168.1.1/apim/apim_worker/repository/tenants
-        ```
-
-2.  Create a file to synchronize the `<API-M_HOME>/repository/deployment/server` folders between the manager and all worker nodes.
-
-    !!! note
-        You must create your own SSH key and define it as the `pem_file` file. Alternatively, you can use an existing SSH key. For information on generating and using the SSH keys, go to the official [SSH documentation](https://www.ssh.com/ssh/keygen/). Specify the `manager_server_dir` depending on the location in your local machine. Change the `logs.txt` file path and the lock location based on where they are located in your machine.
-
-    **rsync-for-carbon-depsync.sh**
-
-    ``` java
-    #!/bin/sh
-    manager_server_dir=~/wso2as-5.2.1/repository/deployment/server/
-    pem_file=~/.ssh/carbon-440-test.pem
-
-
-    #delete the lock on exit
-    trap 'rm -rf /var/lock/depsync-lock' EXIT 
-
-    mkdir /tmp/carbon-rsync-logs/
-
-
-    #keep a lock to stop parallel runs
-    if mkdir /var/lock/depsync-lock; then
-      echo "Locking succeeded" >&2
-    else
-      echo "Lock failed - exit" >&2
-      exit 1
-    fi
-
-    #get the workers-list.txt
-    pushd `dirname $0` > /dev/null
-    SCRIPTPATH=`pwd`
-    popd > /dev/null
-    echo $SCRIPTPATH
-
-
-    for x in `cat ${SCRIPTPATH}/workers-list.txt`
-    do
-    echo ================================================== >> /tmp/carbon-rsync-logs/logs.txt;
-    echo Syncing $x;
-    rsync --delete -arve "ssh -i  $pem_file -o StrictHostKeyChecking=no" $manager_server_dir $x >> /tmp/carbon-rsync-logs/logs.txt
-    echo ================================================== >> /tmp/carbon-rsync-logs/logs.txt;
-    done
-    ```
-
-3. Create a cron job that executes the above file every minute for deployment synchronization. Do this by running the following command in your command line.
-
-    !!! note
-        You can only run the cron job on one given node (master) at a given time. If you switch the cron job to another node, you must stop the cron job on the existing node and start a new cron job on the new node after updating it with the latest files.
-
-    `
-    *   *  *   *   *     /home/ubuntu/setup/rsync-for-depsync/rsync-for-depsync.sh
-    `

--- a/en/docs/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/synchronizing-artifacts-in-a-gateway-cluster.md
@@ -12,8 +12,9 @@ shared file system. Configure a shared file system as the content synchronizatio
 system such as Network File System (NFS) or any other shared file system that is available. 
 
 You need to mount the following directories of the two nodes to the shared file system, in order to share all the APIs and throttling policies between all the nodes.
-    1. `<API-M_HOME>/repository/deployment/server/synapse-configs`
-    2. `<API-M_HOME>/repository/deployment/server/executionplans`
+
+1. `<API-M_HOME>/repository/deployment/server/synapse-configs`
+2. `<API-M_HOME>/repository/deployment/server/executionplans`
 
 ## Inbuilt artifact synchronization
 


### PR DESCRIPTION
## Purpose
> As rsync is no longer in use, after discussion decided to remove **Artifact synchronization with rsync** section.

Issue : https://github.com/wso2/docs-apim/issues/2699

