### PR TITLE
[3.2.0] [PRSync] Added Basic Claims Configurations and Role configurations

### DIFF
--- a/en/docs/develop/customizations/log-in-to-the-dev-portal-using-social-media.md
+++ b/en/docs/develop/customizations/log-in-to-the-dev-portal-using-social-media.md
@@ -100,11 +100,24 @@ We need to acquire the identity information by configuring claims to use Authent
 
 4.  Select the **Define Custom Claim Dialect** option under **Select Claim mapping Dialect** and click **Add Claim Mapping** to add custom claim mappings as follows.
 
+    | Identity Provider Claim URI | Local Claim URI                     |
+    |-----------------------------|-------------------------------------|
+    | email                       | http://wso2.org/claims/emailaddress |
+    | name_format                 | http://wso2.org/claims/roles        |
+
+    Select **User ID Claim URL** as **email** from dropdown.
+
     ![Claim configuration for Facebook Login]({{base_path}}/assets/img/learn/claim-configuration-facebook.png)
 
     If you prefer to use the User ID as your first name of Facebook account, configure `first_name` claim as above. You need to select the same claim as **UserID Claim URI**.
 
-5.  The following are some common attribute names. You can map these names to any suitable **Local Claim URI**. (Local Claim is a set of standard claim values which are local to the WSO2 Identity Server)
+5. Add **Identitity Provide Roles** under **Role Configurations** as follows.
+
+    | Identity Provider Role      | Local Role                          |
+    |-----------------------------|-------------------------------------|
+    | {first}{last}               | Internal/subscriber                 |
+
+6.  The following are some common attribute names. You can map these names to any suitable **Local Claim URI**. (Local Claim is a set of standard claim values which are local to the WSO2 Identity Server)
     - `id`
     - `email`
     - `name`


### PR DESCRIPTION
## Purpose
Adding missing Basic Claims configurations and Role configurations in the **Log in to the Developer Portal using Social Media** section.

## Goals
PR Sync for https://github.com/wso2/docs-apim/pull/1385

## Approach
![screenshot-localhost-8000-develop-customizations-log-in-to-the-dev-portal-using-social-media-1611554617597](https://user-images.githubusercontent.com/42435576/105667765-ebc38f00-5f01-11eb-91d1-427ef603850d.png)

## User stories
> Summary of user stories addressed by this change>

