### PR TITLE
[3.2.x] Adding docs on overriding policies using the api_params.yaml via apictl

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -36,7 +36,10 @@ environments:
       mutualSslCerts:
           - tierName: <subscription_tier_name>
             alias: <certificate_alias>
-            path: <certificate_file_path>            
+            path: <certificate_file_path>
+	  policies:
+          - <subscription_policy_1_name>
+          - <subscription_policy_2_name>
 ```
 The following code snippet contains sample configuration of the parameter file.
 
@@ -57,7 +60,10 @@ The following code snippet contains sample configuration of the parameter file.
                 alias: Dev
                 path: ~/.certs/dev.pem 
           gatewayEnvironments:
-              - Production and Sandbox    
+              - Production and Sandbox
+          policies:
+              - Gold
+              - Silver
         - name: test
           endpoints:
               production:


### PR DESCRIPTION
## Purpose
Adding the documentation on overriding policies using the api_params.yaml via apictl. 

## Goals
The doc changes for for apictl 3.2.2 has been added.

## Approach
- Added the policies field to the api_params.yaml template
  ![image](https://user-images.githubusercontent.com/25246848/118428318-d068d380-b6ec-11eb-86ef-23ce67766acb.png)
- Added the examples
  ![image](https://user-images.githubusercontent.com/25246848/118428364-e70f2a80-b6ec-11eb-95bf-8f0b58a1b079.png)

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/745