### PR TITLE
Add documentation for the support to override subscription policies of an API using the api_params.yaml

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -105,9 +105,10 @@ Instead of the default `api_params.yaml`, you can a provide custom parameter fil
 
 !!! info
     -   Production/Sandbox backends for each environment can be specified in the parameter file with additional configurations, such as timeouts.
-    -   Under the security field, if the `enabled` attribute is `true`, you must specify the `username`, `password` and the `type` (can be either only `basic` or `digest`). If the `enabled` attribute is `false`, then non of the security parameters will be set. If the `enabled` attribute is not set (blank), then the security parameters in api.yaml file will be considered.
+    -   Under the `security` field, if the `enabled` attribute is `true`, you must specify the `username`, `password` and the `type` (can be either only `basic` or `digest`). If the `enabled` attribute is `false`, then non of the security parameters will be set. If the `enabled` attribute is not set (blank), then the security parameters in api.yaml file will be considered.
     -   The parameter file supports detecting environment variables during the API import process. You can use the usual notation. For example, `url: $DEV_PROD_URL`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
     - To learn about setting up different endpoint types such as HTTP/REST, HTTP/SOAP (with load balancing and failover), Dynamic and AWS Lambda, see [Configuring Different Endpoint Types]({{base_path}}/learn/api-controller/advanced-topics/configuring-different-endpoint-types).
+    - You can define the subscription level policies of an API using the field `policies`. There you can specify one or more subscription level policies that is available in the particular environment where you are importing the API to.
 
 !!! note
 

--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -32,12 +32,12 @@ environments:
             - <gateway_environment_name>           
         certs:
             - hostName: <endpoint_url>
-                alias: <certificate_alias>
-                path: <certificate_name>
+              alias: <certificate_alias>
+              path: <certificate_name>
         mutualSslCerts:
             - tierName: <subscription_tier_name>
-                alias: <certificate_alias>
-                path: <certificate_name>
+              alias: <certificate_alias>
+              path: <certificate_name>
 ```
 The following code snippet contains sample configuration of the parameter file.
 

--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -38,6 +38,9 @@ environments:
             - tierName: <subscription_tier_name>
               alias: <certificate_alias>
               path: <certificate_name>
+        policies:
+            - <subscription_policy_1_name>
+            - <subscription_policy_2_name>
 ```
 The following code snippet contains sample configuration of the parameter file.
 
@@ -59,7 +62,10 @@ The following code snippet contains sample configuration of the parameter file.
                   alias: Dev
                   path: dev.crt 
             gatewayEnvironments:
-                - Production and Sandbox    
+                - Production and Sandbox   
+            policies:
+                - Gold
+                - Silver 
         - name: test
           configs:
             endpoints:


### PR DESCRIPTION
## Purpose
The documentation should be added for the improvement done in [1]

## Goals
The usage of **policies** field that can be used to specify the subscription level policies of an API should be added to the APICTL docs.

## Approach
- Format of the api_params.yaml has been updated with the **policies** field as shown below.
  ![image](https://user-images.githubusercontent.com/25246848/103911936-adba2300-512c-11eb-8f8d-fb7a37f455af.png)
- Sample api_params.yaml has been updated by adding an example for the field **policies**.
  ![image](https://user-images.githubusercontent.com/25246848/103912065-d8a47700-512c-11eb-8e05-da56030eb1c0.png)
- An explanation has been added to specify the usage of the **policies** field.
  ![image](https://user-images.githubusercontent.com/25246848/103912191-fbcf2680-512c-11eb-8976-97f499247ad2.png)

## User stories
- If **policies** parameter is set in api_params.yaml file, override the values in api.yaml file.
- If **policies** parameter is not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/9537

[1] https://github.com/wso2/carbon-apimgt/pull/9537