### PR TITLE
Add changed related to OpenApi support.

### DIFF
--- a/en/docs/integrate/develop/advanced-development/using-swagger-for-apis.md
+++ b/en/docs/integrate/develop/advanced-development/using-swagger-for-apis.md
@@ -9,10 +9,8 @@ When you create a REST API artifact or a RESTful data service from WSO2 Integrat
 If your REST API is deployed, copy the following URLs (with your API details) to your browser:
 
 !!! Note
-    If you have a custom Swagger definition attached to the API, the following URLs will return the custom definition and not the default Swagger definition of the API.
-    
-!!! Note
-    When attaching, both swagger 2.0 and OpenAPI definitions can be used.     
+    -   If you have a custom Swagger definition attached to the API, the following URLs will return the custom definition and not the default Swagger definition of the API.
+    -   Both swagger 2.0 and OpenAPI definitions are supported as the custom swagger definition.     
 
 
 -   To access the `swagger.json` file, use the following URL:

--- a/en/docs/integrate/develop/advanced-development/using-swagger-for-apis.md
+++ b/en/docs/integrate/develop/advanced-development/using-swagger-for-apis.md
@@ -2,7 +2,7 @@
 
 API documentation is important to guide the users on what they can do using specific APIs. 
 
-When you create a REST API artifact or a RESTful data service from WSO2 Integration Studio, a default Swagger definition is generated. For [REST API]({{base_path}}/integrate/develop/creating-artifacts/creating-an-api) artifacts, you can also attach an additional custom Swagger definition for the API.
+When you create a REST API artifact or a RESTful data service from WSO2 Integration Studio, a default Swagger 3.0 (OpenAPI) definition is generated. For [REST API]({{base_path}}/integrate/develop/creating-artifacts/creating-an-api) artifacts, you can also attach an additional custom Swagger definition for the API.
 
 ## Swagger documents of API artifacts
 
@@ -10,6 +10,9 @@ If your REST API is deployed, copy the following URLs (with your API details) to
 
 !!! Note
     If you have a custom Swagger definition attached to the API, the following URLs will return the custom definition and not the default Swagger definition of the API.
+    
+!!! Note
+    When attaching, both swagger 2.0 and OpenAPI definitions can be used.     
 
 
 -   To access the `swagger.json` file, use the following URL:

--- a/en/docs/integrate/examples/data_integration/swagger-data-services.md
+++ b/en/docs/integrate/examples/data_integration/swagger-data-services.md
@@ -1,6 +1,6 @@
 # Using Swagger Documents of RESTful Data Services
 
-When RESTful resources are added to the data service, the Micro Integrator generates a corresponding swagger definition automatically. You can access this Swagger document by suffixing the service URL with `?swagger.json` or `?swagger.yaml` as shown below.
+When RESTful resources are added to the data service, the Micro Integrator generates a corresponding swagger 3.0 (OpenApi) definition automatically. You can access this Swagger document by suffixing the service URL with `?swagger.json` or `?swagger.yaml` as shown below.
 
 -   JSON format
 

--- a/en/docs/integrate/examples/rest_api_examples/publishing-a-swagger-api.md
+++ b/en/docs/integrate/examples/rest_api_examples/publishing-a-swagger-api.md
@@ -1,7 +1,6 @@
 # Publishing a Custom Swagger Document
 
-When you create a REST API, a default Swagger definition is automatically
-generated. You can access this Swagger document by suffixing the API URL
+When you create a REST API, by default a Swagger 3.0 (OpenApi) definition is generated automatically. You can access this Swagger document by suffixing the API URL
 with `?swagger.json` or `?swagger.yaml`. See [Using Swagger Documents]({{base_path}}/integrate/develop/advanced-development/using-swagger-for-apis) for more information.
 
 This example demonstrates how a custom Swagger definition is published for a REST API. 


### PR DESCRIPTION
## Purpose
> From APIM 4.0 onwards the default swagger version we expose from the
Micro integrator is swagger 3.0 (OpenApi)
Related to wso2/micro-integrator/issues/2043