### PR TITLE
Landing update

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -52,7 +52,7 @@ template: templates/single-column.html
             <p>
                 Introduces WSO2 API Manager and quickly describes what it can do.
             </p>
-            <a href='{{base_path}}/get-started/key-concepts'><h4>Understand the Concepts</h4></a>
+            <a href='{{base_path}}/get-started/overview'><h4>Read a Short Overview</h4></a>
         </div>
         <div class="linkSet2 middle" onclick="location.href='{{base_path}}/tutorials/tutorials-overview';">
             <h3>Concepts</h3>

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -48,18 +48,18 @@ template: templates/single-column.html
     </div>
     <div class="section03">
         <div class="linkSet2" onclick="location.href='{{base_path}}/get-started/key-concepts';">
+            <h3>Overview</h3>
+            <p>
+                Introduces WSO2 API Manager and quickly describes what it can do.
+            </p>
+            <a href='{{base_path}}/get-started/key-concepts'><h4>Understand the Concepts</h4></a>
+        </div>
+        <div class="linkSet2 middle" onclick="location.href='{{base_path}}/tutorials/tutorials-overview';">
             <h3>Concepts</h3>
             <p>
                 The key concepts of WSO2 API Manager give you a brief introduction to the terminology and make it easy for you to understand the API management domain.
             </p>
             <a href='{{base_path}}/get-started/key-concepts'><h4>Understand the Concepts</h4></a>
-        </div>
-        <div class="linkSet2 middle" onclick="location.href='{{base_path}}/tutorials/tutorials-overview';">
-            <h3>User Scenarios</h3>
-            <p>
-                Try out the first WSO2 API Manager tutorial, which helps you solve a real world problem using the product. This tutorial aims to showcase all the major features of the product and get you acquainted with API Manager.
-            </p>
-            <a href='{{base_path}}/tutorials/tutorials-overview'><h4>User Scenarios</h4></a>
         </div>
         <div class="linkSet2 last" onclick="location.href='{{base_path}}/get-started/architecture';">
             <h3>Architecture</h3>

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -150,38 +150,3 @@ template: templates/single-column.html
             </div>
         </div>
     </div>
-    <div class="section06">
-        <h3>Tutorials</h3>
-        <p>
-            These tutorials will walk you through the main capabilities and features of WSO2 API Manager, and help you understand how to build API Management, integration, and streaming solutions.
-        </p>
-        <div class="DeploymentWrapper">
-            <div class="Deploymentlinks">
-                <h4>API Management </h4>
-                <ul>
-                    <li><a href='#'>Message Routing and Transformation</a></li>
-                    <li><a href='#'>Service Orchestration</a></li>
-                    <li><a href='#'>Asynchronous Message Processing</a></li>
-                    <li><a href='#'>SaaS and B2B Connectivity</a></li>
-                </ul>
-            </div>
-            <div class="Deploymentlinks middle">
-                <h4>Integration </h4>
-                <ul>
-                    <li><a href='#'>Message Routing and Transformation</a></li>
-                    <li><a href='#'>Service Orchestration</a></li>
-                    <li><a href='#'>Asynchronous Message Processing</a></li>
-                    <li><a href='#'>SaaS and B2B Connectivity</a></li>
-                </ul>
-            </div>
-            <div class="Deploymentlinks last">
-                <h4>Streaming Integration </h4>
-                <ul>
-                    <li><a href='#'>Message Routing and Transformation</a></li>
-                    <li><a href='#'>Service Orchestration</a></li>
-                    <li><a href='#'>Asynchronous Message Processing</a></li>
-                    <li><a href='#'>SaaS and B2B Connectivity</a></li>
-                </ul>
-            </div>
-        </div>
-    </div>


### PR DESCRIPTION
This removes tutorials from the landing page - the reasoning is that scenarios are supposed to cover the same aspect and will be better from a product introduction perspective.

Also adding in Overview to this page.