### PR TITLE
[3.0.0] Add warning to take WUM update for devportal anonymous mode

### DIFF
--- a/en/docs/administer/product-administration/disabling-anonymous-access-to-developer-portal.md
+++ b/en/docs/administer/product-administration/disabling-anonymous-access-to-developer-portal.md
@@ -1,5 +1,11 @@
 # Disabling Anonymous Access to the Developer Portal
 
+!!! warning
+    This feature is supported by default only from WSO2 API Manager 3.2.0 onwards. It is 
+    available for WSO2 APIM 3.0.0 only as a **WUM** update and is effective from 29th January 2021 (2021-01-29). For more 
+    information on how to update using WUM, see 
+    [Getting WSO2 Updates](https://docs.wso2.com/display/ADMIN44x/Getting+WSO2+Updates) documentation.
+
 By default, anonymous access to the Developer Portal is enabled. Therefore, users do not need to authenticate themselves by way of signing in when accessing the Developer Portal in WSO2 API Manager. However, if required, you can disable anonymous access to the Developer Portal to prevent anonymous users from accessing the Developer Portal. When anonymous access is disabled, users will not be allowed to access the Developer Portal UI without appropriate login details or an access token.
 
 Follow the instructions below to disable anonymous access to the Developer Portal for a particular tenant:

--- a/en/docs/administer/product-administration/disabling-anonymous-access-to-developer-portal.md
+++ b/en/docs/administer/product-administration/disabling-anonymous-access-to-developer-portal.md
@@ -3,8 +3,8 @@
 !!! warning
     This feature is supported by default only from WSO2 API Manager 3.2.0 onwards. It is 
     available for WSO2 APIM 3.0.0 only as a **WUM** update and is effective from 29th January 2021 (2021-01-29). For more 
-    information on how to update using WUM, see 
-    [Getting WSO2 Updates](https://docs.wso2.com/display/ADMIN44x/Getting+WSO2+Updates) documentation.
+    information on how to update using WUM, see the
+    [WSO2 Updates](https://updates.docs.wso2.com/en/latest/) documentation.
 
 By default, anonymous access to the Developer Portal is enabled. Therefore, users do not need to authenticate themselves by way of signing in when accessing the Developer Portal in WSO2 API Manager. However, if required, you can disable anonymous access to the Developer Portal to prevent anonymous users from accessing the Developer Portal. When anonymous access is disabled, users will not be allowed to access the Developer Portal UI without appropriate login details or an access token.
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/3049

## Goals
Adding the warning to get the latest WUM update to have this feature similarly as shown in [1].

## Approach
- Added a warning as shown below to the page **Disabling Anonymous Access to the Developer Portal**.
  ![image](https://user-images.githubusercontent.com/25246848/107136656-4362f100-692b-11eb-9cef-7d5d77d794c2.png)

[1] https://apim.docs.wso2.com/en/3.0.0/install-and-setup/deploying-wso2-api-manager/distributed-deployment/product-profiles/#method-2-optimizing-while-starting-the-server