### PR TITLE
[3.0.0] Backporting MTSL related configs

### DIFF
--- a/en/docs/learn/api-security/api-authentication/secure-apis-using-mutual-ssl.md
+++ b/en/docs/learn/api-security/api-authentication/secure-apis-using-mutual-ssl.md
@@ -59,16 +59,41 @@ The below diagram shows how MutualSSL works in such an environment.
 
 ![]({{base_path}}/assets/img/learn/mtls-loadbalancer.png)
 
-By default, the WSO2 API Manager retrieves the client certificate from the **X-WSO2-CLIENT-CERTIFICATE** HTTP header. In order to change the header,
+### Using MTLS Header to invoke APIs secured with Mutual SSL
+
+By default, the WSO2 API Manager retrieves the client certificate from the **X-WSO2-CLIENT-CERTIFICATE** HTTP header. 
+
+Follow the instructions below to change the header:
 
 1.  Navigate to the `<API-M_HOME>/repository/conf/deployment.toml` file.
 2.  Configure the *certificate_header* under the [apimgt.mutual_ssl] configuration.
 
-    ```toml
-    [apimgt.mutual_ssl]
-    certificate_header = "<Header Name>"
-    # This property need to be true if MutualSSL connection established between load balancer and gateway.
-    enable_client_validation = false
+    ``` tab="Format"
+     [apimgt.mutual_ssl]
+     certificate_header = "<Header Name>"
+     # This property needs to be true if the MutualSSL connection is established between the load balancer and the Gateway.
+     enable_client_validation = false
+     #This property needs to be true if the certificate should be decoded when it is passed from the load balancer to the Gateway.
+     client_certificate_encode = false
+    ```
+    
+    ``` tab="Example"
+     [apimgt.mutual_ssl]
+     certificate_header = "SSL-CLIENT-CERT"
+     enable_client_validation = false
+     client_certificate_encode = false
     ```
 
 3.  Start the Server.
+4.  Invoke the API  with the custom header.
+
+    ``` bash tab="Format"
+    curl -k --location -X GET "<API_URL>" -H  "accept: application/json" -H  "Authorization: Bearer <access-token>" -H "<MTSL_Header_name>:<Certificate_Key>"
+    ```
+    
+    ``` bash tab="Example"
+    curl -k --location -X GET 'https://localhost:8243/test/1.0/foo' -H 'accept: applicaition/json' -H 'Authorization: Bearer 0ee9aa70-d631-3401-b152-521b431036ca' -H 'SSL-CLIENT-CERT: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURsakNDQW40Q0NRRDc2MUpWekluMGNUQU5CZ2txaGtpRzl3MEJBUXNGQURDQmpERUxNQWtHQTFVRUJoTUMKVTB3eEVEQU9CZ05WQkFnTUIxZGxjM1JsY200eEVEQU9CZ05WQkFjTUIwTnZiRzl0WW04eERUQUxCZ05WQkFvTQpCRmRUVHpJeEN6QUpCZ05WQkFzTUFrTlRNUkl3RUFZRFZRUUREQWxzYjJOaGJHaHZjM1F4S1RBbkJna3Foa2lHCjl3MEJDUUVXR25kaGRHaHpZV3hoYTI5eVlXeGxaMlZBWjIxaGFXd3VZMjl0TUI0WERUSXhNREV4TkRBME16VXoKTlZvWERUSXlNREV4TkRBME16VXpOVm93Z1l3eEN6QUpCZ05WQkFZVEFsTk1NUkF3RGdZRFZRUUlEQWRYWlhOMApaWEp1TVJBd0RnWURWUVFIREFkRGIyeHZiV0p2TVEwd0N3WURWUVFLREFSWFUwOHlNUXN3Q1FZRFZRUUxEQUpEClV6RVNNQkFHQTFVRUF3d0piRzlqWVd4b2IzTjBNU2t3SndZSktvWklodmNOQVFrQkZocDNZWFJvYzJGc1lXdHYKY21Gc1pXZGxRR2R0WVdsc0xtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQgpBTWMrRjhJblZmMzAwZ2FraTh2QUZ6cUFTSGNQV0xZalQ4dmMwOUs1TzZHRjgzaXpUa2F0UDFtYW1ydWlKL2VRCk1KL2VLVGhJdzR3MWEzS3Y4cjJwc3d2bWRjdjAzZnhRNis2aFh3Ykh5VUtHWFFwbVhtL3d5VE01NzRlR1cybXAKM2toTjlIdFV0SU5uS3BzSENLcFI3MFhGKzNrTTZleHJJNnRJUUpxdTdKM2t1OEdqRVI3R1Vma2trYXI1OGs3eApibEpIWG5URkdjWXJNSXAvcS9YUENqR0pGajhub2tNbjhnL0dWTExCVGFXSWJVa3E2ejRJYjk1dHNOd2thU1dhCnh6U2t3K3JIVkZLWnpPTlV1WTdKTk16Zkp6RkllZG5lY0U3c2Y0WnFIRlF6aUpVbW9qWklDMXp5bFdZdzQ4OEUKNUZvaU9xTWpHYTlUMXhXMUpOWTBab01DQXdFQUFUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFSZTdrcWZlbwpjd1htazRLWlBKMmlnaGY2VU9jc2dYSEZqMnVpQTNhSWMrd2xwREJpdkdCbDJHM2gxQXl6UFNtcVpYaUcvTGttCkg1dm43VUpGQXlQRVBlQ25HdWduTk5kZGpnSFp0SEdJLzdXcm1LTHdIOEU3TWdmSWJ6dk5Hd3ZXWmRrZi9DblcKNjNDYzhhTzJQMDhYd0dHU25JSDg2cWF6NEtvZUF1aFlCdHZyekNObERraTFjZ1E1bHczU0djU3dxMlB0eEd4cApvS0xWOUJYUzlVdUNJRDRrYjFqRUo3YlplTis0Z0pDbTVGTldUbWdhWXFDcjdERWIwRkhpWitLVnBsZzJZZ3ZYCkM2Z2ZrRm9NYTVJREwvWGVja0J0dFlITzFKcWUyMElRKy9kVHB4ZWE4RjE5aDVmeDRZWVlsRFhLWS8wRmxiRXoKZ1l2UGFIUnVKWnFlV1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=='
+    ```
+
+!!! note
+     The above MTLS flow described is specifically with the **Nginx** load balancer. When using a different ELB to configure the MTSL with SSL termination, please check the service provider's documentation and feature catalog and do the necessary configurations.

--- a/en/docs/learn/api-security/api-authentication/secure-apis-using-mutual-ssl.md
+++ b/en/docs/learn/api-security/api-authentication/secure-apis-using-mutual-ssl.md
@@ -96,4 +96,4 @@ Follow the instructions below to change the header:
     ```
 
 !!! note
-     The above MTLS flow described is specifically with the **Nginx** load balancer. When using a different ELB to configure the MTSL with SSL termination, please check the service provider's documentation and feature catalog and do the necessary configurations.
+     The MTLS flow described above uses the **Nginx** load balancer. When using a different ELB to configure the MTSL with SSL termination, refer the service provider's documentation and feature catalog to do the necessary configurations.


### PR DESCRIPTION
## Purpose

- Adding a note stating the flow is specifically designed for using SSL termination and MTSL with Nginx ELB. And other ELBs has to be configured accordingly.
- Add missing MutualSSL Configurations related to Certificate Headers.

## Goals
Fixes https://github.com/wso2/docs-apim/issues/3007 for 3.0.0 docs space
Backporting fix for https://github.com/wso2/docs-apim/issues/2935

## Approach

![screenshot-localhost-8000-learn-api-security-api-authentication-secure-apis-using-mutual-ssl-1611651691724](https://user-images.githubusercontent.com/42435576/105823505-3e28ac80-5fe3-11eb-8adf-df0e7d43ca6e.png)

![Screenshot from 2021-01-26 14-08-10](https://user-images.githubusercontent.com/42435576/105821269-aa55e100-5fe0-11eb-8736-8984357d3f7b.png)

