### PR TITLE
Update 'Turning off registry versioning' section with correct procedure

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
@@ -25,7 +25,7 @@ Therefore, when migrating to API Manager 3.0.0, it is **required** run the below
     Alternatively, it is possible to turn on registry versioning in API Manager 3.0.0 and continue. But this is
     highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
-!!! info "Verifying registry versioning turned on in your current API-M and running the scripts"
+!!! info "Verifying registry versioning is turned on in your current API-M and running the scripts"
     Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
     Check whether `versioningProperties`, `versioningComments`, `versioningTags` and `versioningRatings` configurations are true.
     

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
@@ -19,14 +19,13 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.0.0.
 
-Therefore, when migrating to API Manager 3.0.0, it is **required** to turn off the registry versioning in your
-current API Manager 2.1.0 version and run the below scripts against **the database that is used by the registry**.
+Therefore, when migrating to API Manager 3.0.0, it is **required** run the below scripts against **the database that is used by the registry**.
 
 !!! note "NOTE"
     Alternatively, it is possible to turn on registry versioning in API Manager 3.0.0 and continue. But this is
     highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
-!!! info "Turning off registry versioning in your current API-M and running the scripts"
+!!! info "Verifying registry versioning turned on in your current API-M and running the scripts"
     Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
     Check whether `versioningProperties`, `versioningComments`, `versioningTags` and `versioningRatings` configurations are true.
     

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
@@ -19,14 +19,13 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.0.0.
 
-Therefore, when migrating to API Manager 3.0.0, it is **required** to turn off the registry versioning in your
-current API Manager 2.2.0 version and run the below scripts against **the database that is used by the registry**.
+Therefore, when migrating to API Manager 3.0.0, it is **required** to run the below scripts against **the database that is used by the registry**.
 
 !!! note "NOTE"
     Alternatively, it is possible to turn on registry versioning in API Manager 3.0.0 and continue. But this is
     highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
-!!! info "Turning off registry versioning in your current API-M and running the scripts"
+!!! info "Verifying registry versioning is turned on in your current API-M and running the scripts"
     Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
     Check whether `versioningProperties`, `versioningComments`, `versioningTags` and `versioningRatings` configurations are true.
     

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
@@ -19,14 +19,13 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.0.0.
 
-Therefore, when migrating to API Manager 3.0.0, it is **required** to turn off the registry versioning in your
-current API Manager 2.5.0 version and run the below scripts against **the registry database**.
+Therefore, when migrating to API Manager 3.0.0, it is **required** to run the below scripts against **the registry database**.
 
 !!! note
     Alternatively, it is possible to turn on registry versioning in API Manager 3.0.0 and continue. But this is
     highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
-!!! info "Turning off registry versioning in your current API-M and running the scripts"
+!!! info "Verifying registry versioning is turned on in your current API-M and running the scripts"
     Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
     Check whether `versioningProperties`, `versioningComments`, `versioningTags` and `versioningRatings` configurations are true.
     

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
@@ -17,14 +17,13 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.0.0.
 
-Therefore, when migrating to API Manager 3.0.0, it is **required** to turn off the registry versioning in your
-current API Manager 2.6.0 version and run the below scripts against **the database that is used by the registry**.
+Therefore, when migrating to API Manager 3.0.0, it is **required** to run the below scripts against **the database that is used by the registry**.
 
 !!! note "NOTE"
     Alternatively, it is possible to turn on registry versioning in API Manager 3.0.0 and continue. But this is
     highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
-!!! info "Turning off registry versioning in your current API-M and running the scripts"
+!!! info "Verifying registry versioning is turned on in your current API-M and running the scripts."
     Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
     Check whether `versioningProperties`, `versioningComments`, `versioningTags` and `versioningRatings` configurations are true.
     


### PR DESCRIPTION
## Purpose
>  As we are running the DB scripts against the backup Dbs it is not required to Turn off the Registry versioning in the old APIM version, these statements in the document might be confusing to the users.

## Goal
> Remove 'Turning off registry versioning' steps for the old APIM version.

Issue : https://github.com/wso2/docs-apim/issues/1403