### PR TITLE
Improve the consistency of the docs on Developer Portal Customizations

### DIFF
--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/customize-api-listing/change-default-view.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/customize-api-listing/change-default-view.md
@@ -1,22 +1,23 @@
 # Change Default View
 
-By default the API Listing view is a grid view. 
+By default the API Listing view is a grid view. You can follow the steps below to change the default API listing to a table view by configuring `defaultTheme.js`.
 
-Open `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor.
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
 
-The following configuration will change the default API listing to a table view.
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor.
 
-```js
-const Configurations = {
-    custom: {
-        defaultApiView: 'list',
-    },
-};
-```
+    You can add the following configuration to the `defaultTheme.js` to change the default API listing to a table view.
 
+    ```js
+    const Configurations = {
+        custom: {
+            defaultApiView: 'list',
+        },
+    };
+    ```
 
+    Changes done in the `defaultTheme.js` will be reflected directly in the developer portal. (It is not required to restart the server or rebuild the source code) 
 
-Changes done in the defaultTheme.js will be reflected directly in the devportal. ( It's not required to restart the server or rebuild the source code)
+2. Refresh the Developer Portal to view the changes.
 
-![{{base_path}}/assets/img/learn/change-default-view.png]({{base_path}}/assets/img/learn/change-default-view.png)
-
+    ![{{base_path}}/assets/img/learn/change-default-view.png]({{base_path}}/assets/img/learn/change-default-view.png)

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-banner.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-banner.md
@@ -1,16 +1,18 @@
 # Enable or Disable Banner
 
-The banner section is hidden by default. The banner section can use to show an announcement to developer portal users as follows. 
+The banner section is hidden by default. The banner section can be used to show an announcement to the developer portal users as follows. 
 
  ![enable or disable banner]({{base_path}}/assets/img/learn/enable-or-disable-banner.png) 
 
-You can show banner by changing themes.light.custom.banner.active to true as follows.
+You can show a banner by configuring the `defaultTheme.js` file.
 
-1. Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and set the `themes.light.custom.banner.active` attribute as true to show the banner.
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the `themes.light.custom.banner.active` attribute as `true` to show the banner.
 
 2. Refresh the Developer Portal to view the changes.
 
-### Following attributes available for banner.
+### The following attributes available for the banner
 
 ```js
 const Configurations = {

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-footer.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-footer.md
@@ -1,12 +1,14 @@
 # Enable or Disable Footer
 
-The footer section is visible by default. You can hide footer by changing themes.light.custom.footer.active to false as follows.
+The footer section is visible by default. You can hide the footer by configuring the `defaultTheme.js` file.
 
-1. Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and set the `themes.light.custom.footer.active` attribute as false to hide the footer.
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the `themes.light.custom.footer.active` attribute as `false` to hide the footer.
 
 2. Refresh the Developer Portal to view the changes.
 
-### Following attributes available for footer.
+### The following attributes are available for the footer
 
 ```js
 const Configurations = {

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-home-page.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-home-page.md
@@ -12,155 +12,159 @@ When the developer portal required to present corporate branding it’s a common
 
 ## Landing page configuration options
 
-Following JSON defines the look and feel and behavior of the landing page.
+1. Open  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file.
+   
+    Following JSON defines the look and feel and behavior of the landing page. You can set the attributes (components) such as `carousel`, `listByTag`, `parallax` and `contact` as shown in the below example. (Refer to the above screenshot to identify the components refered by the attribute names)
 
-<div>
-<div class="jsonTreeOutput"></div>
-<textarea class="jsonTreeInput" data-level="2">
-{
- "landingPage": {
-      "active": true,
-      "carousel": {
-        "active": true,
-        "slides": [
-          {
-            "src": "/site/public/images/landing/01.jpg",
-            "title": "Lorem <span>ipsum</span> dolor sit amet",
-            "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor."
+    <div>
+    <div class="jsonTreeOutput"></div>
+    <textarea class="jsonTreeInput" data-level="2">
+    {
+    "landingPage": {
+          "active": true,
+          "carousel": {
+            "active": true,
+            "slides": [
+              {
+                "src": "/site/public/images/landing/01.jpg",
+                "title": "Lorem <span>ipsum</span> dolor sit amet",
+                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor."
+              },
+              {
+                "src": "/site/public/images/landing/02.jpg",
+                "title": "Curabitur <span>malesuada</span> arcu sapien",
+                "content": "Curabitur malesuada arcu sapien, suscipit egestas purus efficitur vitae. Etiam vulputate hendrerit venenatis. "
+              },
+              {
+                "src": "/site/public/images/landing/03.jpg",
+                "title": "Nam vel ex <span>feugiat</span> nunc laoreet",
+                "content": "Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam."
+              }
+            ]
           },
-          {
-            "src": "/site/public/images/landing/02.jpg",
-            "title": "Curabitur <span>malesuada</span> arcu sapien",
-            "content": "Curabitur malesuada arcu sapien, suscipit egestas purus efficitur vitae. Etiam vulputate hendrerit venenatis. "
+          "listByTag": {
+            "active": true,
+            "content": [
+              {
+                "tag": "finance",
+                "title": "Checkout our Finance APIs",
+                "description": "We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.",
+                "maxCount": 5
+              },
+              {
+                "tag": "weather",
+                "title": "Checkout our Weather APIs",
+                "description": "We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.",
+                "maxCount": 5
+              }
+            ]
           },
-          {
-            "src": "/site/public/images/landing/03.jpg",
-            "title": "Nam vel ex <span>feugiat</span> nunc laoreet",
-            "content": "Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam."
+          "parallax": {
+            "active": true,
+            "content": [
+              {
+                "src": "/site/public/images/landing/parallax1.jpg",
+                "title": "Lorem <span>ipsum</span> dolor sit amet",
+                "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor."
+              },
+              {
+                "src": "/site/public/images/landing/parallax2.jpg",
+                "title": "Nam vel ex <span>feugiat</span> nunc laoreet",
+                "content": "Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam."
+              }
+            ]
+          },
+          "contact": {
+            "active": true
           }
-        ]
-      },
-      "listByTag": {
-        "active": true,
-        "content": [
-          {
-            "tag": "finance",
-            "title": "Checkout our Finance APIs",
-            "description": "We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.",
-            "maxCount": 5
-          },
-          {
-            "tag": "weather",
-            "title": "Checkout our Weather APIs",
-            "description": "We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.",
-            "maxCount": 5
-          }
-        ]
-      },
-      "parallax": {
-        "active": true,
-        "content": [
-          {
-            "src": "/site/public/images/landing/parallax1.jpg",
-            "title": "Lorem <span>ipsum</span> dolor sit amet",
-            "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor."
-          },
-          {
-            "src": "/site/public/images/landing/parallax2.jpg",
-            "title": "Nam vel ex <span>feugiat</span> nunc laoreet",
-            "content": "Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam."
-          }
-        ]
-      },
-      "contact": {
-        "active": true
-      }
-    }}
-</textarea>
-</div>
+        }}
+    </textarea>
+    </div>
 
-``` js
-const Configurations = {
-    custom: {
-        landingPage: {
-            active: true,
-            carousel: {
+    ``` js
+    const Configurations = {
+        custom: {
+            landingPage: {
                 active: true,
-                slides: [
-                    {
-                        src: '/site/public/images/landing/01.jpg',
-                        title: 'Lorem <span>ipsum</span> dolor sit amet',
-                        content:
-                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor.',
-                    },
-                    {
-                        src: '/site/public/images/landing/02.jpg',
-                        title: 'Curabitur <span>malesuada</span> arcu sapien',
-                        content:
-                            'Curabitur malesuada arcu sapien, suscipit egestas purus efficitur vitae. Etiam vulputate hendrerit venenatis. ',
-                    },
-                    {
-                        src: '/site/public/images/landing/03.jpg',
-                        title: 'Nam vel ex <span>feugiat</span> nunc laoreet',
-                        content:
-                            'Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam.',
-                    },
-                ],
-            },
-            listByTag: {
-                active: true,
-                content: [
-                    {
-                        tag: 'finance',
-                        title: 'Checkout our Finance APIs',
-                        description:
-                            'We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.',
-                        maxCount: 5,
-                    },
-                    {
-                        tag: 'weather',
-                        title: 'Checkout our Weather APIs',
-                        description:
-                            'We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.',
-                        maxCount: 5,
-                    },
-                ],
-            },
-            parallax: {
-                active: true,
-                content: [
-                    {
-                        src: '/site/public/images/landing/parallax1.jpg',
-                        title: 'Lorem <span>ipsum</span> dolor sit amet',
-                        content:
-                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor.',
-                    },
-                    {
-                        src: '/site/public/images/landing/parallax2.jpg',
-                        title: 'Nam vel ex <span>feugiat</span> nunc laoreet',
-                        content:
-                            'Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam.',
-                    },
-                ],
-            },
-            contact: {
-                active: true,
+                carousel: {
+                    active: true,
+                    slides: [
+                        {
+                            src: '/site/public/images/landing/01.jpg',
+                            title: 'Lorem <span>ipsum</span> dolor sit amet',
+                            content:
+                                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor.',
+                        },
+                        {
+                            src: '/site/public/images/landing/02.jpg',
+                            title: 'Curabitur <span>malesuada</span> arcu sapien',
+                            content:
+                                'Curabitur malesuada arcu sapien, suscipit egestas purus efficitur vitae. Etiam vulputate hendrerit venenatis. ',
+                        },
+                        {
+                            src: '/site/public/images/landing/03.jpg',
+                            title: 'Nam vel ex <span>feugiat</span> nunc laoreet',
+                            content:
+                                'Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam.',
+                        },
+                    ],
+                },
+                listByTag: {
+                    active: true,
+                    content: [
+                        {
+                            tag: 'finance',
+                            title: 'Checkout our Finance APIs',
+                            description:
+                                'We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.',
+                            maxCount: 5,
+                        },
+                        {
+                            tag: 'weather',
+                            title: 'Checkout our Weather APIs',
+                            description:
+                                'We offers online payment solutions and has more than 123 million customers worldwide. The WSO2 Finane API makes powerful functionality available to developers by exposing various features of our platform. Functionality includes but is not limited to invoice management, transaction processing and account management.',
+                            maxCount: 5,
+                        },
+                    ],
+                },
+                parallax: {
+                    active: true,
+                    content: [
+                        {
+                            src: '/site/public/images/landing/parallax1.jpg',
+                            title: 'Lorem <span>ipsum</span> dolor sit amet',
+                            content:
+                                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer felis lacus, placerat vel condimentum in, porta a urna. Suspendisse dolor diam, vestibulum at molestie dapibus, semper eget ex. Morbi sit amet euismod tortor.',
+                        },
+                        {
+                            src: '/site/public/images/landing/parallax2.jpg',
+                            title: 'Nam vel ex <span>feugiat</span> nunc laoreet',
+                            content:
+                                'Nam vel ex feugiat nunc laoreet elementum. Duis sed nibh condimentum, posuere risus a, mollis diam. Vivamus ultricies, augue id pulvinar semper, mauris lorem bibendum urna, eget tincidunt quam ex ut diam.',
+                        },
+                    ],
+                },
+                contact: {
+                    active: true,
+                },
             },
         },
-    },
-};
+    };
 
-```
+    ```
 
-| Option | type | Values | Description |
-| ------ | -- | ----------- | ----------- |
-| active | boolean | true, false | If true the feature is enabled. If false(default), the feature is disabled  |
-| carousel.active | boolean | true, false | If true( default ) the carousel section is visible. If false carousel section is hidden. |
-| carousel.slides | array | |  Provide the content for the carousel animation at the page top. Slide is a json of following format. {src: 'path-to-slide-image/image.png', title: 'Title text with <span>special text</span>',content:'Slide description' }  |
-| listByTag.active | boolean | true, false | If true( default ) the listByTag section is visible. If false listByTag section is hidden. |
-listByTag.content | array | | Provide the content for the API grouping. It's an array of JSON where the JSON of following format. { tag: 'tag-name', title: 'Title for tag-name', description: '', maxCount: 5 } .|
-| parallax.active | boolean | true, false | If true( default ) the parallax scrolling section is visible. If false parallax scrolling section is hidden. |
-| contact.active | boolean | true, false | If true( default ) the contact us section is visible. If false contact us section is hidden. |  
+    | Option | type | Values | Description |
+    | ------ | -- | ----------- | ----------- |
+    | active | boolean | true, false | If true the feature is enabled. If false(default), the feature is disabled  |
+    | carousel.active | boolean | true, false | If true( default ) the carousel section is visible. If false carousel section is hidden. |
+    | carousel.slides | array | |  Provide the content for the carousel animation at the page top. Slide is a json of following format. {src: 'path-to-slide-image/image.png', title: 'Title text with <span>special text</span>',content:'Slide description' }  |
+    | listByTag.active | boolean | true, false | If true( default ) the listByTag section is visible. If false listByTag section is hidden. |
+    listByTag.content | array | | Provide the content for the API grouping. It's an array of JSON where the JSON of following format. { tag: 'tag-name', title: 'Title for tag-name', description: '', maxCount: 5 } .|
+    | parallax.active | boolean | true, false | If true( default ) the parallax scrolling section is visible. If false parallax scrolling section is hidden. |
+    | contact.active | boolean | true, false | If true( default ) the contact us section is visible. If false contact us section is hidden. |  
+
+2. Refresh the Developer Portal to view the changes.  
 
 The landing page provides a headstart for developers who tries to rebrand the devportal for their needs. If the requirements are much complicated, then you need to override the relevant components. The step to override only specific react components can be found [here]({{base_path}}/reference/customize-product/customizations/advanced-ui-customization/) .
 

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-home-page.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-home-page.md
@@ -1,20 +1,22 @@
 # Enable or Disable Home Page
 
-When the developer portal required to present corporate branding it’s a common requirement to have a landing page. The default landing page is the API listing page. But when we enable home page, there will be an additional landing page. It can be customized based on the design requirements. 
+It is a common requirement to have a Landing Page if the developer portal is required to present corporate branding. The default Landing Page is the API listing page. But when we enable the Home Page, there will be an additional Landing Page. It can be customized based on the design requirements by configuring the `defaultTheme.js` file.
 
-### The home page has four sections.
-1. carousel
-2. First Description and the listing of APIs filtered by a given tag ( provided via the theme file ).
-3. Second description and the listing of APIs filtered by a given tag ( provided via the theme file ).
-4. Contact us section
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+### The Home Page has Four Sections
+1. Carousel
+2. First Description and the listing of APIs filtered by a given tag (provided via the theme file)
+3. Second description and the listing of APIs filtered by a given tag (provided via the theme file)
+4. "Contact Us" section
 
  ![enable or disable home page]({{base_path}}/assets/img/learn/enable-or-disable-home-page.png) 
 
-## Landing page configuration options
+## Steps to Configure the Landing Page
 
-1. Open  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file.
-   
-    Following JSON defines the look and feel and behavior of the landing page. You can set the attributes (components) such as `carousel`, `listByTag`, `parallax` and `contact` as shown in the below example. (Refer to the above screenshot to identify the components refered by the attribute names)
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the attributes accordingly.
+
+    Following JSON is an example for a `defaultTheme.js` to define the look and feel, and the behavior of the landing page. You can set the attributes (components) such as `carousel`, `listByTag`, `parallax` and `contact` as shown in the below example. (Refer to the above screenshot to identify the components refered by the attribute names)
 
     <div>
     <div class="jsonTreeOutput"></div>
@@ -166,5 +168,5 @@ When the developer portal required to present corporate branding it’s a common
 
 2. Refresh the Developer Portal to view the changes.  
 
-The landing page provides a headstart for developers who tries to rebrand the devportal for their needs. If the requirements are much complicated, then you need to override the relevant components. The step to override only specific react components can be found [here]({{base_path}}/reference/customize-product/customizations/advanced-ui-customization/) .
+The Landing Page provides a headstart for developers who try to rebrand the developer portal for their needs. If the requirements are much complicated, then you need to override the relevant components. The steps to override only specific react components can be found [here]({{base_path}}/reference/customize-product/customizations/advanced-ui-customization/).
 

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-rating.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-rating.md
@@ -1,15 +1,19 @@
 # Enable or Disable Rating
 
-The star traing is enable by default. You can disable star rating by changing themes.light.custom.social.showRating to false as follows.
+The star rating is enabled by default. You can disable the star rating by configuring the `defaultTheme.js` file.
 
-1. Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and set the `themes.light.custom.social.showRating` attribute to false if you want to disable rating.
-```js
-const Configurations = {
-    custom: {
-        social: {
-            showRating: false,
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the `themes.light.custom.social.showRating` attribute to `false` if you want to disable the star rating.
+
+    ```js
+    const Configurations = {
+        custom: {
+            social: {
+                showRating: false,
+            },
         },
-    },
-};
-```
+    };
+    ```
+
 2. Refresh the Developer Portal to view the changes.

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-tag-cloud.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enable-or-disable-tag-cloud.md
@@ -1,8 +1,10 @@
 # Enable or Disable Tag Cloud
 
-The tag cloud is enable by default. You can disable tag cloud by changing themes.light.custom.tagCloud.active to false as follows.
+The tag cloud is enabled by default. You can disable the tag cloud by configuring the `defaultTheme.js` file.
 
-1. Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and set the `themes.light.custom.tagCloud.active` attribute as false.
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the `themes.light.custom.tagCloud.active` attribute as `false`.
 
 2. Refresh the Developer Portal to view the changes.
 
@@ -29,7 +31,7 @@ const Configurations = {
     },
 };
 ```
-leftMenu object properties are applied only if the tagCloud.style='fixed-left'
+`leftMenu` object properties are applied only if the `tagCloud.style='fixed-left'`.
 
 | Option | type | Values | Description |
 | ------ | -- | ----------- | ----------- |

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-api-detail-tabs.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-api-detail-tabs.md
@@ -1,32 +1,33 @@
 # Enable or Disable API Detail Tabs
 
-When you go to the API detials page all the links ( credentials, comments, tryout, sdks, documents) tabs are displayed. You can enable or disable them by configuring defaultTheme.js.
+When you go to the API details page, all the linked tabs (credentials, comments, tryout, sdks, documents) are displayed. You can enable or disable them by configuring the `defaultTheme.js` file.
 
-Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and set the `themes.light.custom.apiDetailPages` attributes accordingly.
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
 
-```js
-const Configurations = {
-    custom: {
-        apiDetailPages: {
-            showCredentials: false,
-            showComments: true,
-            showTryout: true,
-            showDocuments: true,
-            showSdks: true,
-            onlyShowSdks: [],
+1. Open `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the `themes.light.custom.apiDetailPages` attributes accordingly as shown in the below example.
+
+    ```js
+    const Configurations = {
+        custom: {
+            apiDetailPages: {
+                showCredentials: false,
+                showComments: true,
+                showTryout: true,
+                showDocuments: true,
+                showSdks: true,
+                onlyShowSdks: [],
+            },
         },
-    },
-};
-```
+    };
+    ```
 
+    | Property Name | type | Perpose |
+    | ---- | ---- | ---- |
+    | showCredentials | boolean | Enables the credentials tab if true or disable the Credentials tab if false. |
+    | showComments | boolean | Enables the comments tab if true or disable the Credentials tab if false. |
+    | showTryout | boolean | Enables the try out tab if true or disable the Credentials tab if false. |
+    | showDocuments | boolean | Enables the documents tab if true or disable the Credentials tab if false. |
+    | showSdks | boolean | Enables the sdks tab if true or disable the Credentials tab if false. |
+    | showSdks | Array of strings | You can put an array of strings to enable only a given set of sdks. Leave empty to show all. ex: ['java','javascript'] |
 
-| Property Name | type | Perpose |
-| ---- | ---- | ---- |
-| showCredentials | boolean | Enables the credentials tab if true or disable the Credentials tab if false. |
-| showComments | boolean | Enables the comments tab if true or disable the Credentials tab if false. |
-| showTryout | boolean | Enables the try out tab if true or disable the Credentials tab if false. |
-| showDocuments | boolean | Enables the documents tab if true or disable the Credentials tab if false. |
-| showSdks | boolean | Enables the sdks tab if true or disable the Credentials tab if false. |
-| showSdks | Array of strings | You can put an array of strings to enable only a given set of sdks. Leave empty to show all. ex: ['java','javascript'] |
-
-Refresh the Developer Portal to view the changes.
+2. Refresh the Developer Portal to view the changes.

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/override-api-overview-page-per-api.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/override-api-overview-page-per-api.md
@@ -1,8 +1,8 @@
 # Override API Overview page per API
 
-It's possible to display a custom Overview content for any API by adding a document by following the steps given bellow.
+It is possible to display a custom Overview content for any API by adding a document by following the steps given bellow.
 
-1. Login to API Publisher go to documents tab of the API you want to override.
+1. Login to API Publisher go to documents tab of the API you want to override.Login to the API Publisher and go to the `Documents` tab of the API that you want to override.
 
 2. Create a new document with the following settings.
     ![override api overview page per api publisher]({{base_path}}/assets/img/learn/override-api-overview-page-per-api-publisher1.png) 
@@ -15,11 +15,11 @@ It's possible to display a custom Overview content for any API by adding a docum
     | Other Document Type | _overview |
     | Source | Markdown |
 
-3. Click the save button and from the dialog box select **ADD CONTENT**
+3. Click the save button and select **ADD CONTENT** from the dialog box.
 
-4. Add markdown content.
+4. Add the markdown content.
 
-    Following keys can be use within the markdown to get some of the API properties.
+    Following keys can be used within the markdown to get some of the API properties.
 
     | Property Name | Key to use in markdown |
     | --- | --- |
@@ -35,8 +35,8 @@ It's possible to display a custom Overview content for any API by adding a docum
 
     ![override api overview page per api publisher]({{base_path}}/assets/img/learn/override-api-overview-page-per-api-publisher2.png) 
 
-Above screen demonstrate the use of `___name___` key to display API name within the markdown content.
+    Above screen demonstrates the use of `___name___` key to display API name within the markdown content.
 
-Overview for the selected API will be rendered from the markdown content in the devportal.
+    Overview for the selected API will be rendered from the markdown content in the developer portal.
 
-![override api overview page per api devportal]({{base_path}}/assets/img/learn/override-api-overview-page-per-api-devportal.png) 
+    ![override api overview page per api devportal]({{base_path}}/assets/img/learn/override-api-overview-page-per-api-devportal.png) 

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-api-details-info-section.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-api-details-info-section.md
@@ -1,20 +1,20 @@
 # Styling API and Application Details Info Section
 
-The "API Details Info" section shown below, can be customized according to your design needs.
+The "API Details Info" section which is shown below can be customized according to your design needs by configuring the `defaultTheme.js` file.
+
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
 
  [![styling api details info section]({{base_path}}/assets/img/learn/styling-api-details-info-section1.png)]({{base_path}}/assets/img/learn/styling-api-details-info-section1.png)
 
-Edit the attributes in `themes.light.custom.infoBar` to change the styling "API Details Info" section and the "Application Details Info" section.
+Edit the attributes in `themes.light.custom.infoBar` by following the below steps to change the styling of "API Details Info" section and the "Application Details Info" section.
 
-1. Go to the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory.
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and update the `themes.light.custom.infoBar` attributes.
 
-2. Open the `defaultTheme.js` file and update the `themes.light.custom.infoBar` attributes.
+2. Refresh the Developer Portal to view the changes.
 
-3. Refresh the Developer Portal to view the changes.
+### The following attributes are available for infoBar
 
-### Attributes available for infoBar
-
-The JSON sample code given below defines the default look and feel.
+The JSON sample code that is given below defines the default look and feel.
 
 ```js
 const Configurations = {

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-api-details-left-menu.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-api-details-left-menu.md
@@ -1,16 +1,18 @@
 # Styling API Details Left Menu
 
-The API details left menu can be customized to match with your design needs.
+The API details left menu can be customized to match with your design needs by configuring the `defaultTheme.js` file.
+
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
 
  ![styling api details left menu]({{base_path}}/assets/img/learn/styling-api-details-left-menu1.png) 
 
-You can change the themes.light.custom.leftMenu attributes to change the left menu styling. Note these changes will effect the same way to application details left menu.
+You can change the `themes.light.custom.leftMenu` attributes to change the left menu styling. Note that, these changes will effect the same way to application details left menu as well.
 
-1. Go to  `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/` directory, open the `defaultTheme.js` file and update `themes.light.custom.leftMenu` attributes.
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and update the `themes.light.custom.leftMenu` attributes.
 
 2. Refresh the Developer Portal to view the changes.
 
-### Following attributes available for leftMenu.
+### The following attributes are available for the leftMenu
 
 ```js
  const Configurations = {
@@ -35,9 +37,9 @@ You can change the themes.light.custom.leftMenu attributes to change the left me
 };
 ```
 
-Above JSON defines the default look and feel.
+The above JSON defines the default look and feel.
 
-We can change the menu to take different positions. For an example following sets the menu as a toolbar by just changing the values of above json as follows.
+We can change the menu to take different positions. For an example, the following configuration sets the menu as a toolbar by just changing the values of the above JSON as follows.
 ```js
 const Configurations = {
     custom: {
@@ -52,7 +54,7 @@ const Configurations = {
  ![styling api details left menu]({{base_path}}/assets/img/learn/styling-api-details-left-menu2.png) 
 
 
-Following will set the menu to right hand side and disable the icons.
+The following will set the menu to the right hand side and will disable the icons.
 
 ```js
 const Configurations = {

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-the-logo-and-header.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/styling-the-logo-and-header.md
@@ -1,38 +1,51 @@
 # Changing the Logo and Header Styles
 
-The header section can be customized to match different design needs. Following is the default look and the configuration.
-The default header of the API Manager Developer Portal is shown below.
+The header section can be customized to match different design needs by configuring the `defaultTheme.js` file.
+
+The `defaultTheme.js` file has all the parameters defining the look and feel of the developer portal. To learn more about `defaultTheme.js` refer [here]({{base_path}}/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme/#global-theming).
+
+The following is the default look and the configuration. The default header of the API Manager Developer Portal is shown below.
 
  ![changing the logo and header]({{base_path}}/assets/img/learn/changing-the-logo-and-header1.png) 
 
-!!! note
-    -   You can find the default theme in the following location
-    `<APIM_HOME>/repository/deployment/server/jaggeryapps/devportal/source/src/defaultTheme.js`
-    -   Using the above file as reference you can override the parameters defined in the above file by altering the `defaultTheme.js` file in following location
-    `<APIM_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js`
+1. Open the `<API-M_HOME>/repository/deployment/server/jaggeryapps/devportal/site/public/theme/defaultTheme.js` file in a text editor and set the attributes accordingly as shown below which customizes the logo and the header of the developer portal.
 
-```js
-const Configurations = {
-    custom: {
-        appBar: {
-            logo: '/site/public/images/logo.svg',
-            logoHeight: 19,
-            logoWidth: 208,
-            background: '#0fa2db',
-            backgroundImage: '/site/public/images/appbarBack.png',
-            searchInputBackground: '#fff',
-            searchInputActiveBackground: '#fff',
-            activeBackground: '#1c6584',
-            showSearch: true,
-            drawerWidth: 200,
+    ```js
+    const Configurations = {
+        custom: {
+            appBar: {
+                logo: '/site/public/images/logo.svg',
+                logoHeight: 19,
+                logoWidth: 208,
+                background: '#0fa2db',
+                backgroundImage: '/site/public/images/appbarBack.png',
+                searchInputBackground: '#fff',
+                searchInputActiveBackground: '#fff',
+                activeBackground: '#1c6584',
+                showSearch: true,
+                drawerWidth: 200,
+            },
         },
-    },
-};
-```
+    };
+    ```
+
+    | Option | type | Description |
+    | ------ | -- | ----------- |
+    | logo | string | Relative path to logo |
+    | logoHeight | integer | Logo height in pixels |
+    | logoWidth | integer | Logo width in pixels |
+    | background | string | Background color of the header |
+    | backgroundImage | string | Set the background image to the header. Ex: '/site/public/images/appbarBack.png' |
+    | searchInputBackground | string | Set the background color for the search input |
+    | searchInputActiveBackground | string | Set the background color for the search input |
+    | activeBackground | string | Background color of the selected header menu item |
+    | drawerWidth | integer | Small resolutions will collopse the top menu in to a toggle drawer. This property sets the it's width in pixels |
+
+2. Refresh the Developer Portal to view the changes.
+
 #### Example
 
-We can change the logo and header background as follows by changing the above parameters.
- ![changing the logo and header]({{base_path}}/assets/img/learn/changing-the-logo-and-header3.png) 
+We can change the logo and the header background as follows by changing the parameters. An example is shown below.
 
 ```js
 const Configurations = {
@@ -48,14 +61,6 @@ const Configurations = {
 };
 ```
 
-| Option | type | Description |
-| ------ | -- | ----------- |
-| logo | string | Relative path to logo |
-| logoHeight | integer | Logo height in pixels |
-| logoWidth | integer | Logo width in pixels |
-| background | string | Background color of the header |
-| backgroundImage | string | Set the background image to the header. Ex: '/site/public/images/appbarBack.png' |
-| searchInputBackground | string | Set the background color for the search input |
-| searchInputActiveBackground | string | Set the background color for the search input |
-| activeBackground | string | Background color of the selected header menu item |
-| drawerWidth | integer | Small resolutions will collopse the top menu in to a toggle drawer. This property sets the it's width in pixels |
+Make sure you restart the server for the changes to take effect.
+
+ ![changing the logo and header]({{base_path}}/assets/img/learn/changing-the-logo-and-header3.png) 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/2945

## Goals
Fixing the steps and inconsistencies in the section **Customizing the Developer Portal**.

## Approach
- Added a sentence on `defaultTheme.js` to almost all the pages under **Customizing the Developer Portal**, so that the user can have an idea of it. (For example, check the second paragraph of the below screenshot.)
  ![image](https://user-images.githubusercontent.com/25246848/106702188-f242bc80-660d-11eb-80b5-39966d7d2be2.png)
- Restructured the steps on some pages.
- Corrected the typos and formatting.
