### PR TITLE
Remove 'Sign in via multiple user attributes' section

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -64,10 +64,6 @@ Use the `<API-M_HOME>/bin/chpasswd.sh` script.
 !!! note
     If you encountered an error similar to `ant: command not found`, Please install [ant](https://ant.apache.org/) before running the above script
 
-### Login in via multiple user attributes in Developer Portal
-
-See [Authentication using multiple Attributes](https://is.docs.wso2.com/en/5.10.0/learn/managing-user-attributes/#authentication-using-multiple-attributes) in the WSO2 IS documentation. Follow those instructions on setting up similarly in API Manager. 
-
 ### Setting up an e-mail login
 
 For information, see [Email Authentication](https://is.docs.wso2.com/en/5.10.0/learn/using-email-address-as-the-username/) in the WSO2 IS documentation.


### PR DESCRIPTION
## Purpose
> Multi-attribute authentication not supported in dev portal from APIM side. Therefore removing from the doc.

Issue : https://github.com/wso2/docs-apim/issues/1813
