### PR TITLE
[3.2.0] Update Oracle migration DB scripts with COMMIT keyword

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-320.md
@@ -249,6 +249,8 @@ versioning in the migrated 3.2.0 setup. Follow the instructions below to disable
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -3651,6 +3653,8 @@ Follow the instructions below to move all the existing API Manager configuration
                     SCOPE_BINDING VARCHAR2(255) NOT NULL,
                     BINDING_TYPE VARCHAR2(255) NOT NULL,
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
+        /
+        COMMIT;
         /       
         ```
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
@@ -248,6 +248,8 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.0.0 setup, it is *
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -2374,6 +2376,8 @@ Follow the instructions below to move all the existing API Manager configuration
                     SCOPE_BINDING VARCHAR2(255) NOT NULL,
                     BINDING_TYPE VARCHAR2(255) NOT NULL,
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
+        /
+        COMMIT;
         /
         ```
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
@@ -247,6 +247,8 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.1.0 setup, it is *
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -2287,6 +2289,8 @@ Follow the instructions below to move all the existing API Manager configuration
                     SCOPE_BINDING VARCHAR2(255) NOT NULL,
                     BINDING_TYPE VARCHAR2(255) NOT NULL,
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
+        /
+        COMMIT;
         /
         ```
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
@@ -247,6 +247,8 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.2.0 setup, it is *
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -2086,6 +2088,8 @@ Follow the instructions below to move all the existing API Manager configuration
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
         /
         DELETE FROM IDN_OAUTH2_SCOPE_BINDING WHERE SCOPE_BINDING IS NULL
+        /
+        COMMIT;
         /        
         ```
         

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
@@ -247,6 +247,8 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.5.0 setup, it is *
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -1927,6 +1929,8 @@ Follow the instructions below to move all the existing API Manager configuration
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
         /  
         DELETE FROM IDN_OAUTH2_SCOPE_BINDING WHERE SCOPE_BINDING IS NULL
+        /
+        COMMIT;
         /              
         ```
         
@@ -2795,6 +2799,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
         ```tab="Oracle"
         ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
         ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        COMMIT;
         ```
             
         ```tab="PostgreSQL"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
@@ -248,6 +248,8 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.6.0 setup, it is *
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /    
         ```
         
         ```tab="PostgreSQL"
@@ -2294,6 +2296,8 @@ Follow the instructions below to move all the existing API Manager configuration
         /
         DELETE FROM IDN_OAUTH2_SCOPE_BINDING WHERE SCOPE_BINDING IS NULL
         /
+        COMMIT;
+        /    
         ```
         
         ```tab="PostgreSQL"
@@ -2939,6 +2943,7 @@ Upgrade the WSO2 API Manager Analytics database from version 2.6.0 to version 3.
     ```tab="Oracle"
     ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
     ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+    COMMIT;
     ```
         
     ```tab="PostgreSQL"
@@ -3040,6 +3045,8 @@ data related to alerts by dropping this table.
       END IF;
     END;
     /
+    COMMIT;
+    /    
     ```
     
     ```tab="PostgreSQL"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
@@ -248,6 +248,8 @@ But, if registry versioning was enabled by you in WSO2 API-M 3.0.0 setup, it is 
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -1255,7 +1257,9 @@ Follow the instructions below to move all the existing API Manager configuration
                     FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
         /
         DELETE FROM IDN_OAUTH2_SCOPE_BINDING WHERE SCOPE_BINDING IS NULL
-        /        
+        /  
+        COMMIT;
+        /      
         ```
         
         ```tab="PostgreSQL"
@@ -1657,6 +1661,7 @@ Upgrade the WSO2 API Manager Analytics database from version 3.0.0 to version 3.
     ```tab="Oracle"
     ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
     ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+    COMMIT;
     ```
         
     ```tab="PostgreSQL"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
@@ -248,6 +248,8 @@ But, if registry versioning was enabled by you in WSO2 API-M 3.1.0 setup, it is 
         /
         UPDATE REG_RESOURCE_RATING SET REG_RESOURCE_RATING.REG_RESOURCE_NAME=(SELECT REG_RESOURCE.REG_NAME FROM REG_RESOURCE WHERE REG_RESOURCE.REG_VERSION=REG_RESOURCE_RATING.REG_VERSION)
         /
+        COMMIT;
+        /
         ```
         
         ```tab="PostgreSQL"
@@ -1114,7 +1116,9 @@ Follow the instructions below to move all the existing API Manager configuration
             FOREIGN KEY (SCOPE_ID) REFERENCES AM_SCOPE(SCOPE_ID) ON DELETE CASCADE)
         /
         DELETE FROM IDN_OAUTH2_SCOPE_BINDING WHERE SCOPE_BINDING IS NULL
-        /        
+        / 
+        COMMIT;
+        /       
         ```
         
         ```tab="PostgreSQL"


### PR DESCRIPTION
## Purpose
Each DB script section provides DB scripts for multiple DB types, including Oracle.

In Oracle, the default behavior is we need to explicitly commit the transactions.
Therefore,  add `COMMIT; `command at the end of the script in order to explicitly commit the transactions.
This change has been added to all the Oracle DB scripts.


## Goals
Update Oracle Database scripts 

## Approach
![Screenshot from 2021-01-20 11-32-19](https://user-images.githubusercontent.com/42435576/105133909-8a6f7a80-5b13-11eb-8e34-66254741464b.png)
