### PR TITLE
Add option to skip file permission check in the move operation

### DIFF
--- a/en/docs/reference/connectors/file-connector/3.x/file-connector-3.x-config.md
+++ b/en/docs/reference/connectors/file-connector/3.x/file-connector-3.x-config.md
@@ -727,6 +727,11 @@ The following operations allow you to work with the File Connector version 2. Cl
             <td>Set to true if you want to include the sub directories.</td>
             <td>Optional</td>
         </tr>
+        <tr>
+            <td>setAvoidPermission</td>
+            <td>Set to true if you want to skip the file permission check.</td>
+            <td>Optional</td>
+        </tr>
 	    <tr>
             <td>sourceSftpIdentities</td>
             <td>Location of the source's private key.</td>
@@ -763,6 +768,7 @@ The following operations allow you to work with the File Connector version 2. Cl
         <filePattern>{$ctx:filePattern}</filePattern>
 	    <includeParentDirectory>{$ctx:includeParentDirectory}</includeParentDirectory>
         <includeSubDirectories>{$ctx:includeSubDirectories}</includeSubDirectories>
+        <setAvoidPermission>{$ctx:setAvoidPermission}</setAvoidPermission>
 	    <sourceSftpIdentities>{$ctx:sftpIdentities}</sourceSftpIdentities>
         <sourceSftpIdentityPassphrase>{$ctx:sourceSftpIdentityPassphrase}</sourceSftpIdentityPassphrase>
         <targetSftpIdentities>{$ctx:targetSftpIdentities}</targetSftpIdentities>


### PR DESCRIPTION
## Purpose
Add the document changes related to the new property `setAvoidPermission` which is added to the file connector move operation by https://github.com/wso2-extensions/esb-connector-file/pull/164.