### PR TITLE
Updating the APICTL documentation on Applications Export/Import with --format flag and fixing inconsistencies

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
@@ -159,10 +159,8 @@ You can import an application to your environment as a zipped application. When 
         !!!note
             `apictl import-app` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl import app` as shown above.
 
-    -   Response
-        ``` java
-        ZipFilePath: /Users/kim/.wso2apictl/exported/apps/dev/admin_SampleApp.zip
-        Completed importing the Application 'dev/admin_SampleApp.zip'
+    -   **Response**
+        ``` bash
         Succesfully imported Application!
         ```
 

--- a/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
@@ -88,7 +88,7 @@ You can export an application in the Developer Portal and download it as a zippe
 
 The exported application zipped file will be as follows:
 ```bash
-<Application-owner>_<Application-Name>.zip         
+<Application-owner>_<Application-name>.zip         
  └── application.yaml        
 ```
 

--- a/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/migrating-applications-to-different-environments.md
@@ -57,7 +57,8 @@ You can export an application in the Developer Portal and download it as a zippe
                 `--owner` or `-o` : Owner of the application to be exported          
                 `--environment` or `-e` : Environment to which the application should be exported  
             -   Optional :  
-                `--withKeys` : Export keys for the application         
+                `--withKeys` : Export keys for the application    
+                `--format` : File format of exported archive (JSON or YAML). The default value is YAML.     
 
         !!! example
             ```go
@@ -73,16 +74,22 @@ You can export an application in the Developer Portal and download it as a zippe
         !!!note
             `apictl export-app` command has been depcrecated from the API Controller 4.0.0 onwards. Instead use `apictl export app` as shown above.
 
-    -   Response
-        ``` java
+    -   **Response**
+
+        ``` bash tab="Response Format"
+        Successfully exported Application!
+        Find the exported Application at <USER_HOME>/.wso2apictl/exported/apps/<envrionment-name>/<Application-owner>_<Application-name>.zip
+        ```
+
+        ``` bash tab="Example Response"
         Successfully exported Application!
         Find the exported Application at /Users/kim/.wso2apictl/exported/apps/dev/admin_SampleApp.zip
         ```
 
 The exported application zipped file will be as follows:
 ```bash
-<exported-Application>.zip              
- └── <Application-Name>.json        
+<Application-owner>_<Application-Name>.zip         
+ └── application.yaml        
 ```
 
 ## Import an application


### PR DESCRIPTION
## Purpose
The documentation should have the usage of the newly introduced flag (--format) when exporting an application. Also, there were some inconsistencies in the responses of exporting and importing an Application. Those will be fixed with this as well.

## Goals
Update the --format flag usage when exporting an Application and fix inconsistencies of the responses of export/import Applications. 

## Approach
- Introduced the --format flag as shown below.
  ![image](https://user-images.githubusercontent.com/25246848/103858892-285c5180-50df-11eb-9359-2793495e941d.png)
- Updated the file structure of an exported Application as below.
  ![image](https://user-images.githubusercontent.com/25246848/103858999-50e44b80-50df-11eb-92ed-6a93fdc2ffaf.png)
- Updated the export response as below.
  ![image](https://user-images.githubusercontent.com/25246848/103859063-6b1e2980-50df-11eb-9243-840c23419574.png)
  ![image](https://user-images.githubusercontent.com/25246848/103859097-77a28200-50df-11eb-816e-3c592ff78507.png)
- Updated the import response as below.
  ![image](https://user-images.githubusercontent.com/25246848/103859182-9acd3180-50df-11eb-951f-54309389263c.png)

## User stories
Users can refer to the documentation to have an understanding of the new file structure of exported Applications and the usage of the --format flag.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/9533
- https://github.com/wso2/product-apim-tooling/pull/567