### PR TITLE
[3.1.0] Fixing HA terminology in APIM Analytics

### DIFF
--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -151,7 +151,7 @@ When using WSO2 API-M Analytics 3.1.0, when publishing to an minimum HA setup of
 <p class="admonition-title">Note</p>
 <p>If the APIM analytics is setting up on an Active-active HA setup, the URLs should have defined with the <b>comma</b> separations, as the setup is configured with the load-balanced configurations.
 <br/><br/>
-When the APIM analytics is on an Active-passive HA setup, the URLs should be defined with <b>pipe</b> separations, as the setup is configured with failover configurations.
+When the APIM analytics is on an Active-passive HA setup, the URLs should be separated with <b>pipe symbol (|)</b>, as the setup is configured with failover configurations.
 </p>
 </div>
 </html>

--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -143,10 +143,18 @@ The server URL of the remote WSO2 API-M Analytics server used to collect statist
 <html><div class="admonition warning">
 <p class="admonition-title">From DAS to SI</p>
 <p>
-When using WSO2 API-M Analytics 3.1.0, when publishing to an HA setup of APIM analytics, you need to separate the Receiver URLs by the pipe symbol (|) because the analytics events are published in a failover manner where only one node handles the processing at any given time.
+When using WSO2 API-M Analytics 3.1.0, when publishing to an minimum HA setup of APIM analytics, you need to separate the Receiver URLs by the pipe symbol (|) because the analytics events are published in a failover manner where only one node handles the processing at any given time.
 <br/>e.g.,
 <br/><code>receiver_urls = "tcp://localhost:7612 | tcp://localhost:7613"</code>
 </p>
+<html><div class="admonition info">
+<p class="admonition-title">Note</p>
+<p>If the APIM analytics is setting up on an Active-active HA setup, the URLs should have defined with the <b>comma</b> separations, as the setup is configured with the load-balanced configurations.
+<br/><br/>
+When the APIM analytics is on an Active-passive HA setup, the URLs should be defined with <b>pipe</b> separations, as the setup is configured with failover configurations.
+</p>
+</div>
+</html>
 </div>
 </html>
 <html><div class="admonition info">
@@ -177,7 +185,17 @@ e.g., Two receiver groups with two load balanced receivers in each can be specif
 <br />analytics_url =["tcp://localhost:7712","tcp://localhost:7713"]
 <br/>type = "loadbalance"
 </code>
+<br/>
 <br/>If the type is not specified it defaults to the fail over.
+<br/><code>
+<br/>[[apim.analytics.url_group]]
+<br/>analytics_url =["tcp://localhost:7612"|"tcp://localhost:7613"]
+<br/>type = "failover"
+<br/>
+<br />[[apim.analytics.url_group]]
+<br />analytics_url =["tcp://localhost:7712"|"tcp://localhost:7713"]
+<br/>type = "failover"
+<code>
 </p>
 <html><div class="admonition info">
 <p class="admonition-title">Note</p>

--- a/en/docs/learn/analytics/configuring-apim-analytics.md
+++ b/en/docs/learn/analytics/configuring-apim-analytics.md
@@ -143,15 +143,15 @@ The server URL of the remote WSO2 API-M Analytics server used to collect statist
 <html><div class="admonition warning">
 <p class="admonition-title">From DAS to SI</p>
 <p>
-When using WSO2 API-M Analytics 3.1.0, when publishing to an minimum HA setup of APIM analytics, you need to separate the Receiver URLs by the pipe symbol (|) because the analytics events are published in a failover manner where only one node handles the processing at any given time.
+When using WSO2 API-M Analytics 3.1.0, when publishing to an minimum HA setup of APIM analytics, you need to separate the Receiver URLs by using a pipe symbol (|) because the analytics events are published in a failover manner where only one node handles the processing at any given time.
 <br/>e.g.,
 <br/><code>receiver_urls = "tcp://localhost:7612 | tcp://localhost:7613"</code>
 </p>
 <html><div class="admonition info">
 <p class="admonition-title">Note</p>
-<p>If the APIM analytics is setting up on an Active-active HA setup, the URLs should have defined with the <b>comma</b> separations, as the setup is configured with the load-balanced configurations.
+<p>If you are setting up APIM analytics on an Active-active HA setup, you need to define the URLs with <b>comma</b> separations, as the setup is configured with load-balanced configurations.
 <br/><br/>
-When the APIM analytics is on an Active-passive HA setup, the URLs should be separated with <b>pipe symbol (|)</b>, as the setup is configured with failover configurations.
+When you are configuring APIM analytics on an Active-passive HA setup, you should separate the URLs using the <b>pipe symbol (|)</b>, as the setup is configured with failover configurations.
 </p>
 </div>
 </html>


### PR DESCRIPTION
## Purpose
Correcting HA setup configuration by adding notes and config examples based on HA setup type.

## Goals
Fixes https://github.com/wso2/docs-apim/issues/2975 for 3.1.0

## Approach
![screenshot-localhost-8000-learn-analytics-configuring-apim-analytics-1611329078691](https://user-images.githubusercontent.com/42435576/105510509-bac23f00-5cf4-11eb-8df6-feb47d6ae68d.png)


![Screenshot from 2021-01-22 20-39-44](https://user-images.githubusercontent.com/42435576/105508099-fc9db600-5cf1-11eb-8b4c-a9aa5e240958.png)



## User stories
> Summary of user stories addressed by this change>

