### PR TITLE
[3.0.0] Mentioning WorkflowCallbackService.xml not to be replaced in migrations

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-300.md
@@ -441,7 +441,7 @@ Follow the instructions below to move all the existing API Manager configuration
         -   /api/\_RevokeAPI_.xml
         -   /sequences/\_cors_request_handler_.xml
         -   /sequences/main.xml
-        -   proxy-services/WorkflowCallbackService.xml
+        -   /proxy-services/WorkflowCallbackService.xml
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-300.md
@@ -439,6 +439,7 @@ Follow the instructions below to move all the existing API Manager configuration
         -   /api/\_RevokeAPI_.xml
         -   /sequences/\_cors_request_handler_.xml
         -   /sequences/main.xml
+        -   /proxy-services/WorkflowCallbackService.xml
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-300.md
@@ -441,6 +441,7 @@ Follow the instructions below to move all the existing API Manager configuration
         -   /api/\_RevokeAPI_.xml
         -   /sequences/\_cors_request_handler_.xml
         -   /sequences/main.xml
+        -   /proxy-services/WorkflowCallbackService.xml
 
     !!! attention          
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-300.md
@@ -437,6 +437,7 @@ Follow the instructions below to move all the existing API Manager configuration
         -   /api/\_RevokeAPI_.xml
         -   /sequences/\_cors_request_handler_.xml
         -   /sequences/main.xml
+        -   /proxy-services/WorkflowCallbackService.xml
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/3114

## Goals
Reflect the changes from 3.2.0 doc space in order to mention that the WorkflowCallbackService.xml should not be replaced during the migrations.

## Approach
Updated the below pages with the above change.
- Upgrading API Manager from 2.1.0 to 3.0.0
- Upgrading API Manager from 2.2.0 to 3.0.0
- Upgrading API Manager from 2.5.0 to 3.0.0
- Upgrading API Manager from 2.6.0 to 3.0.0