### PR TITLE
[Docs] [3.1.0] Remove inconsistency in examples when configuring MutualSSL

### DIFF
--- a/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
+++ b/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
@@ -29,7 +29,7 @@ This section explains how to secure your backend by enabling mutual SSL between 
 4.  Export the public certificate from API Manager's keystore. The `<APIM_HOME>/repository/resources/security/wso2carbon.jks` file which is the default keystore shipped with WSO2 API Manager is used in this example. Use the command below to generate the certificate for the default keystore. Give the default password `wso2carbon` when prompted.
 
     ``` java
-    keytool -export -keystore wso2carbon.jks -alias wso2carbon -file wso2PubCert.cert
+    keytool -export -keystore wso2carbon.jks -alias wso2carbon -file wso2PubCert.crt
     ```
 
     !!! info


### PR DESCRIPTION
## Purpose
https://apim.docs.wso2.com/en/latest/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend/#mutual-ssl-between-api-gateway-and-backend

The examples attached to step 4 and step 5 have some inconsistencies. This PR will fix them.

## Goals
Fixes https://github.com/wso2/docs-apim/issues/1336

## Approach
![screenshot-localhost-8000-learn-api-gateway-mutual-ssl-between-api-gateway-and-backend-1608640210405](https://user-images.githubusercontent.com/42435576/102888929-b13c8180-447f-11eb-89a2-a7e4c9cbbfa0.png)



