### PR TITLE
fixing warning in mkdocs

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -121,7 +121,6 @@ nav:
                         - Secure APIs using Mutual SSL: design/api-security/api-authentication/secure-apis-using-mutual-ssl.md
                         - Secure APIs using Basic Authentication: design/api-security/api-authentication/secure-apis-using-basic-authentication.md
                         - Secure APIs using Certificate Bound Access Token: design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
-                        - Securing APIs Deployed in Cloud Clusters: design/api-security/api-authentication/securing-apis-deployed-in-cloud-clusters.md
                         - Federating OAuth Applications: design/api-security/api-authentication/advanced-topics/federating-oauth-applications.md
                 - Authorization:
                         - Overview: design/api-security/authorization/api-authorization.md


### PR DESCRIPTION
## Purpose
fixing warning in mkdocs
`WARNING -  A relative path to 'design/api-security/api-authentication/securing-apis-deployed-in-cloud-clusters.md' is included in the 'nav' configuration, which is not found in the documentation files `