### PR TITLE
[3.2.0] Deprecating the docs on Implicit Grant in APIM 3.2.0

### DIFF
--- a/en/docs/getting-started/about-this-release.md
+++ b/en/docs/getting-started/about-this-release.md
@@ -162,6 +162,10 @@ The **WSO2 API Manager 3.2.0** is the **latest** **WSO2 API Manager release*
 
 - **[Admin Portal](https://apim.docs.wso2.com/en/3.2.0/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17/) v0.17 based REST APIs**.
 
+- **[Implicit Grant]({{base_path}}/learn/api-security/oauth2/grant-types/implicit-grant)**
+
+     This has been deprecated since the OAuth 2.1.0 has removed/discouraged the use of the implicit grant type due to security concerns. Please refer [here](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-2.1.2) for more details. 
+
 ### Removed features and functionalities
 
 - **Tag wise grouping**

--- a/en/docs/getting-started/about-this-release.md
+++ b/en/docs/getting-started/about-this-release.md
@@ -163,8 +163,9 @@ The **WSO2 API Manager 3.2.0** is the **latest** **WSO2 API Manager release*
 - **[Admin Portal](https://apim.docs.wso2.com/en/3.2.0/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17/) v0.17 based REST APIs**.
 
 - **[Implicit Grant]({{base_path}}/learn/api-security/oauth2/grant-types/implicit-grant)**
+     
+     OAuth 2.1.0 has removed/discouraged the use of Implicit grant type due to security concerns. Therefore, the support for Implicit grant has been deprecated in WSO2 API Manager. See [here](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-2.1.2) for more details. 
 
-     This has been deprecated since the OAuth 2.1.0 has removed/discouraged the use of the implicit grant type due to security concerns. Please refer [here](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-2.1.2) for more details. 
 
 ### Removed features and functionalities
 

--- a/en/docs/learn/api-security/oauth2/grant-types/implicit-grant.md
+++ b/en/docs/learn/api-security/oauth2/grant-types/implicit-grant.md
@@ -1,5 +1,8 @@
 # Implicit Grant
 
+!!! note
+    The Implicit Grant has been deprecated in WSO2 API Manager 3.2.0 and will be removed from the future releases. This has been done since the OAuth 2.1.0 has removed/discouraged the use of the implicit grant type due to security concerns. Please refer [here](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14#section-2.1.2) for more details.
+
 Implicit grant type is used to obtain access tokens if your application (client) is a mobile application or a browser based app such as a JavaScript client. Similar to authorization code grant, the implicit grant type is also based on redirection flow. The redirection URI includes the access token in the URI fragment. Therefore, the client application is capable of interacting with the resource owner user agent to obtain the access token from the redirection URI which is sent from the authorization server.
 
 #### Flow


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/2944
Fixes: https://github.com/wso2/docs-apim/issues/3064

## Goals
Tell the users that the Implicit Grant has been deprecated in APIM 3.2.0 and will be removed in future.

## Approach
- Added a note under the section **Deprecated features and functionalities** in the "About this Release" as shown below.
  ![image](https://user-images.githubusercontent.com/25246848/107482848-3e5da600-6ba6-11eb-8c68-a2e5bae64936.png)
- Added a note in the **Implicit Grant** page as shown below.
  ![image](https://user-images.githubusercontent.com/25246848/107482978-6ea54480-6ba6-11eb-9757-63769741412c.png)