### PR TITLE
Remove unwanted migration replacements

### DIFF
--- a/en/docs/assets/attachments/install-and-setup/apim210_to_apim310_gateway_artifact_migrator_for_tenants.ps1
+++ b/en/docs/assets/attachments/install-and-setup/apim210_to_apim310_gateway_artifact_migrator_for_tenants.ps1
@@ -15,7 +15,6 @@ foreach ($file in $configFiles)
     Foreach-Object { $_ -replace "org.wso2.carbon.mediator.cache.digest.DOMHASHGenerator", "org.wso2.carbon.mediator.cache.digest.REQUESTHASHGenerator" } |
     Foreach-Object { $_ -replace "org.wso2.caching.digest.REQUESTHASHGenerator", "org.wso2.carbon.mediator.cache.digest.REQUESTHASHGenerator" } |
     Foreach-Object { $_ -replace "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`"/>", "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`">`n`t`t<property name=`"RemoveOAuthHeadersFromOutMessage`" value=`"true`"/>`n`t</handler>" } |
-    Foreach-Object { $_ -replace "org.wso2.carbon.apimgt.usage.publisher.APIMgtResponseHandler", "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtResponseHandler" } |
     Set-Content $file.PSPath
 }
 

--- a/en/docs/assets/attachments/install-and-setup/apim220_to_apim310_gateway_artifact_migrator_for_tenants.ps1
+++ b/en/docs/assets/attachments/install-and-setup/apim220_to_apim310_gateway_artifact_migrator_for_tenants.ps1
@@ -13,7 +13,6 @@ foreach ($file in $configFiles)
 {
     (Get-Content $file.PSPath) |    
     Foreach-Object { $_ -replace "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`"/>", "<handler class=`"org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler`">`n`t`t<property name=`"RemoveOAuthHeadersFromOutMessage`" value=`"true`"/>`n`t</handler>" } |
-    Foreach-Object { $_ -replace "org.wso2.carbon.apimgt.usage.publisher.APIMgtResponseHandler", "org.wso2.carbon.apimgt.gateway.handlers.analytics.APIMgtResponseHandler" } |
     Set-Content $file.PSPath
 }
 


### PR DESCRIPTION
### Purpose
As $subject, this removes the unwanted migration handlers in the migration scripts.





