### PR TITLE
[3.1.0] Define specific runtime artifact directories for persistence

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup.md
@@ -673,7 +673,7 @@ This section involves setting up the Gateway node and enabling it to work with t
           xxx.xxx.xxx.xx4 gw.wso2.com
           ```
 
-      4.  Mount the `<API-M_HOME>/repository/deployment/server` directory of all the Gateway nodes to the shared file system to share all APIs between the Gateway nodes.
+      4.  Mount the `<API-M_HOME>/repository/deployment/server/synapse-configs` directory of all the Gateway nodes to the shared file system to share all APIs between the Gateway nodes.
  
         !!! note
               WSO2 recommends using a shared file system as the content synchronization mechanism to synchronize the artifacts among the WSO2 API-M Gateway nodes, because a shared file system does not require a specific node to act as a Gateway Manager, instead all the nodes have the worker manager capabilities.

--- a/en/docs/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts.md
+++ b/en/docs/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts.md
@@ -35,9 +35,11 @@ The following are the artifacts used commonly in a WSO2 API Manager and API Mana
     Shared Artifacts
 
     The following artifacts can be shared among API Manager nodes
-
-    1. `<API-M_HOME>/repository/deployment/server`
-    2. `<API-M_HOME>/repository/tenants`
+    
+    1. `<API-M_HOME>/repository/deployment/server/executionplans`
+    2. `<API-M_HOME>/repository/deployment/server/synapse-configs`
+    3. `<API-M_HOME>/repository/deployment/server/userstores` (Optional)
+    4. `<API-M_HOME>/repository/tenants`
 
 
 ### Persistent Configuration Artifacts


### PR DESCRIPTION
## Purpose
This PR add the artifact directories for persistence in a deployment, rather than using the parent directory.

Fixes https://github.com/wso2/docs-apim/issues/1453  
