### PR TITLE
Revert "[3.0.0] Add authorization manager doc to mkdocs"

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -430,7 +430,6 @@ nav:
                     - Configuring a Read-Write Active Directory User Store: administer/product-administration/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-read-write-active-directory-user-store.md
                 - Configuring Secondary User Store: administer/product-administration/managing-users-and-roles/managing-user-stores/configuring-secondary-user-stores.md
                 - Writing a custom User Store Manager: administer/product-administration/managing-users-and-roles/managing-user-stores/writing-a-custom-user-store-manager.md
-                - Configuring the Authorization Manager: administer/managing-users-and-roles/managing-user-stores/configuring-the-authorization-manager.md
             - Multitenancy:
                   - Introduction to Multitenancy: administer/product-administration/multitenancy/introduction-to-multitenancy.md
                   - Managing Tenants: administer/product-administration/multitenancy/managing-tenants.md


### PR DESCRIPTION
Reverts wso2/docs-apim#2843

The path for 3.0.0 is incorrect. It should be 
{{base_path}}/administer/product-administration/managing-users-and-roles/managing-user-stores/configuring-the-authorization-manager