### PR TITLE
[3.1.0] Fixing #2939 and #2940 issues.

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/managing-log-growth.md
+++ b/en/docs/administer/logging-and-monitoring/logging/managing-log-growth.md
@@ -27,14 +27,8 @@ Log growth in [Carbon logs]({{base_path}}/administer/product-administration/moni
            ``` toml
            appender.CARBON_LOGFILE.policies.time.modulate = false
            ```
-       
-    2.  Add following configuration to log4j2.properties file, in order to enable size based triggering policy.
-
-           ``` toml
-           appender.CARBON_LOGFILE.policies.size.modulate = true
-           ```
            
-    3.  By default, the size limit of the log file is 10MB. You can change the default value using following configuration.
+    2.  By default, the size limit of the log file is 10MB. You can change the default value using following configuration.
     
         ```toml
         appender.CARBON_LOGFILE.policies.size.size=<file_size_limit>
@@ -42,7 +36,7 @@ Log growth in [Carbon logs]({{base_path}}/administer/product-administration/moni
             
         If the size of the log file is exceeding the value defined in the `appender.CARBON_LOGFILE.policies.size.size` property, the content is copied to a backup file and the logs are continued to be added to a new empty log file.  
          
-    4.  Append timestamp(MM-dd-yyyy) to file pattern `appender.CARBON_LOGFILE.filePattern`. 
+    3.  Append timestamp(MM-dd-yyyy) to file pattern `appender.CARBON_LOGFILE.filePattern`. 
     
         !!!Note
             When file size based log rollover has been enabled, the timestamp should be appended to file pattern in order to differentiate the backup file names by time stamp. Unless, the current backup file will be replaced by the next backup which is created on the same day, since both file  will be having the same name(ie: wso2carbon-12-16-2019.log).

--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -149,7 +149,6 @@ When using WSO2 API-M Analytics 3.1.0, when publishing to an HA setup of APIM an
 </p>
 </div>
 </html>
-
 <html><div class="admonition info">
 <p class="admonition-title">Note</p>
 <p>If the <code>receiver_urls</code> property is configured in the  <code>[apim.analytics]</code> section , no need to configure the  
@@ -157,7 +156,6 @@ When using WSO2 API-M Analytics 3.1.0, when publishing to an HA setup of APIM an
 </p>
 </div>
 </html>
-
 </td>
 </tr>
 <tr class="odd">

--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -151,7 +151,7 @@ When using WSO2 API-M Analytics 3.1.0, when publishing to an HA setup of APIM an
 </html>
 <html><div class="admonition info">
 <p class="admonition-title">Note</p>
-<p>If the <code>receiver_urls</code> property is configured in the  <code>[apim.analytics]</code> section , no need to configure the  
+<p>If the <code>receiver_urls</code> property is configured in the <code>[apim.analytics]</code> section, you do not need to configure the  
    <code>[[apim.analytics.url_group]]</code> properties. Configuring either one of these properties is enough.
 </p>
 </div>
@@ -181,7 +181,7 @@ e.g., Two receiver groups with two load balanced receivers in each can be specif
 </p>
 <html><div class="admonition info">
 <p class="admonition-title">Note</p>
-<p>If the <code>[[apim.analytics.url_group]]</code> property group is configured in the  <code>[apim.analytics]</code> section , no need to configure the  <code>receiver_urls</code> properties. Configuring either one of these properties is enough.
+<p>If the <code>[[apim.analytics.url_group]]</code> property group is configured in the <code>[apim.analytics]</code> section, you do no need to configure the  <code>receiver_urls</code> properties. Configuring either one of these properties is enough.
 </p>
 </div>
 </html>

--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -149,6 +149,15 @@ When using WSO2 API-M Analytics 3.1.0, when publishing to an HA setup of APIM an
 </p>
 </div>
 </html>
+
+<html><div class="admonition info">
+<p class="admonition-title">Note</p>
+<p>If the <code>receiver_urls</code> property is configured in the  <code>[apim.analytics]</code> section , no need to configure the  
+   <code>[[apim.analytics.url_group]]</code> properties. Configuring either one of these properties is enough.
+</p>
+</div>
+</html>
+
 </td>
 </tr>
 <tr class="odd">
@@ -172,6 +181,12 @@ e.g., Two receiver groups with two load balanced receivers in each can be specif
 </code>
 <br/>If the type is not specified it defaults to the fail over.
 </p>
+<html><div class="admonition info">
+<p class="admonition-title">Note</p>
+<p>If the <code>[[apim.analytics.url_group]]</code> property group is configured in the  <code>[apim.analytics]</code> section , no need to configure the  <code>receiver_urls</code> properties. Configuring either one of these properties is enough.
+</p>
+</div>
+</html>
 </td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
## Purpose

**Fixing problems with enabling the size based logging**
It is unnecessary to set "modulate" property to a size-based triggering policy. When the above property is set, it is trying to pass an invalid argument to a size-based triggering policy, which results in the error message above.
Therefore the step b in the section under Managing the growth of Carbon logs in the documentation[1] should be removed from the document and update according to that.

**Modify the documentation for APIM analytics configurations**
In [2], It says to configure 'receiver_urls' and [[apim.analytics.url_group]] both in order to specify the URLs and not required to use both the properties. Therefore it is required to add notes stating this fact.


[1]. https://apim.docs.wso2.com/en/latest/administer/logging-and-monitoring/logging/managing-log-growth/#
[2]. https://apim.docs.wso2.com/en/3.1.0/learn/analytics/configuring-apim-analytics/

## Goals

- Fixes #2939 
- Fixes #2940 
For 3.1.0 Docs space

## Approach

### 2939 
![screenshot-localhost-8000-learn-analytics-configuring-apim-analytics-1611203617299](https://user-images.githubusercontent.com/42435576/105283353-4beec400-5bd6-11eb-8341-0a91fb9cdfd0.png)

### 2940

![screenshot-localhost-8000-administer-logging-and-monitoring-logging-managing-log-growth-1611204720088](https://user-images.githubusercontent.com/42435576/105283364-50b37800-5bd6-11eb-8170-cb824c471b1c.png)



> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.