### PR TITLE
fixes broken link

### DIFF
--- a/en/docs/includes/analytics/configure-synapse-gateway.md
+++ b/en/docs/includes/analytics/configure-synapse-gateway.md
@@ -13,7 +13,7 @@ Follow the instructions below to publish analytics data to the analytics cloud v
       <div class="admonition note">
       <p class="admonition-title">Note</p>
       <ul><li><p>This is the basic configuration that you need to publish analytics data to the analytics cloud.</p></li>
-      <li>If you need to change the following default values of the Worker Thread Count, Queue Size or Client Flushing Delay, see the <a href="/../../../../../api-analytics/gateways/configure-synapse-gateway/#advanced-configurations">Advanced configurations</a>.
+      <li>If you need to change the following default values of the Worker Thread Count, Queue Size or Client Flushing Delay, see the <a href="https://apim.docs.wso2.com/en/4.0.0/api-analytics/gateways/configure-synapse-gateway/#advanced-configurations">Advanced configurations</a>.
       <table>
       <tr>
       <th><b>Parameter</b></th>


### PR DESCRIPTION
## Purpose
- Added absolute link because the relative link breaks when used with the include plug-in
- fixes https://github.com/wso2/docs-apim/issues/4165