### PR TITLE
[3.1.0] Adding/Updating the configs on enable loading dynamic MutualSSL profiles

### DIFF
--- a/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
+++ b/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
@@ -78,14 +78,15 @@ To configure APIM for Dynamic SSL Profiles for HTTPS transport Sender, you need 
 </profile>
 </parameter>
 ```
-To enable dynamic loading of this configuration, add below configurations to the Transport Sender configuration ( `PassThroughHttpSSLSender` ) of API Manager ( `<APIM_HOME>/repository/conf/axis2.xml` ) . Set above file’s path as the `filePath` parameter.
+To enable dynamic loading of this configuration, add the below configurations to the `<API-M_HOME>/repository/conf/deployment.toml` file (Make sure to set the above file’s path as the value for the `file_path` field under `[transport.passthru_https.sender.ssl_profile]`).
 
-``` java
-<parameter name="dynamicSSLProfilesConfig">  
-    <filePath>repository/deployment/server/multi_ssl_profiles.xml</filePath>
-    <fileReadInterval>3600000</fileReadInterval>  
-</parameter>
-<parameter name="HostnameVerifier">AllowAll</parameter>
+``` toml
+[transport.passthru_https.sender.ssl_profile]
+file_path = "repository/deployment/server/mutual_ssl_profiles.xml"
+interval = 3600000
+
+[transport.passthru_https.sender.parameters]
+HostnameVerifier = "AllowAll"
 ```
 
 Now both the backend service and ESB is configured to use default key stores and API Manager is configured to load dynamic SSL profiles. Restart API Manager.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/2313
Fixes: https://github.com/wso2/docs-apim/issues/1635

## Goals
Updating the configs on enable loading dynamic MutualSSL profiles

## Approach
Replaced the config which was asked to be done in axis2.xml file with the correct configurations to be done on **deployment.toml** file on the page **Mutual SSL Between API Gateway and Backend**. Refer below for the updated config.
![image](https://user-images.githubusercontent.com/25246848/102873841-a83fb600-4467-11eb-98c8-1dcf334fa766.png)

## Note
This will update the configs in APIM 3.0.0 docs as well since it is referring the same page here [1].

[1] https://apim.docs.wso2.com/en/3.0.0/administer/product-security/mutual-ssl-between-api-gateway-and-backend/#mutual-ssl-between-api-gateway-and-backend 