### PR TITLE
Add throttling configs to the config catalog

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3189,10 +3189,6 @@ enable_query_param_based_throttling = true
 enable_unlimited_tier = true
 throttle_decision_endpoints = ["tcp://localhost:5672","tcp://localhost:5672"]
 skip_redeploying_policies = ["carbon.super_app_unitApp","carbon.super_app_20PerMin"]
-enable_data_publishing = true
-enable_policy_deploy = true
-enable_blacklist_condition = true
-enable_persistence = false
 </code></pre>
                     </div>
                 </div>
@@ -3370,6 +3366,7 @@ enable_persistence = false
                                     <div>
                                         <p>
                                             <span class="param-type string"> boolean </span>
+                                            
                                         </p>
                                         <div class="param-default">
                                             <span class="param-default-value">Default: <code>true</code></span>
@@ -3379,70 +3376,73 @@ enable_persistence = false
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable publishing of request and throttling data</p>
+                                        <p>Enable publishing of request and throttling data.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
-                                  <div class="param-name">
-                                    <span class="param-name-wrap"> <code>enable_policy_deploy</code> </span>
-                                  </div>
-                                  <div class="param-info">
-                                      <div>
-                                          <p>
-                                              <span class="param-type string"> boolean </span>
-                                          </p>
-                                          <div class="param-default">
-                                              <span class="param-default-value">Default: <code>true</code></span>
-                                          </div>
-                                          <div class="param-possible">
-                                              <span class="param-possible-values">Possible Values: <code>true, false</code></span>
-                                          </div>
-                                      </div>
-                                      <div class="param-description">
-                                          <p>Enable deploying of throttling policies</p>
-                                      </div>
-                                  </div>
-                              </div><div class="param">
-                                    <div class="param-name">
-                                      <span class="param-name-wrap"> <code>enable_blacklist_condition</code> </span>
-                                    </div>
-                                    <div class="param-info">
-                                        <div>
-                                            <p>
-                                                <span class="param-type string"> boolean </span>
-                                            </p>
-                                            <div class="param-default">
-                                                <span class="param-default-value">Default: <code>true</code></span>
-                                            </div>
-                                            <div class="param-possible">
-                                                <span class="param-possible-values">Possible Values: <code>true, false</code></span>
-                                            </div>
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_policy_deploy</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
                                         </div>
-                                        <div class="param-description">
-                                            <p>Enable blocking conditions from the admin portal</p>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
                                         </div>
                                     </div>
-                                </div><div class="param">
-                                    <div class="param-name">
-                                      <span class="param-name-wrap"> <code>enable_persistence</code> </span>
-                                    </div>
-                                    <div class="param-info">
-                                        <div>
-                                            <p>
-                                                <span class="param-type string"> boolean </span>
-                                            </p>
-                                            <div class="param-default">
-                                                <span class="param-default-value">Default: <code>false</code></span>
-                                            </div>
-                                            <div class="param-possible">
-                                                <span class="param-possible-values">Possible Values: <code>true, false</code></span>
-                                            </div>
-                                        </div>
-                                        <div class="param-description">
-                                            <p>Enable persisting current counter state of the TM</p>
-                                        </div>
+                                    <div class="param-description">
+                                        <p>Enable deploying of throttling policies.</p>
                                     </div>
                                 </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_blacklist_condition</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable blocking conditions from the admin portal.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_persistence</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable persisting current counter state of the TM.</p>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3189,6 +3189,10 @@ enable_query_param_based_throttling = true
 enable_unlimited_tier = true
 throttle_decision_endpoints = ["tcp://localhost:5672","tcp://localhost:5672"]
 skip_redeploying_policies = ["carbon.super_app_unitApp","carbon.super_app_20PerMin"]
+enable_data_publishing = true
+enable_policy_deploy = true
+enable_blacklist_condition = true
+enable_persistence = false
 </code></pre>
                     </div>
                 </div>
@@ -3358,7 +3362,87 @@ skip_redeploying_policies = ["carbon.super_app_unitApp","carbon.super_app_20PerM
                                         <p>This will enable/disable the JMS Message retrieval connection based on the provided value(true/false).</p>
                                     </div>
                                 </div>
-                            </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_data_publishing</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable publishing of request and throttling data</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                  <div class="param-name">
+                                    <span class="param-name-wrap"> <code>enable_policy_deploy</code> </span>
+                                  </div>
+                                  <div class="param-info">
+                                      <div>
+                                          <p>
+                                              <span class="param-type string"> boolean </span>
+                                          </p>
+                                          <div class="param-default">
+                                              <span class="param-default-value">Default: <code>true</code></span>
+                                          </div>
+                                          <div class="param-possible">
+                                              <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                          </div>
+                                      </div>
+                                      <div class="param-description">
+                                          <p>Enable deploying of throttling policies</p>
+                                      </div>
+                                  </div>
+                              </div><div class="param">
+                                    <div class="param-name">
+                                      <span class="param-name-wrap"> <code>enable_blacklist_condition</code> </span>
+                                    </div>
+                                    <div class="param-info">
+                                        <div>
+                                            <p>
+                                                <span class="param-type string"> boolean </span>
+                                            </p>
+                                            <div class="param-default">
+                                                <span class="param-default-value">Default: <code>true</code></span>
+                                            </div>
+                                            <div class="param-possible">
+                                                <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                            </div>
+                                        </div>
+                                        <div class="param-description">
+                                            <p>Enable blocking conditions from the admin portal</p>
+                                        </div>
+                                    </div>
+                                </div><div class="param">
+                                    <div class="param-name">
+                                      <span class="param-name-wrap"> <code>enable_persistence</code> </span>
+                                    </div>
+                                    <div class="param-info">
+                                        <div>
+                                            <p>
+                                                <span class="param-type string"> boolean </span>
+                                            </p>
+                                            <div class="param-default">
+                                                <span class="param-default-value">Default: <code>false</code></span>
+                                            </div>
+                                            <div class="param-possible">
+                                                <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                            </div>
+                                        </div>
+                                        <div class="param-description">
+                                            <p>Enable persisting current counter state of the TM</p>
+                                        </div>
+                                    </div>
+                                </div>
                         </div>
                     </div>
                 </div>

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1248,6 +1248,38 @@
                             "default": "true",
                             "possible": "true, false",
                             "description": "This will enable/disable the JMS Message retrieval connection based on the provided value(true/false)."
+                        },
+                        {
+                            "name": "enable_data_publishing",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "true",
+                            "possible": "true, false",
+                            "description": "Enable publishing of request and throttling data."
+                        },
+                        {
+                            "name": "enable_policy_deploy",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "true",
+                            "possible": "true, false",
+                            "description": "Enable deploying of throttling policies."
+                        },
+                        {
+                            "name": "enable_blacklist_condition",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "true",
+                            "possible": "true, false",
+                            "description": "Enable blocking conditions from the admin portal."
+                        },
+                        {
+                            "name": "enable_persistence",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Enable persisting current counter state of the TM."
                         }
                     ]
                 }

--- a/en/tools/config-catalog-generator/dist/config-catalog.md
+++ b/en/tools/config-catalog-generator/dist/config-catalog.md
@@ -3358,6 +3358,90 @@ skip_redeploying_policies = ["carbon.super_app_unitApp","carbon.super_app_20PerM
                                         <p>This will enable/disable the JMS Message retrieval connection based on the provided value(true/false).</p>
                                     </div>
                                 </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_data_publishing</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable publishing of request and throttling data.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_policy_deploy</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable deploying of throttling policies.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_blacklist_condition</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable blocking conditions from the admin portal.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_persistence</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable persisting current counter state of the TM.</p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Purpose
Adds the missing throttling configs to the config catalog.

Fixes https://github.com/wso2/docs-apim/issues/3540