### PR TITLE
[Master] Remove DomainName property from JDBC user store configs

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-a-jdbc-user-store.md
@@ -93,7 +93,6 @@ You can either use the default configuration or you can change it in the followi
     AddUserToRoleSQL-openedge = "INSERT INTO UM_USER_ROLE (UM_USER_ID, UM_ROLE_ID, UM_TENANT_ID) SELECT UU.UM_ID, UR.UM_ID, ? FROM UM_USER UU, UM_ROLE UR WHERE UU.UM_USER_NAME=? AND UU.UM_TENANT_ID=? AND UR.UM_ROLE_NAME=? AND UR.UM_TENANT_ID=?"
     AddRoleToUserSQL-openedge = "INSERT INTO UM_USER_ROLE (UM_ROLE_ID, UM_USER_ID, UM_TENANT_ID) SELECT UR.UM_ID, UU.UM_ID, ? FROM UM_ROLE UR, UM_USER UU WHERE UR.UM_ROLE_NAME=? AND UR.UM_TENANT_ID=? AND UU.UM_USER_NAME=? AND UU.UM_TENANT_ID=?"
     AddUserPropertySQL-openedge = "INSERT INTO UM_USER_ATTRIBUTE (UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID) SELECT UM_ID, ?, ?, ?, ? FROM UM_USER WHERE UM_USER_NAME=? AND UM_TENANT_ID=?"
-    DomainName = "wso2.org"
     Description = "This is an external JDBC primary user store"
     UserCoreCacheTimeOut = 5
     ```


### PR DESCRIPTION
## Purpose
If the RDBMS primary user store is configured and when the DomainName under the [user_store.properties] in the deployement.toml file is added, the default primary user store domain name, PRIMARY, will be replaced with this new name. This will lead the user not to list the users in the carbon management console when the "ALL-USER-STORE-DOMAINS" is selected from the domains dropdown list.

Since there will be only one primary user store, there is no point in changing its name as no need to uniquely identify it. So changing the DomainName will create unwanted complexity to the deployment and even if we want to revert it back to the PRIMARY domain name it requires many DB level updates which are complicated and might lead to DB corruption. Therefore, removing the step to change the **DomainName** in the official documentation will prevent users from complicating this process.



## Goals
Fixes #2934 for 3.0.0

## Approach
![screenshot-apim-docs-wso2-com-en-latest-administer-managing-users-and-roles-managing-user-stores-configure-primary-user-store-configuring-a-jdbc-user-store-1611657415432](https://user-images.githubusercontent.com/42435576/105834964-2f48f680-5ff1-11eb-9350-155cb1522aef.png)


After Removing the property
![Screenshot from 2021-01-26 16-07-47](https://user-images.githubusercontent.com/42435576/105835024-42f45d00-5ff1-11eb-8e18-1b32a7b921f7.png)


## User stories
> Summary of user stories addressed by this change>

