### PR TITLE
[3.1.0] Adding the section on "Configure the dynamic callback origin" in reverse proxy related documentation

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer.md
+++ b/en/docs/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer.md
@@ -476,3 +476,35 @@ proxyPort = 443
 [server]
 hostname = "sample.com"
 ```
+
+### Step 4 - Configure the dynamic callback origin
+
+When you have a custom URL configured for WSO2 API-M client applications (Publisher/ Developer Portal/ Admin Portal), the callback origin also has to be changed dynamically according to the X-Forwarded-For header in a typical scenario.
+
+1. Open the new configuration file for reverse proxy config in the react applications.
+
+    - **For Developer Portal**
+
+         Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/settings.js` file.
+    
+    - **For Publisher**
+        
+         Open the file `<API-M_HOME>/repository/deployment/server/jaggeryapps/publisher/site/public/conf/settings.js` file.
+    
+    - **For Admin Portal**
+        
+         Open the file `<API-M_HOME>/repository/deployment/server/jaggeryapps/admin/site/public/conf/settings.js` file.
+ 
+
+2. Set `customUrl.enabled` to `true`
+  
+    ```json
+        
+    customUrl: { // Dynamically set the redirect origin according to the forwardedHeader host|proxyPort combination
+        enabled: true,
+        forwardedHeader: 'X-Forwarded-For',
+    },
+    ```
+
+    !!! Note
+        New configurations do not have auto as a config value for the `customUrl.enable` property as it was in the 2.x versions.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/1540

## Goals
Backporting https://github.com/isharac/docs-apim/commit/3d7cbca19fd4f6a11567a9e9bdbf9ce6b8c395b6

## Approach
Adding a new section named **Configure the dynamic callback origin** to the page **Configuring the Proxy Server and the Load Balancer** as shown below.
![screencapture-localhost-8000-install-and-setup-deploying-wso2-api-manager-configuring-the-proxy-server-and-the-load-balancer-2020-12-23-14_57_55](https://user-images.githubusercontent.com/25246848/102981880-a2150c80-452f-11eb-9bbf-12aa2579bd1b.png)