### PR TITLE
Update kafka docs with error codes

### DIFF
--- a/en/docs/reference/connectors/kafka-connector/kafka-connector-config.md
+++ b/en/docs/reference/connectors/kafka-connector/kafka-connector-config.md
@@ -476,3 +476,21 @@ To use the Kafka connector, add the `<kafkaTransport.init>` element in your conf
        <valueSchemaId>schemaId of the configured value</valueSchema>
     </kafkaTransport.publishMessages>
     ```
+
+### Error codes related to Kafka Connector
+
+!!!note
+    With Kafka connector v3.1.2 and above, when an error occurs one of the following errors will get set to the message context. Refer [Generic Properties]({{base_path}}/reference/mediators/property-reference/generic-properties/#error_code) for details on how to access these error properties.
+
+
+| **Error Code** |   **Detail**                                             |
+|----------------|----------------------------------------------------------|
+| 700501         | Connection error.                                        |
+| 700502         | Invalid configuration.                                   |
+| 700503         | Error while serializing the Avro message in the producer.|
+| 700504         | Illegal type is used in an Avro message.                 |
+| 700505         | Error while building Avro schemas.                       |
+| 700506         | Error while parsing schemas and protocols.               |
+| 700507         | Expected contents of a union cannot be resolved.         |
+| 700508         | The request message cannot be processed.                 |
+| 700509         | Any other Kafka related error.                           |

--- a/en/docs/reference/connectors/kafka-connector/kafka-connector-config.md
+++ b/en/docs/reference/connectors/kafka-connector/kafka-connector-config.md
@@ -479,8 +479,8 @@ To use the Kafka connector, add the `<kafkaTransport.init>` element in your conf
 
 ### Error codes related to Kafka Connector
 
-!!!note
-    With Kafka connector v3.1.2 and above, when an error occurs one of the following errors will get set to the message context. Refer [Generic Properties]({{base_path}}/reference/mediators/property-reference/generic-properties/#error_code) for details on how to access these error properties.
+!!! note
+    With Kafka connector v3.1.2 and above, when an error occurs, one of the following errors will get set to the message context. For details on how to access these error properties, refer [Generic Properties]({{base_path}}/reference/mediators/property-reference/generic-properties/#error_code).
 
 
 | **Error Code** |   **Detail**                                             |


### PR DESCRIPTION
## Purpose
With https://github.com/wso2-extensions/esb-connector-kafka/pull/62, for Kafka connector v3.1.2 and above, when an error occurs the error will get set to the message context. This PR update the docs with the relevant error code.

![kafka_error_codes](https://user-images.githubusercontent.com/18748929/130191103-2741c30e-e4c6-4f08-bb0c-3585058d9560.png)
