### PR TITLE
Update docsearch:version in base.html

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -12,7 +12,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">
       <meta name="docsearch:language" content="en" />
-      <meta name="docsearch:version" content="next" />
+      <meta name="docsearch:version" content="4.0.0" />
       <meta name="robots" content="noindex" />
       <meta http-equiv="x-ua-compatible" content="ie=edge">
       {% if page and page.meta and page.meta.description %}


### PR DESCRIPTION
## Purpose

Update `docsearch:version` to 4.0.0

Note: Currently APIM latest document search is not working due to missing indexing for the latest version.

This change will update the `docsearch` meta tag and it will take at most 24 H to update the algolia index and search results to appear on the page.  

Here is a quick fix https://github.com/wso2/docs-apim/pull/3844, We can update the `docsearch` to get the indexing correct , and use `next` facet filter in the search query to get the latest doc result, Since currently `next` index pointing to the latest docs.
And once the indexing is done , we can change only the facet filter from `next` to `4.0.0`