### PR TITLE
Removed Hazelcast ref in mkdocs

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -382,7 +382,6 @@ nav:
               - Deploying WSO2 API-M in a Distributed Setup: install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup.md
               - Product Profiles: install-and-setup/setup/distributed-deployment/product-profiles.md
               - Clustering WSO2 API-M Gateways for HA with rsync: install-and-setup/setup/distributed-deployment/clustering-gateway-for-ha-using-rsync.md
-              - Working with Hazelcast Clustering: install-and-setup/setup/distributed-deployment/working-with-hazelcast-clustering.md
           - Configure Key Manager:
               - Configure a Third Party Key Manager: install-and-setup/setup/distributed-deployment/configure-a-third-party-key-manager.md
               - Configuring WSO2 Identity Server as Key Manager: install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager.md


### PR DESCRIPTION
## Purpose
Removed Hazelcast ref in mkdocs to fix build break in 3.1.0