### PR TITLE
Add 'Configuring Allowed Origins for REST APIs' Content

### DIFF
--- a/en/docs/reference/product-apis/advanced-configurations.md
+++ b/en/docs/reference/product-apis/advanced-configurations.md
@@ -12,3 +12,118 @@ You can modify the default roles defined in RESTAPIScopes configuration accordin
 
 !!! note
     Restart the server for the RESTAPIScopes configuration changes to take effect.
+
+##Configuring Allowed Origins
+
+By default, each of the Product REST APIs (except Admin v2 REST API) allows requests from all origins. If only a specific set of origins should be allowed to access a Product REST API, the allowed origins for that particular REST API should be configured as a system parameter. The defined system parameters are as follows.
+
+-   For Publisher REST APIs : rest.api.publisher.allowed.origins
+-   For Developer Portal REST APIs : rest.api.devportal.allowed.origins
+-   For Gateway REST APIs : rest.api.gateway.allowed.origins
+-   For Service Catalog REST APIs : rest.api.service.catalog.allowed.origins
+
+The allowed origins for a particular REST API can be configured as a system parameter as follows.
+
+!!! Note
+
+    - The origin will have the following syntax.
+
+    ```bash tab="Format"
+    <scheme>://<hostname>[ :<port> ]
+    ```
+
+    ```bash tab="Example"
+    https://myorg1.publisher.example.com
+    ```
+
+### Method 1- Specify the allowed origins in the deployment.toml file under [system.parameter]
+
+ 1.  Open the `<APIM_HOME>/repository/deployment.toml` file and specify the allowed origins for the REST APIs under `[system.parameter]`.
+
+    ```toml tab="Format"
+    [system.parameter]
+    'rest.api.publisher.allowed.origins' = "<comma-separated-origins>"
+    'rest.api.devportal.allowed.origins' = "<comma-separated-origins>"
+    'rest.api.gateway.allowed.origins' = "<comma-separated-origins>"
+    'rest.api.service.catalog.allowed.origins' = "<comma-separated-origins>"
+    ```
+
+    ```toml tab="Example"
+    [system.parameter]
+    'rest.api.publisher.allowed.origins' = "https://myorg1.publisher.example.com"
+    'rest.api.devportal.allowed.origins' = "https://myorg1.devportal.example.com,https://myorg2.devportal.example.com"
+    'rest.api.gateway.allowed.origins' = "https://myorg1.gateway.example.com,https://myorg3.gateway.example.com"
+    'rest.api.service.catalog.allowed.origins' = "https://myorg1.service.catalog.example.com"
+    ```
+
+ 2.  Start the server to apply the changes.
+
+      * On Linux/Mac OS: `./api-manager.sh`
+      * On Windows: `api-manager.bat`
+
+### Method 2- Specify the allowed origins when starting the server
+
+This can be done in one of two ways.
+
+**Option 1**: Specifying the allowed origins in the server startup script
+
+   1. Specify the allowed origins for the REST APIs in the server startup script stored in the `<PRODUCT_HOME>/bin` directory. (`api-manager.sh` for Linux/Mac OS and `api-manager.bat` for Windows)
+
+    ```bash tab="Format"
+    -Drest.api.publisher.allowed.origins=<comma-separated-origins> \
+    -Drest.api.devportal.allowed.origins=<comma-separated-origins> \
+    -Drest.api.gateway.allowed.origins=<comma-separated-origins> \
+    -Drest.api.service.catalog.allowed.origins=<comma-separated-origins>
+    ```
+
+    ```bash tab="Example"
+    -Drest.api.publisher.allowed.origins=https://myorg1.publisher.example.com \
+    -Drest.api.devportal.allowed.origins=https://myorg1.devportal.example.com,https://myorg2.devportal.example.com \
+    -Drest.api.gateway.allowed.origins=https://myorg1.gateway.example.com,https://myorg3.gateway.example.com \
+    -Drest.api.service.catalog.allowed.origins=https://myorg1.service.catalog.example.com
+    ```
+
+   2. Start the server.
+
+      * On Linux/Mac OS: `./api-manager.sh`
+      * On Windows: `api-manager.bat`
+
+**Option 2**: Specify the allowed origins during server startup
+
+Start the API-M server by specifying the allowed origins for the REST APIs as system parameters.
+
+   - Linux/Mac OS
+
+```bash tab="Format"
+./api-manager.sh \
+-Drest.api.publisher.allowed.origins=<comma-separated-origins> \
+-Drest.api.devportal.allowed.origins=<comma-separated-origins> \
+-Drest.api.gateway.allowed.origins=<comma-separated-origins> \
+-Drest.api.service.catalog.allowed.origins=<comma-separated-origins>
+```
+
+```bash tab="Example"
+./api-manager.sh \
+-Drest.api.publisher.allowed.origins=https://myorg1.publisher.example.com \
+-Drest.api.devportal.allowed.origins=https://myorg1.devportal.example.com,https://myorg2.devportal.example.com \
+-Drest.api.gateway.allowed.origins=https://myorg1.gateway.example.com,https://myorg3.gateway.example.com \
+-Drest.api.service.catalog.allowed.origins=https://myorg1.service.catalog.example.com
+```
+
+   - Windows
+
+```bash tab="Format"
+api-manager.bat \
+-Drest.api.publisher.allowed.origins=<comma-separated-origins> \
+-Drest.api.devportal.allowed.origins=<comma-separated-origins> \
+-Drest.api.gateway.allowed.origins=<comma-separated-origins> \
+-Drest.api.service.catalog.allowed.origins=<comma-separated-origins>
+```
+
+```bash tab="Example"
+api-manager.bat \
+-Drest.api.publisher.allowed.origins=https://myorg1.publisher.example.com \
+-Drest.api.devportal.allowed.origins=https://myorg1.devportal.example.com,https://myorg2.devportal.example.com \
+-Drest.api.gateway.allowed.origins=https://myorg1.gateway.example.com,https://myorg3.gateway.example.com \
+-Drest.api.service.catalog.allowed.origins=https://myorg1.service.catalog.example.com
+```


### PR DESCRIPTION
## Purpose
- Add "Configuring Allowed Origins for REST APIs" content under "Advanced Configurations" section of Product REST APIs
- Updated document content: [product-apis-advanced-configurations.pdf](https://github.com/wso2/docs-apim/files/6642231/product-apis-advanced-configurations.pdf)

Related Issue: https://github.com/wso2/docs-apim/issues/4110