### PR TITLE
Fixing the style issue with the title spacing

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1142,3 +1142,9 @@ html .md-footer-meta.md-typeset a,
   .algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content {
     background-color: #ffaa001f !important;
   }
+  .md-typeset .headerlink.localLink{
+    display: inline;    
+  }
+  .md-typeset h1 {
+      margin: 0 0 1rem;
+  }

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -43,7 +43,7 @@ theme:
         tabs: true
     language: 'en'
 #Breaks build if there's a warning
-strict: false
+strict: true
 # Navigation
 nav:
     - Welcome to WSO2 API Manager Documentation: index.md

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -43,7 +43,7 @@ theme:
         tabs: true
     language: 'en'
 #Breaks build if there's a warning
-strict: true
+strict: false
 # Navigation
 nav:
     - Welcome to WSO2 API Manager Documentation: index.md


### PR DESCRIPTION
## Purpose
Fixing the following issue 

The Issue with the following pic is a responsive issue where the "Permanent Link" icon drops to the second line when the text in the title takes up all the space in the first row, making the space between the title and the introduction section too much. 
<img width="1360" alt="Screen Shot 2021-01-22 at 10 28 29 PM" src="https://user-images.githubusercontent.com/3424539/105524991-6e7ffa80-5d06-11eb-893c-316d5a6ead03.png">

When we collapse out the right-hand side menu, the issue is no longer there.<img width="1327" alt="Screen Shot 2021-01-22 at 10 28 40 PM" src="https://user-images.githubusercontent.com/3424539/105525001-72ac1800-5d06-11eb-811a-766e59dc6961.png">

The solution for this is to make the icon behave like a text element so that it will take the last word with it to the second line. I think this will fix this issue in a responsive manner.
<img width="1362" alt="Screen Shot 2021-01-22 at 10 29 10 PM" src="https://user-images.githubusercontent.com/3424539/105525004-73dd4500-5d06-11eb-9dcb-28ed12d25771.png">
