### PR TITLE
[3.0.0] Updating the WorkFlow Callback URL

### DIFF
--- a/en/docs/learn/extensions/managing-workflow-extension/invoking-the-api-manager-from-the-bpel-engine.md
+++ b/en/docs/learn/extensions/managing-workflow-extension/invoking-the-api-manager-from-the-bpel-engine.md
@@ -21,7 +21,7 @@ Once the workflow configurations are finalized at the BPEL, the call-back URL of
 </tr>
 <tr class="even">
 <td>REST</td>
-<td><a href="https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status" class="uri">https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status</a></td>
+<td><a href="https://localhost:9443/api/am/admin/v0.15/workflows/update-workflow-status" class="uri">https://localhost:9443/api/am/admin/v0.15/workflows/update-workflow-status</a></td>
 </tr>
 </tbody>
 </table>
@@ -65,7 +65,7 @@ The endpoint expects the following list of parameters:
 A sample curl request for invoking the REST endpoint is as follows:
 
 ```
-curl -H "Authorization:Basic YWRtaW46YWRtaW4=" -X POST https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status -d 'workflowReference=b530be39-9174-43b3-acb3-2603a223b094&status=APPROVED&description=DESCRIPTION'
+curl -H "Authorization:Basic YWRtaW46YWRtaW4=" -X POST https://localhost:9443/api/am/admin/v0.15/workflows/update-workflow-status -d 'workflowReference=b530be39-9174-43b3-acb3-2603a223b094&status=APPROVED&description=DESCRIPTION'
 ```
 
 A sample SOAP request is given below:

--- a/en/docs/learn/extensions/managing-workflow-extension/invoking-the-api-manager-from-the-bpel-engine.md
+++ b/en/docs/learn/extensions/managing-workflow-extension/invoking-the-api-manager-from-the-bpel-engine.md
@@ -21,7 +21,7 @@ Once the workflow configurations are finalized at the BPEL, the call-back URL of
 </tr>
 <tr class="even">
 <td>REST</td>
-<td><a href="https://localhost:9443/store/site/blocks/workflow/workflow-listener/ajax/workflow-listener.jag" class="uri">https://localhost:9443/store/site/blocks/workflow/workflow-listener/ajax/workflow-listener.jag</a></td>
+<td><a href="https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status" class="uri">https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status</a></td>
 </tr>
 </tbody>
 </table>
@@ -64,21 +64,21 @@ The endpoint expects the following list of parameters:
 
 A sample curl request for invoking the REST endpoint is as follows:
 
-``` html/xml
-    curl -H "Authorization:Basic YWRtaW46YWRtaW4=" -X POST http://localhost:9763/store/site/blocks/workflow/workflow-listener/ajax/workflow-listener.jag -d 'workflowReference=b530be39-9174-43b3-acb3-2603a223b094&status=APPROVED&description=DESCRIPTION'
+```
+curl -H "Authorization:Basic YWRtaW46YWRtaW4=" -X POST https://localhost:9443/api/am/publisher/v0.15/workflows/update-workflow-status -d 'workflowReference=b530be39-9174-43b3-acb3-2603a223b094&status=APPROVED&description=DESCRIPTION'
 ```
 
 A sample SOAP request is given below:
 
-``` html/xml
-    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cal="http://callback.workflow.apimgt.carbon.wso2.org">
-       <soapenv:Header/>
-       <soapenv:Body>
-          <cal:resumeEvent>
-             <cal:workflowReference>b530be39-9174-43b3-acb3-2603a223b094</cal:workflowReference>
-             <cal:status>APPROVED</cal:status>
-             <cal:description>DESCRIPTION</cal:description>
-          </cal:resumeEvent>
-       </soapenv:Body>
-    </soapenv:Envelope>
+``` xml
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cal="http://callback.workflow.apimgt.carbon.wso2.org">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <cal:resumeEvent>
+         <cal:workflowReference>b530be39-9174-43b3-acb3-2603a223b094</cal:workflowReference>
+         <cal:status>APPROVED</cal:status>
+         <cal:description>DESCRIPTION</cal:description>
+      </cal:resumeEvent>
+   </soapenv:Body>
+</soapenv:Envelope>
 ```


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/3076

## Goals
Change the old URL to the correct WorkFlowCallBackURL.

## Approach
- Changed the URL and the examples in the page **Invoking the API Manager from the BPEL Engine**.
  ![image](https://user-images.githubusercontent.com/25246848/106764969-542b1280-665e-11eb-8bda-6ff757779765.png)