### PR TITLE
Update getting-started-with-wso2-api-controller.md

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -20,7 +20,7 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
         From API Manager Tooling 3.1.0 version onwards, the names of the endpoints have been modified and this causes changing the syntax in `/home/<user>/.wso2apictl/main_config.yaml` file. If you have an older file, you'll get an error while executing the apictl commands due to this. To avoid that, backup and remove `/home/<user>/.wso2apictl/main_config.yaml` file and reconfigure the environments using new commands as explained below in [Add an environment](#add-an-environment) section.
 
     ``` go
-    ./apictl
+    apictl
     ```
     The directory structure for the configuration files ( `<USER_HOME>/.wso2apictl` ) will be created upon the execution of the `apictl` command.
 


### PR DESCRIPTION
The command "./apictl" to start the CTL tool doesn't work and gives out an error as seen below.
![image](https://user-images.githubusercontent.com/66669898/108025376-62106880-704c-11eb-8fa7-ae752ba3f0fe.png)

 Instead just running the command as "apictl" works and the directory structure for the configuration files ( <USER_HOME>/.wso2apictl ) gets created.

![image](https://user-images.githubusercontent.com/66669898/108025539-a7cd3100-704c-11eb-9d71-8092d6583078.png)

