### PR TITLE
Removing the unwanted description in "Invoke an API using the Integrated API Console" page

### DIFF
--- a/en/docs/consume/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
+++ b/en/docs/consume/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console.md
@@ -2,10 +2,6 @@
 
 WSO2 API Manager has an integrated API Console, which allows you to visualize the API contract and interact with API's resources without being aware of the backend logic.
 
-The API Console generates interactive and consumer-focused documentation for API Contracts which are compliant with OpenAPI specification.
-
-For more information, see the [OpenAPI specification, version 2.0](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md) and [OpenAPI specification, version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md).
-
 Let's see how to use the API Console in the Developer Portal to invoke an API.
 
 !!! Note


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/2764

## Goals
Remove unnecessary description in the page **Invoke an API using the Integrated API Console**.

## Approach
Removed the below description from the page **Invoke an API using the Integrated API Console**.
"The API Console generates interactive and consumer-focused documentation for API Contracts which are compliant with OpenAPI specification.

For more information, see the OpenAPI specification, version 2.0 and OpenAPI specification, version 3.0."

- Before removing
  ![image](https://user-images.githubusercontent.com/25246848/102963607-8732a000-450f-11eb-945e-6e3c5e38816c.png)

- After removing
  ![image](https://user-images.githubusercontent.com/25246848/102963636-a03b5100-450f-11eb-9c48-e45760efa53e.png)