### PR TITLE
[3.2.0] Remove invalid step from Managing the growth of Carbon logs section

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/managing-log-growth.md
+++ b/en/docs/administer/logging-and-monitoring/logging/managing-log-growth.md
@@ -27,14 +27,8 @@ Log growth in [Carbon logs]({{base_path}}/administer/product-administration/moni
            ``` toml
            appender.CARBON_LOGFILE.policies.time.modulate = false
            ```
-       
-    2.  Add following configuration to log4j2.properties file, in order to enable size based triggering policy.
-
-           ``` toml
-           appender.CARBON_LOGFILE.policies.size.modulate = true
-           ```
-           
-    3.  By default, the size limit of the log file is 10MB. You can change the default value using following configuration.
+         
+    2.  By default, the size limit of the log file is 10MB. You can change the default value using following configuration.
     
         ```toml
         appender.CARBON_LOGFILE.policies.size.size=<file_size_limit>
@@ -42,7 +36,7 @@ Log growth in [Carbon logs]({{base_path}}/administer/product-administration/moni
             
         If the size of the log file is exceeding the value defined in the `appender.CARBON_LOGFILE.policies.size.size` property, the content is copied to a backup file and the logs are continued to be added to a new empty log file.  
          
-    4.  Append timestamp(MM-dd-yyyy) to file pattern `appender.CARBON_LOGFILE.filePattern`. 
+    3.  Append timestamp(MM-dd-yyyy) to file pattern `appender.CARBON_LOGFILE.filePattern`. 
     
         !!!Note
             When file size based log rollover has been enabled, the timestamp should be appended to file pattern in order to differentiate the backup file names by time stamp. Unless, the current backup file will be replaced by the next backup which is created on the same day, since both file  will be having the same name(ie: wso2carbon-12-16-2019.log).


### PR DESCRIPTION
## Purpose
**Fixing problems with enabling the size based logging**
It is unnecessary to set "modulate" property to a size-based triggering policy. When the above property is set, it is trying to pass an invalid argument to a size-based triggering policy, which results in the error message above.
Therefore the step b in the section under Managing the growth of Carbon logs in the documentation[1] should be removed from the document and update according to that.

[1]. https://apim.docs.wso2.com/en/latest/administer/logging-and-monitoring/logging/managing-log-growth/#

## Goals
- Fixes #2940 
For 3.2.0 Docs space

## Approach
![screenshot-localhost-8000-administer-logging-and-monitoring-logging-managing-log-growth-1611204720088](https://user-images.githubusercontent.com/42435576/105284317-367a9980-5bd8-11eb-996b-bdb847f60fa1.png)

## User stories
> Summary of user stories addressed by this change>

