### PR TITLE
Update the About this Release section of APICTL and corrected the examples of undeploy and get commands

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -373,25 +373,93 @@ It is now available to download from [here](https://github.com/wso2/streaming-in
 
 ---
 
-## API Controller
+## API Controller (apictl)
 
-WSO2 API Controller is a command-line tool providing the capability to move APIs, API Products, and Applications across environments and to perform CI/CD operations. It can also be used to perform these same tasks on a Kubernetes deployment. In addition, API Controller can be used as a developer CLI tool for API Microgateway. Furthermore, it can perform Micro Integrator server specific operations such as monitoring Synapse artifacts and performing MI management/administrative tasks from the command line. The Micro Integrator operations are newly added in for API Manager 4.0.0.
+WSO2 API Controller (apictl) is a command-line tool providing the capability to move APIs, API Products, and Applications across environments and to perform CI/CD operations. It can also be used to perform these same tasks on a Kubernetes deployment. In addition, apictl can be used as a developer CLI tool for Microgateway. Furthermore, it can perform Micro Integrator server specific operations such as monitoring Synapse artifacts and performing MI management/administrative tasks from the command line.
 
 It is now available to download from [here](https://github.com/wso2/product-apim-tooling/releases/tag/v4.0.0-alpha).
 
 #### New features
 
-- **[API Controller as a developer CLI tool for Microgateway]({{base_path}}/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller/)**
-    This includes the following features and improvements:
-    - Merge Micro Integrator cli commands with APICTL
-    - Support import/export revisioning of APIs- Adding proxy environment variables support for APICTL
-    - Alias for APICTL commands ([)APICTL)
-    - Resolve parameters at server side while importing an API project
-    - Defining schemas for API Controller API/API Product project artifacts (A part of migrating data via apictl)
-    - Defining schemas for API Controller Application project artifacts (A part of migrating data via apictl)
-    - Support to override subscription policies of an API using the params file
-    - Support TLS renegotiation configuration
-    - Support APICTL bundle command (archives an API Project) 
+- [API Controller as a developer CLI tool for Microgateway]({{base_path}}/install-and-setup/setup/api-controller/managing-choreo-connect/managing-choreo-connect-with-ctl/)
+- [Merge Micro Integrator (MI) CLI commands with apictl]({{base_path}}/install-and-setup/setup/api-controller/managing-integrations/managing-integrations-with-ctl/)
+- Support import/export revisioning of APIs and API Products
+- [Adding proxy environment variables support for apictl]({{base_path}}/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller/#set-proxy-environment-variables-for-apictl/)
+- Resolve parameters at server side while importing an API/API Product project
+- [Params file support for API Products]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters/#defining-the-params-file-for-an-api-product/)
+- Introducing new schemas for apictl API/API Product/Application project artifacts
+- [Support to override subscription policies of an API using the params file]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters/#defining-the-params-file-for-an-api/)
+- [Support TLS renegotiation configuration]({{base_path}}/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller/#set-tls-renegotiation-mode/)
+- [Support apictl bundle command (archives an API Project)]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters/#bundling-the-generated-directory-before-import/)
+- [Introducing a structure for deployment and source repositories]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters/#generating-the-deployment-directory/)
+- Support endpoint security separately for Production and Sandbox endpoints via params file
+- VCS support for both the deployment and source repositories
+- Support for import/export Async APIs
+- Introducing "apictl aws init" command to extract APIs from AWS API and to initialize an apictl API project
+- Standardized the apictl flags with a common convention
+- Deprecated few old apictl commands and introduced new improved commands
+    <table>
+        <tr class="odd">
+            <th>Deprecated Command</th>
+            <th>New Command</th>
+        </tr>
+        <tr class="even">
+            <td>apictl import-api [flags]</td>
+            <td>apictl import api [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl import-app [flags]</td>
+            <td>apictl import app [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl export-api [flags]</td>
+            <td>apictl export api [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl export-apis [flags]</td>
+            <td>apictl export apis [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl export-app [flags]</td>
+            <td>apictl export app [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl list apis [flags]</td>
+            <td>apictl get apis [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl list api-products [flags]</td>
+            <td>apictl get api-products [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl list apps [flags]</td>
+            <td>apictl get apps [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl list envs [flags]</td>
+            <td>apictl get envs [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl get-keys [flags]</td>
+            <td>apictl get keys [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl delete api [flags]</td>
+            <td>apictl delete api [flags] <br> apictl k8s delete api [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl add api [flags]</td>
+            <td>apictl k8s add api [flags]</td>
+        </tr>
+        <tr class="even">
+            <td>apictl update api [flags]</td>
+            <td>apictl k8s update api [flags]</td>
+        </tr>
+        <tr class="odd">
+            <td>apictl add-env [flags]</td>
+            <td>apictl k8s update api [flags]</td>
+        </tr>
+    </table>
 
 ---
 

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -346,7 +346,7 @@
         <td>Contains the endpoint certificates for endpoint security enabled APIs.</td>
         </tr>
         <tr class="odd">
-        <td><Image</td>
+        <td>Image</td>
         <td>Contains the thumbnail image of the API.</td>
         </tr>
         </tbody>
@@ -433,13 +433,12 @@ After editing the mandatory fields in the API Project, you can import the API to
             `--file` or `-f` : The file path of the API project to import.  
             `--environment` or `-e` : Environment to which the API should be imported.   
         -   Optional :  
-            `--rotate-revision` : If the maximum revision limit reached, delete the oldest revision and create a new revision.
-            `--skip-deployments` : Skip the deployment environments specified in the project and only update the working copy of the API. 
-            `--preserve-provider` : Preserve the existing provider of API after importing. The default value is `true`. 
-            `--update` : Update an existing API or create a new API in the importing environment.  
-            `--params` : Provide a API Manager environment params file.   
-            For more information, see [Configuring Environment Specific Parameters]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters).  
-            `--skip-cleanup` : Leave all temporary files created in apictl during import process. The default value is `false`.  
+            `--rotate-revision` : If the maximum revision limit reached, delete the oldest revision and create a new revision.  
+            `--skip-deployments` : Skip the deployment environments specified in the project and only update the working copy of the API.   
+            `--preserve-provider` : Preserve the existing provider of API after importing. The default value is `true`.   
+            `--update` : Update an existing API or create a new API in the importing environment.    
+            `--params` : Provide a API Manager environment params file. For more information, see [Configuring Environment Specific Parameters]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters).    
+            `--skip-cleanup` : Leave all temporary files created in apictl during import process. The default value is `false`.    
 
     !!! example
         ```bash

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
@@ -388,7 +388,7 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
             apictl undeploy api -n <API name> -v <API version> --rev <Revision number> -e <environment>
             ```
             ``` bash
-            apictl undeploy api --n <API name> --v <API version> --rev <Revision number> --g <gateway environment> --e <environment> 
+            apictl undeploy api -n <API name> -v <API version> --rev <Revision number> -g <gateway environment> -e <environment> 
             ```
             ``` bash
             apictl undeploy api --name <API name> --version <API version> --rev <Revision number> --environment <environment> --provider <API provider> 
@@ -408,13 +408,13 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
     
             !!! example
                 ```bash
-                apictl undeploy api -a Publish -n PizzaShackAPI -v 1.0.0 -e dev 
+                apictl undeploy api -n PizzaShackAPI -v 1.0.0 --rev 1 -e dev 
                 ```
                 ```bash
-                apictl undeploy api --n PizzaShackAPI --v 1.0.0 --rev 2 -g Label1 Label2 Label3 --e production 
+                apictl undeploy api -n PizzaShackAPI -v 1.0.0 --rev 2 -g Label1 -g Label2 -g Label3 -e production 
                 ```    
                 ```go
-                apictl undeploy api --name PizzaShackAPI --version 1.0.0 --provider Alice --rev 3 --gateway-env Label1 "Default"  --environment production 
+                apictl undeploy api --name PizzaShackAPI --version 1.0.0 --provider Alice --rev 3 --gateway-env Label1 --gateway-env Default --environment production 
                 ```  
     
         -   **Response**
@@ -430,7 +430,7 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
                 apictl undeploy api-product -n <API Product name> --rev <Revision number> -e <environment>
                 ```
                 ``` bash
-                apictl undeploy api-product --n <API Product name> --rev <Revision number> --g <gateway environment> --e <environment> 
+                apictl undeploy api-product -n <API Product name> --rev <Revision number> -g <gateway environment> -e <environment> 
                 ```
                 ``` bash
                 apictl undeploy api-product --name <API Product name> --rev <Revision number> --environment <environment> --provider <API Product provider>   
@@ -449,13 +449,13 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
            
             !!! example
                 ```bash
-                apictl undeploy api-product -n LeasingAPIProduct -e dev 
+                apictl undeploy api-product -n LeasingAPIProduct --rev 1 -e dev 
                 ```
                 ```bash
-                apictl undeploy api-product -n PizzaProduct --rev 2 -g Label1 Label2 Label3 --e production 
+                apictl undeploy api-product -n PizzaProduct --rev 2 -g Label1 -g Label2 -g Label3 -e production 
                 ```    
                 ```go
-                apictl undeploy api-product --name ShopProduct --provider Alice --rev 3 --gateway-env Label1 "Default"  --environment production 
+                apictl undeploy api-product --name ShopProduct --provider Alice --rev 3 --gateway-env Label1 --gateway-env Default  -environment production 
                 ```  
          
             -   **Response**
@@ -466,5 +466,5 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
 
     !!! Info
         - If ```--gateway-env``` or ```-g``` flag not provided, revision will be undeployed from all the gateway environments it is already deployed.
-        - If there are multiple gateway environments, provide them one by one separated with a space. If a label has more than one words,
+        - If there are multiple gateway environments, provide them one by one by specifying the flag ```--gateway-env``` or ```-g```. If a label has more than one words,
         wrap the entire label name with quotes.

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
@@ -45,7 +45,7 @@ Follow the instructions below to display a list of APIs or API Products in an en
                 apictl get apis --environment production --limit 15 
                 ```    
                 ```go
-                apictl get apis --environment production --query provider:Alice name:PizzaShackAPI 
+                apictl get apis --environment production --query provider:Alice --query name:PizzaShackAPI 
                 ```  
 
         -   **Response**
@@ -61,8 +61,9 @@ Follow the instructions below to display a list of APIs or API Products in an en
                 search for APIs.
                 You can search in attributes by using a `:` modifier. Supported attribute modifiers are **name**, 
                 **version**, **provider**, **context**, **status**, **description**, **subcontext**, **doc** and 
-                **label**.  You can also use combined modifiers.  
-                **Example:**
+                **label**.  You can also use multiple modifiers specified by multiple `-q` or `--query` flags in the same command.  
+                
+                **Examples:**
                    
                 -  `provider:wso2` will match an API if the provider of the API contains `wso2`.
                 -  `'provider:"wso2"'` will match an API if the provider of the API is exactly `wso2`.
@@ -109,7 +110,7 @@ Follow the instructions below to display a list of APIs or API Products in an en
                 apictl get api-products --environment production 
                 ```    
                 ```go
-                apictl get api-products --environment production --query provider:Alice name:PizzaShackAPI --limit 25 
+                apictl get api-products --environment production --query provider:Alice --query name:PizzaShackAPI --limit 25 
                 ```  
 
         -   **Response**


### PR DESCRIPTION
## Purpose
Partially fixes https://github.com/wso2/product-apim-tooling/issues/558
Fixes: https://github.com/wso2/product-apim-tooling/issues/704

## Goals
Fix the incorrect flags and examples of undeploy/get commands and add the initial content for About this Release section of APICTL.

## Approach
- Modified the About this Release section of APICTL as below.
  ![image](https://user-images.githubusercontent.com/25246848/115538930-036ca280-a2ba-11eb-8b56-9cecb04b7429.png)
- Modified the examples of **apictl undeploy** and **apictl get apis/api-products** commands