### PR TITLE
(4.0.0 branch) Updating the default ports documentation

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
@@ -154,7 +154,7 @@ The default port offset in each of the WSO2 Streaming Integrator components is `
 
 #### Changing the Binary and Thrift ports
 
-You can offset the binary and thrift ports by configuring the offset parameter in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` file. 
+You can offset the binary and thrift ports by configuring the offset parameter in the `<SI_HOME>|<SI_TOOLING_HOME>|<SI_DASHBOARD_HOME>/conf/server/deployment.yaml` file. 
 
 The following is a sample configuration:
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
@@ -4,16 +4,19 @@ When you run multiple runtimes on the same server or virtual machines (VMs), you
 
 For example, if the default HTTP port is 9763 and the offset is 1, the effective HTTP port changes to 9764. For each additional WSO2 product instance running on the same machine, you set the port offset to a unique value.
 
-!!! Info
-    See the complete list of [Default API-M ports]({{base_path}}/administer/product-configurations/default-product-ports/).
-
 There are two ways to set an offset to a port: Update the server configurations, or pass the port offset during server startup. See the instructions given below to port offset the three runtimes of WSO2 API Manager.
+
+## Before you begin
+
+See the complete list of [default ports]({{base_path}}/administer/product-configurations/default-product-ports/) in all the API Manager components.
+
+Note that most of the **runtime ports** change automatically based on the offset you specify here.
 
 ## Changing the default API-M ports
 
 The default port offset in the WSO2 API-M runtime is `0`. Use one of the following two methods to apply an offset to the API-M runtime.
 
-### Update the server configurations
+#### Update the server configurations
 
 1. [Stop the API-M server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/#stopping-the-server) if it is already running.
 
@@ -34,7 +37,7 @@ The default port offset in the WSO2 API-M runtime is `0`. Use one of the followi
 
 4. [Restart the server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/).
 
-### Pass the port offset during server startup
+#### Pass the port offset during server startup
 
 1.  [Stop the API-M server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/#stopping-the-server) if it is already running.
 
@@ -73,7 +76,7 @@ The default port offset in the WSO2 Micro Integrator runtime is `10`. Use one of
 		- `9164` -> `9157` (9164 - 10 + 3)
 	-	Note that if you manually set an offset of 10 using the following method, you will get the same default ports.
 
-### Update the server configurations
+#### Update the server configurations
 
 1. [Stop the MI server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/#stopping-the-server) if it is already running.
 
@@ -93,7 +96,7 @@ The default port offset in the WSO2 Micro Integrator runtime is `10`. Use one of
 
 4. [Restart the server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/).
 
-### Pass the port offset during server startup
+#### Pass the port offset during server startup
 
 1.  [Stop the MI server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/#stopping-the-server) if it is already running.
 
@@ -119,7 +122,7 @@ The default port offset in the WSO2 Micro Integrator runtime is `10`. Use one of
         micro-integrator.bat -DportOffset=3
         ```
 
-## Changing the default EI Analytics ports
+#### Changing the default EI Analytics ports
 
 If required, you can manually change the HTTP/HTTPS ports in the `deployment.yaml` file (stored in `EI_ANALYTICS_HOME/conf/server` folder) as shown below.
 
@@ -145,3 +148,49 @@ listenerConfigurations:
   port: http_port
 ```
 
+## Changing the default SI ports
+
+The default port offset in each of the WSO2 Streaming Integrator components is `0`. The components include the Streaming Integrator runtime, Tooling, and the Dashboard.
+
+#### Changing the Binary and Thrift ports
+
+You can offset the binary and thrift ports by configuring the offset parameter in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` file. 
+
+The following is a sample configuration:
+
+```yaml
+# Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+id: wso2-si
+    # server name
+name: WSO2 Streaming Integrator
+    # server type
+type: wso2-si
+    # ports used by this server
+ports:
+    # port offset
+    offset: 1
+```
+
+#### Changing the default Netty ports
+
+You can offset the default netty ports by updating the required parameters in the `<SI_HOME>|<SI_TOOLING_HOME>|<SI_DASHBOARD_HOME>/conf/server/deployment.yaml` file. 
+
+The following is a sample configuration:
+
+```yaml
+wso2.transport.http:
+    transportProperties:
+    listenerConfigurations:
+    -
+    id: "default"
+    port: 9390
+    -
+    id: "msf4j-https"
+    port: 9743
+```
+
+## What's Next?
+
+You need to restart the server for these changes to take effect.

--- a/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
@@ -150,46 +150,87 @@ listenerConfigurations:
 
 ## Changing the default SI ports
 
-The default port offset in each of the WSO2 Streaming Integrator components is `0`. The components include the Streaming Integrator runtime, Tooling, and the Dashboard.
+The default port offsets in the WSO2 Streaming Integrator (SI) runtime and the Streaming Integrator **Tooling** runtime is `0` and `3` respectively.
 
 #### Changing the Binary and Thrift ports
 
-You can offset the binary and thrift ports by configuring the offset parameter in the `<SI_HOME>|<SI_TOOLING_HOME>|<SI_DASHBOARD_HOME>/conf/server/deployment.yaml` file. 
+To offset the binary and thrift ports:
 
-The following is a sample configuration:
+1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
+    
+    !!! Info
+        The file is stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory. 
 
-```yaml
-# Carbon Configuration Parameters
-wso2.carbon:
-    # value to uniquely identify a server
-id: wso2-si
-    # server name
-name: WSO2 Streaming Integrator
-    # server type
-type: wso2-si
-    # ports used by this server
-ports:
-    # port offset
-    offset: 1
-```
+2.  Update the port offset parameter:
+
+    ```yaml tab="SI Runtime Configuration"
+    # Carbon Configuration Parameters
+    wso2.carbon:
+        # value to uniquely identify a server
+    id: wso2-si
+        # server name
+    name: WSO2 Streaming Integrator
+        # server type
+    type: wso2-si
+        # ports used by this server
+    ports:
+        # port offset
+        offset: 0
+    ```
+
+    ```yaml tab="Tooling Runtime Configuration"
+    # Carbon Configuration Parameters
+    wso2.carbon:
+        # value to uniquely identify a server
+    id: wso2-si
+        # server name
+    name: WSO2 Streaming Integrator Tooling
+        # ports used by this server
+    ports:
+        # port offset
+        offset: 3
+    ```
 
 #### Changing the default Netty ports
 
-You can offset the default netty ports by updating the required parameters in the `<SI_HOME>|<SI_TOOLING_HOME>|<SI_DASHBOARD_HOME>/conf/server/deployment.yaml` file. 
+To change the default netty ports: 
 
-The following is a sample configuration:
+1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
+    
+    !!! Info
+        The file is stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory. 
 
-```yaml
-wso2.transport.http:
-    transportProperties:
-    listenerConfigurations:
-    -
-    id: "default"
-    port: 9390
-    -
-    id: "msf4j-https"
-    port: 9743
-```
+2.  Update the port offset parameter:
+
+    ```yaml tab="SI Runtime"
+    wso2.transport.http:
+        transportProperties:
+        ........
+        listenerConfigurations:
+        -
+        id: "default"
+        host: "0.0.0.0"
+        port: 9090
+        -
+        id: "msf4j-https"
+        host: "0.0.0.0"
+        port: 9443
+    ```
+
+    ```yaml tab="SI Tooling"
+    wso2.transport.http:
+        transportProperties:
+        ........
+        listenerConfigurations:
+        -
+        id: "default"
+        host: "0.0.0.0"
+        port: 9387
+        -
+        id: "msf4j-https"
+        host: "0.0.0.0"
+        port: 9740
+    ```
 
 ## What's Next?
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
@@ -150,11 +150,13 @@ listenerConfigurations:
 
 ## Changing the default SI ports
 
-The default port offsets in the WSO2 Streaming Integrator (SI) runtime and the Streaming Integrator **Tooling** runtime is `0` and `3` respectively.
+The default port offsets in the WSO2 Streaming Integrator (SI) runtime and the Streaming Integrator **Tooling** runtime are `0` and `3` respectively. 
 
 #### Changing the Binary and Thrift ports
 
-To offset the binary and thrift ports:
+To offset the default ports in the SI runtime and SI Tooling runtime, you need to offset the **binary** and **thrift** ports.
+
+Follow the steps given below.
 
 1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
     
@@ -193,44 +195,50 @@ To offset the binary and thrift ports:
 
 #### Changing the default Netty ports
 
-To change the default netty ports: 
+Shown below are the default Netty ports of the SI runtime and the SI Tooling runtime when you have a [default port offset](#changing-the-binary-and-thrift-ports) for these runtimes.
+
+!!! Note   
+    If you [change the default offset](#changing-the-binary-and-thrift-ports), the netty ports are affected.
+
+```yaml tab="SI Runtime"
+wso2.transport.http:
+    transportProperties:
+    ........
+    listenerConfigurations:
+    -
+    id: "default"
+    host: "0.0.0.0"
+    port: 9090
+    -
+    id: "msf4j-https"
+    host: "0.0.0.0"
+    port: 9443
+```
+
+```yaml tab="SI Tooling"
+wso2.transport.http:
+    transportProperties:
+    ........
+    listenerConfigurations:
+    -
+    id: "default"
+    host: "0.0.0.0"
+    port: 9387
+    -
+    id: "msf4j-https"
+    host: "0.0.0.0"
+    port: 9740
+```
+
+To change the Netty ports:
 
 1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
     
     !!! Info
         The file is stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory. 
 
-2.  Update the port offset parameter:
-
-    ```yaml tab="SI Runtime"
-    wso2.transport.http:
-        transportProperties:
-        ........
-        listenerConfigurations:
-        -
-        id: "default"
-        host: "0.0.0.0"
-        port: 9090
-        -
-        id: "msf4j-https"
-        host: "0.0.0.0"
-        port: 9443
-    ```
-
-    ```yaml tab="SI Tooling"
-    wso2.transport.http:
-        transportProperties:
-        ........
-        listenerConfigurations:
-        -
-        id: "default"
-        host: "0.0.0.0"
-        port: 9387
-        -
-        id: "msf4j-https"
-        host: "0.0.0.0"
-        port: 9740
-    ```
+2.  Update the listener ports.
+    
 
 ## What's Next?
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset.md
@@ -150,22 +150,15 @@ listenerConfigurations:
 
 ## Changing the default SI ports
 
-The default port offsets in the WSO2 Streaming Integrator (SI) runtime and the Streaming Integrator **Tooling** runtime are `0` and `3` respectively. 
-
-#### Changing the Binary and Thrift ports
-
-To offset the default ports in the SI runtime and SI Tooling runtime, you need to offset the **binary** and **thrift** ports.
+The default port offset in the WSO2 Streaming Integrator (SI) runtime and the SI Tooling runtime are `0` and `3` respectively. Setting a port offset changes the **thrift**, **binary**, and **management** [ports of the SI runtimes]({{base_path}}/install-and-setup/setup/reference/default-product-ports/streaming-integrator-ports).
 
 Follow the steps given below.
 
-1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
-    
-    !!! Info
-        The file is stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory. 
+1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime (stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory). 
 
-2.  Update the port offset parameter:
+2.  Update the port offset parameters in the following configurations:
 
-    ```yaml tab="SI Runtime Configuration"
+    ```yaml tab="SI runtime"
     # Carbon Configuration Parameters
     wso2.carbon:
         # value to uniquely identify a server
@@ -180,8 +173,8 @@ Follow the steps given below.
         offset: 0
     ```
 
-    ```yaml tab="Tooling Runtime Configuration"
-    # Carbon Configuration Parameters
+    ```yaml tab="SI Tooling runtime"
+      # Carbon Configuration Parameters
     wso2.carbon:
         # value to uniquely identify a server
     id: wso2-si
@@ -192,53 +185,6 @@ Follow the steps given below.
         # port offset
         offset: 3
     ```
-
-#### Changing the default Netty ports
-
-Shown below are the default Netty ports of the SI runtime and the SI Tooling runtime when you have a [default port offset](#changing-the-binary-and-thrift-ports) for these runtimes.
-
-!!! Note   
-    If you [change the default offset](#changing-the-binary-and-thrift-ports), the netty ports are affected.
-
-```yaml tab="SI Runtime"
-wso2.transport.http:
-    transportProperties:
-    ........
-    listenerConfigurations:
-    -
-    id: "default"
-    host: "0.0.0.0"
-    port: 9090
-    -
-    id: "msf4j-https"
-    host: "0.0.0.0"
-    port: 9443
-```
-
-```yaml tab="SI Tooling"
-wso2.transport.http:
-    transportProperties:
-    ........
-    listenerConfigurations:
-    -
-    id: "default"
-    host: "0.0.0.0"
-    port: 9387
-    -
-    id: "msf4j-https"
-    host: "0.0.0.0"
-    port: 9740
-```
-
-To change the Netty ports:
-
-1.  Open the `deployment.toml` file of the SI runtime or the SI Tooling runtime.
-    
-    !!! Info
-        The file is stored in the `<SI_HOME>|<SI_TOOLING_HOME>/conf/server/deployment.yaml` directory. 
-
-2.  Update the listener ports.
-    
 
 ## What's Next?
 

--- a/en/docs/install-and-setup/setup/reference/default-product-ports.md
+++ b/en/docs/install-and-setup/setup/reference/default-product-ports.md
@@ -201,7 +201,7 @@ By default, the Micro Integrator is **internally** configured with a port offset
 
 ## Streaming Integrator Ports
 
-Listed below are the ports used by the Streaming Integrator and its components when the port offset is `0`.
+Listed below are the default ports used by the Streaming Integrator runtime and the Streaming Integrator Tooling runtime. The defualt port offset in these runtimes are `0` and `3` respectively.
 
 !!! Info
     See the instructions on [changing the default SI ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-si-ports).
@@ -252,7 +252,7 @@ Listed below are the ports used by the Streaming Integrator and its components w
       </table>
 
 
--  Netty ports:
+-  Management ports:
 
     **Streaming Integrator runtime**
 
@@ -305,35 +305,6 @@ Listed below are the ports used by the Streaming Integrator and its components w
          <tr>
             <td>
                   <code>9743</code>
-            </td>
-            <td>
-                  HTTPS netty transport.
-            </td>
-         </tr>
-      </table>
-
-    **Streaming Integrator Dashboard**:
-
-      <table>
-         <tr>
-            <th>
-                  Default Port
-            </th>
-            <th>
-                  Description
-            </th>
-         </tr>
-         <tr>
-            <td>
-                  <code>9290</code>
-            </td>
-            <td>
-                  HTTP netty transport.
-            </td>
-         </tr>
-         <tr>
-            <td>
-                  <code>9643</code>
             </td>
             <td>
                   HTTPS netty transport.

--- a/en/docs/install-and-setup/setup/reference/default-product-ports.md
+++ b/en/docs/install-and-setup/setup/reference/default-product-ports.md
@@ -2,15 +2,15 @@
 
 This page describes the default ports used by each runtime of WSO2 API Manager.
 
-!!! Attention
-    **Note** that it is recommended to disable the HTTP transport in an API Manager production setup. Using the `Bearer` token over HTTP is a violation of the OAuth specification and can lead to security vulnerabilities.
-
 !!! Note
-    If you change the default runtime ports with a port offset, most of the runtime ports change automatically based on the offset.
+    If you [change the default runtime ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset) with a port offset, most of the runtime ports change automatically based on the offset.
 
 ## API-M ports
 
 Listed below are the ports used by the API-M runtime when the [port offset]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#configuring-the-port-offset) is 0.
+
+!!! Info
+    See the instructions on [changing the default MI ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-api-m-ports).
 
 <table>
     <tr>
@@ -139,6 +139,9 @@ Listed below are the ports used by the API-M runtime when the [port offset]({{ba
 
 By default, the Micro Integrator is **internally** configured with a port offset of 10. Listed below are the ports that are effective in the Micro Integrator by default (due to the internal port offset of 10).
 
+!!! Info
+    See the instructions on [changing the default MI ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-mi-ports).
+
 <table>
     <tr>
         <th>
@@ -196,6 +199,210 @@ By default, the Micro Integrator is **internally** configured with a port offset
     </tr>
 </table>
 
+## Streaming Integrator Ports
+
+Listed below are the ports used by the Streaming Integrator and its components when the port offset is `0`.
+
+!!! Info
+    See the instructions on [changing the default SI ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-si-ports).
+
+-  Thrift and Binary ports:
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>7611</code>
+            </td>
+            <td>
+                  Thrift TCP port to receive events from clients.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>7711</code>
+            </td>
+            <td>
+                  Thrift SSL port for secure transport where the client is authenticated.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9611</code>
+            </td>
+            <td>
+                  Binary TCP port to receive events from clients.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9711 </code>
+            </td>
+            <td>
+                  Binary SSL port for secure transport where the client is authenticated.
+            </td>
+         </tr>
+      </table>
+
+
+-  Netty ports:
+
+    **Streaming Integrator runtime**
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>9090</code>
+            </td>
+            <td>
+                  HTTP netty transport.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9443</code>
+            </td>
+            <td>
+                  HTTPS netty transport.
+            </td>
+         </tr>
+      </table>
+
+    **Streaming Integrator Tooling runtime**:
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>9390</code>
+            </td>
+            <td>
+                  HTTP netty transport.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9743</code>
+            </td>
+            <td>
+                  HTTPS netty transport.
+            </td>
+         </tr>
+      </table>
+
+    **Streaming Integrator Dashboard**:
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>9290</code>
+            </td>
+            <td>
+                  HTTP netty transport.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9643</code>
+            </td>
+            <td>
+                  HTTPS netty transport.
+            </td>
+         </tr>
+      </table>
+
+-  Streaming Integrator clustering ports:
+
+      **Minimum High Availability (HA) Deployment**
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>9090</code>
+            </td>
+            <td>
+                  HTTP netty transport.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9090</code>
+            </td>
+            <td>
+                  Specify the port of the node for the `advertisedPort` parameter in the `liveSync` section. The HTTP netty transport port is considered the default port.
+            </td>
+         </tr>
+         <tr>
+            <td>
+                  <code>9443</code>
+            </td>
+            <td>
+                  HTTPS netty transport.
+            </td>
+         </tr>
+      </table>
+
+      **Multi Datacenter High-Availability Deployment**:
+
+      In addition to the ports used in clustering setups (i.e. a minimum HA deployment or a scalable cluster), the port given below is required.
+
+      <table>
+         <tr>
+            <th>
+                  Default Port
+            </th>
+            <th>
+                  Description
+            </th>
+         </tr>
+         <tr>
+            <td>
+                  <code>9092</code>
+            </td>
+            <td>
+                  Ports of the two separate instances of the broker deployed in each data center (e.g., `bootstrap.servers= 'host1:9092, host2:9092'. The default is `9092` where the external kafka servers start.).
+            </td>
+         </tr>
+      </table>
+
 ## Random ports
 
 Certain ports are randomly opened during server startup. This is due to the specific properties and configurations that become effective when the product is started. Note that the IDs of these random ports will change every time the server is started.
@@ -203,37 +410,3 @@ Certain ports are randomly opened during server startup. This is due to the spec
 -   A random TCP port will open at server startup because the `-Dcom.sun.management.jmxremote` property is set in the server startup script. This property is used for the JMX monitoring facility in JVM.
 
 -   A random UDP port is opened at server startup due to the log4j appender (`SyslogAppender`), which is configured in the `<PRODUCT_HOME>/repository/conf/log4j2.properties` file.
-
-## Disabling HTTP Transports
-
-API Manager has two HTTP transports. See below for instructions on how to disable the following:
-
-1.  Passthru (API Traffic) Transport
-2.  Servlet (UI Traffic and Admin service access) Transport
-
-### Disabling Passthrough Transport
-
-Add the following configuration in the `deployment.toml` file which resides in the `<API-M_HOME>/repository/conf` directory.
-
-``` toml
-[transport.passthru_http.listener]
-enable = false
-```
-
-### Disabling Servlet Transport
-
-1.  Open the `<API-M_HOME>/repository/conf/tomcat/catalina-server.xml` file.
-2.  Locate the Connector with port 9763 as shown below:
-
-    **HTTP Transport Receiver**
-
-    ``` xml
-    <Connector protocol="org.apache.coyote.http11.Http11NioProtocol" port="9763"
-        ...
-    />
-    ```
-
-3.  Comment out the HTTP connector section.
-
-!!! Note
-    You need to restart the server for these changes to take effect.

--- a/en/docs/install-and-setup/setup/reference/default-product-ports.md
+++ b/en/docs/install-and-setup/setup/reference/default-product-ports.md
@@ -3,14 +3,14 @@
 This page describes the default ports used by each runtime of WSO2 API Manager.
 
 !!! Note
-    If you [change the default runtime ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset) with a port offset, most of the runtime ports change automatically based on the offset.
+    If you [change the default runtime ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset), most of the runtime ports change automatically based on the offset.
 
 ## API-M ports
 
 Listed below are the ports used by the API-M runtime when the [port offset]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#configuring-the-port-offset) is 0.
 
 !!! Info
-    See the instructions on [changing the default MI ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-api-m-ports).
+    See the instructions on [changing the default API-I ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-api-m-ports).
 
 <table>
     <tr>

--- a/en/docs/install-and-setup/setup/reference/default-product-ports.md
+++ b/en/docs/install-and-setup/setup/reference/default-product-ports.md
@@ -230,7 +230,7 @@ Listed below are the ports used by the Streaming Integrator and its components w
                   <code>7711</code>
             </td>
             <td>
-                  Thrift SSL port for secure transport where the client is authenticated.
+                  Thrift SSL port for the secure transport where the client is authenticated.
             </td>
          </tr>
          <tr>
@@ -246,7 +246,7 @@ Listed below are the ports used by the Streaming Integrator and its components w
                   <code>9711 </code>
             </td>
             <td>
-                  Binary SSL port for secure transport where the client is authenticated.
+                  Binary SSL port for the secure transport where the client is authenticated.
             </td>
          </tr>
       </table>
@@ -367,7 +367,7 @@ Listed below are the ports used by the Streaming Integrator and its components w
                   <code>9090</code>
             </td>
             <td>
-                  Specify the port of the node for the `advertisedPort` parameter in the `liveSync` section. The HTTP netty transport port is considered the default port.
+                  The port of the node for the <code>advertisedPort</code> parameter in the <code>liveSync</code> section. The HTTP netty transport port is considered the default port.
             </td>
          </tr>
          <tr>
@@ -380,9 +380,9 @@ Listed below are the ports used by the Streaming Integrator and its components w
          </tr>
       </table>
 
-      **Multi Datacenter High-Availability Deployment**:
+      **Multi Datacenter High-Availability Deployment**
 
-      In addition to the ports used in clustering setups (i.e. a minimum HA deployment or a scalable cluster), the port given below is required.
+      In addition to the ports used in clustering setups (i.e. a minimum HA deployment or a scalable cluster), the following port is required:
 
       <table>
          <tr>

--- a/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
+++ b/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
@@ -1,12 +1,12 @@
 # Configuring Transport Level Security
 
-Given below are the various transport-level security configurations that are required for WSO2 products. See the following topics for instructions.
+Given below are the various transport-level security configurations that are required for WSO2 API Manager. See the following topics for instructions.
 
 -   [Enabling SSL protocols and ciphers in ThriftAuthenticationService](#enabling-ssl-protocols-and-ciphers-in-thriftauthenticationservice)
 -   [Disabling weak ciphers](#disabling-weak-ciphers)
 -   [Changing the server name in HTTP response headers](#changing-the-server-name-in-http-response-headers)
 
-### Enabling SSL protocols and ciphers in ThriftAuthenticationService
+## Enabling SSL protocols and ciphers in ThriftAuthenticationService
 
 Do the following to enable SSL protocols and ciphers in the `ThriftAuthenticationService.        `
 
@@ -17,24 +17,24 @@ Do the following to enable SSL protocols and ciphers in the `ThriftAuthenticatio
     <Ciphers>TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256</Ciphers>
     ```
 
-!!! tip
-    You can also add the following additional cipher suites to the `<Ciphers>` property if JCE Unlimited Strength Jurisdiction Policy is enabled in Java.
+    !!! tip
+        You can also add the following additional cipher suites to the `<Ciphers>` property if JCE Unlimited Strength Jurisdiction Policy is enabled in Java.
 
-    ``` java
-    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WIT
-    ```
+        ``` java
+        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WIT
+        ```
 
     If you wish to remove `TLSv1` or `TLSv1.1` , you can do so by removing them as values from the `<SSLEnabledProtocols>` property.
 
 2.  Restart the server.
 
-### Disabling weak ciphers
+## Disabling weak ciphers
 
 A cipher is an algorithm for performing encryption or decryption. When you set the `sslprotocol` of your server to TLS, the TLS and the default ciphers get enabled without considering the strength of the ciphers. This is a security risk as weak ciphers, also known as EXPORT ciphers, can make your system vulnerable to attacks such as the Logjam attack on Diffie-Hellman key exchange. The Logjam attack is also called the Man-in-the-Middle attack. It downgrades your connection's encryption to a less-secured level (e.g., 512 bit) that can be decrypted with sufficient processing power.
 
 To prevent these types of security attacks, it is encouraged to disable the weak ciphers. You can enable only the ciphers that you want the server to support in a comma-separated list in the `ciphers` attribute. Also, if you do not add this cipher attribute or keep it blank, the browser will support all the SSL ciphers by JSSE. This will enable the weak ciphers.
 
-#### Disabling weak ciphers for the Tomcat transport
+### Disabling weak ciphers for the Tomcat transport
 
 1.  Open the `<PRODUCT_HOME>/repository/conf/deployment.toml` file.
 2.  Take a backup of the `deployment.toml` file and stop the Carbon server.
@@ -49,25 +49,26 @@ To prevent these types of security attacks, it is encouraged to disable the weak
 4.  Start the server.
 5.  To verify that the configurations are all set correctly, download and run the [TestSSLServer.jar]({{base_path}}/assets/attachments/administer/TestSSLServer.jar).
 
-    ``` java
-    $ java -jar TestSSLServer.jar localhost 9443
-    ```
+    !!! note
+        Note the following when you run `TestSSLServer.jar` :
 
-!!! note
-    Note the following when you run `TestSSLServer.jar` :
+        -   The "Supported cipher suites" section in the output does not contain any EXPORT ciphers.
 
-    -   The "Supported cipher suites" section in the output does not contain any EXPORT ciphers.
+        -   When you use the supported cipher suites listed [here](https://docs.wso2.com/display/ADMIN44x/Supported+Cipher+Suites) , the BEAST attack status will be shown as vulnerable. Note that this is a client-side vulnerability caused by the TLSv1 protocol. You can make the BEAST status protected by removing TLSv1, which will make clients with TLSv1 unusable. Therefore, it is recommended tofixed this from the client side.
 
-    -   When you use the supported cipher suites listed [here](https://docs.wso2.com/display/ADMIN44x/Supported+Cipher+Suites) , the BEAST attack status will be shown as vulnerable. Note that this is a client-side vulnerability caused by the TLSv1 protocol. You can make the BEAST status protected by removing TLSv1, which will make clients with TLSv1 unusable. Therefore, it is recommended tofixed this from the client side.
+        ``` java
+        $ java -jar TestSSLServer.jar localhost 9443
+        ```
 
 !!! info
     From **Firefox** 39.0 onwards, the browser does not allow to access Web sites that support DHE with keys less than 1023 bits (not just DHE\_EXPORT). 768/1024 bits are considered to be too small and vulnerable to attacks if the hacker has enough computing resources.
-!!! tip
-    To use AES-256, the Java JCE Unlimited Strength Jurisdiction Policy files need to be installed. Download them from [http://www.oracle.com/technetwork/java/javase/downloads/index.html](index) .
-!!! tip
-    From Java 7, you must set the `jdk.certpath.disabledAlgorithms` property in the `<JAVA_HOME>/jre/lib/security/java.security` file to `jdk.certpath.disabledAlgorithms=MD2, DSA, RSA keySize < 2048` . It rejects all algorithms that have key sizes less than 2048 for MD2, DSA and RSA.
 
-### Changing the server name in HTTP response headers
+!!! tip
+
+    -   To use AES-256, the Java JCE Unlimited Strength Jurisdiction Policy files need to be installed. Download them from [http://www.oracle.com/technetwork/java/javase/downloads/index.html](index) .
+    -   From Java 7, you must set the `jdk.certpath.disabledAlgorithms` property in the `<JAVA_HOME>/jre/lib/security/java.security` file to `jdk.certpath.disabledAlgorithms=MD2, DSA, RSA keySize < 2048` . It rejects all algorithms that have key sizes less than 2048 for MD2, DSA and RSA.
+
+## Changing the server name in HTTP response headers
 
 By default, all WSO2 products pass "WSO2 Carbon Server" as the server value in HTTP headers when sending HTTP responses. This means that information about the WSO2 product stack will be exposed through HTTP responses. It is recommended to change this by configuring the server name in the `deployment.toml` file.
 
@@ -82,7 +83,42 @@ By default, all WSO2 products pass "WSO2 Carbon Server" as the server value in H
     server="WSO2 Carbon Server"
     ```
 
-!!! info
-    See the [Security Guidelines for Production Deployment](https://docs.wso2.com/display/ADMIN44x/Security+Guidelines+for+Production+Deployment) for the full list of security-related recommendations for WSO2 products.
+## Disabling HTTP Transports
 
+!!! Note
+    It is recommended to disable the HTTP transport in an API Manager production setup. Using the `Bearer` token over HTTP is a violation of the OAuth specification and can lead to security vulnerabilities.
 
+API Manager has two HTTP transports.
+
+-   Passthru (API Traffic) Transport
+-   Servlet (UI Traffic and Admin service access) Transport
+
+See the instructions given below to disable these transports.
+
+### Disabling Passthrough Transport
+
+Add the following configuration in the `deployment.toml` file (stored in the `<API-M_HOME>/repository/conf` folder).
+
+```toml
+[transport.passthru_http.listener]
+enable = false
+```
+
+### Disabling Servlet Transport
+
+1.  Open the `<API-M_HOME>/repository/conf/tomcat/catalina-server.xml` file.
+2.  Locate the Connector with port 9763 as shown below:
+
+    **HTTP Transport Receiver**
+
+    ``` xml
+    <Connector protocol="org.apache.coyote.http11.Http11NioProtocol" port="9763"
+        ...
+    />
+    ```
+
+3.  Comment out the HTTP connector section.
+
+## What's Next?
+
+See the [Security Guidelines for Production Deployment]({{base_path}}/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment) for the full list of security-related recommendations for WSO2 API Manager.


### PR DESCRIPTION
- Adding streaming integration ports
- Consolidating the link between 'Changing default ports' and the 'list of default ports' for all of the API Manager runtimes.
- Moved the section on 'disabling the HTTP transport for the API-M runtime' from the Ports documentation to https://apim.docs.wso2.com/en/latest/install-and-setup/setup/security/configuring-transport-level-security/

Fixes https://github.com/wso2/docs-apim/issues/3956