### PR TITLE
Fix image size in threat protection docs

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/json-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/json-threat-protection-for-api-gateway.md
@@ -53,7 +53,7 @@ in sequence.
 
 -   Select `json\_validator` from the drop-down menu for Common Policies.
 
-    [ ![]({{base_path}}/assets/img/learn/mediation-json-validator.png) ]({{base_path}}/assets/img/learn/mediation-json-validator.png)
+    <a href="{{base_path}}/assets/img/learn/mediation-json-validator.png"><img src="{{base_path}}/assets/img/learn/mediation-json-validator.png" width="70%" alt="Select JSON validator from the drop-down menu"></a> 
 
 -   Scroll down the page and click **Save** to save the changes.
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
@@ -86,7 +86,7 @@ regex\_policy in sequence.
 3.  Select **Edit** in the message mediation bar and select **Common Policies** .
 4.  Select `regex_policy` from the drop-down menu for Common Policies.
 
-    [ ![]({{base_path}}/assets/img/learn/mediation-regex-policy.png) ]({{base_path}}/assets/img/learn/mediation-regex-policy.png)
+    <a href="{{base_path}}/assets/img/learn/mediation-regex-policy.png"><img src="{{base_path}}/assets/img/learn/mediation-regex-policy.png" width="70%" alt="Select Regex policy from the drop-down menu"></a> 
     
 4.  Scroll down the page and click **Save** to save the changes.
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
@@ -102,8 +102,6 @@ in sequence.
 
 -   Select `xml_validator` from the drop-down menu for Common Policies.
 
-    ![]({{base_path}}/assets/img/learn/mediation-xml-validator.png)
-
     <a href="{{base_path}}/assets/img/learn/mediation-xml-validator.png"><img src="{{base_path}}/assets/img/learn/mediation-xml-validator.png" width="70%" alt="Select XML validator from the drop-down menu"></a> 
 
     

--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway.md
@@ -103,6 +103,9 @@ in sequence.
 -   Select `xml_validator` from the drop-down menu for Common Policies.
 
     ![]({{base_path}}/assets/img/learn/mediation-xml-validator.png)
+
+    <a href="{{base_path}}/assets/img/learn/mediation-xml-validator.png"><img src="{{base_path}}/assets/img/learn/mediation-xml-validator.png" width="70%" alt="Select XML validator from the drop-down menu"></a> 
+
     
 -   Scroll down the page and click **Save** to save the changes.
 


### PR DESCRIPTION
Fixed in the following pages:

- https://apim.docs.wso2.com/en/latest/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway/
- https://apim.docs.wso2.com/en/latest/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/json-threat-protection-for-api-gateway/
- https://apim.docs.wso2.com/en/latest/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/xml-threat-protection-for-api-gateway/