### PR TITLE
Fix SI Tooling URL

### DIFF
--- a/en/docs/develop/streaming-apps/creating-a-siddhi-application.md
+++ b/en/docs/develop/streaming-apps/creating-a-siddhi-application.md
@@ -55,7 +55,7 @@ gos
 
  2.  Access the Streaming Integration Tooling via the `http://<HOST_NAME>:<TOOLING_PORT>/editor` URL.
 
-    !!!info
+    !!! info
         The default URL is `http://<localhost:9390/editor`.
 
    The Streaming Integration Tooling opens as shown below.
@@ -225,7 +225,7 @@ gos
 
 
 
-5. To save this Siddhi application, click **File**, and then click **Save**. By default siddhi applications are saved in the  `<SI_HOME>/wso2/editor/deployment/workspace` directory.
+5. To save this Siddhi application, click **File**, and then click **Save**. By default, Siddhi applications are saved in the `<SI_HOME>/wso2/editor/deployment/workspace` directory.
 
 6.  To export the Siddhi application to your preferred location, click
     **File**, and then click **Export File**.

--- a/en/docs/develop/streaming-apps/creating-a-siddhi-application.md
+++ b/en/docs/develop/streaming-apps/creating-a-siddhi-application.md
@@ -47,30 +47,36 @@ view of the Streaming Integrator Tooling.
 To create a Siddhi application via the source view of the Streaming Integrator Tooling, follow the steps below:
 
 1. Start the Streaming Integrator Tooling by navigating to the `<SI_TOOLING_HOME>/bin` directory and issue one of the following commands:
+gos
 
     - For Windows: `tooling.bat`
 
     - For Linux: `./tooling.sh`
 
- The Streaming Integrator Tooling opens as shown below.
+ 2.  Access the Streaming Integration Tooling via the `http://<HOST_NAME>:<TOOLING_PORT>/editor` URL.
+
+    !!!info
+        The default URL is `http://<localhost:9390/editor`.
+
+   The Streaming Integration Tooling opens as shown below.
 
   ![Welcome Page]({{base_path}}/assets/img/streaming/creating-siddhi-applications/welcome-page.png)
 
-2. Click **New** to start defining a new Siddhi application. A new file opens as shown below.
+3. Click **New** to start defining a new Siddhi application. A new file opens as shown below.
 
     ![New Siddhi File]({{base_path}}/assets/img/streaming/creating-siddhi-applications/new-siddhi-file.png)
 
-3.  Add the following sample Siddhi application to the file.
+4.  Add the following sample Siddhi application to the file.
 
     ``` sql
         @App:name("SweetProductionAnalysis")
-    
+
         @Source(type = 'tcp', context='SweetProductionData', @map(type='binary'))
         define stream SweetProductionStream (name string, amount double);
-    
+
         @sink(type='log', @map(type='json'))
         define stream ProductionAlertStream (name string, amount double);
-    
+
         from SweetProductionStream
         select *
         insert into ProductionAlertStream;
@@ -142,7 +148,7 @@ To create a Siddhi application via the source view of the Streaming Integrator T
                                       </code></pre>
                              <p>This configuration defines the input mapping. In this scenario, Binary Mapper is used which converts input events into binary events and feeds them into siddhi.</p>
                           </li>
-                       </ul>                      
+                       </ul>
                            The source types and map types are available as Siddhi extensions, and you can find via the operator finder as follows:
                        <ol>
                           <li>
@@ -219,18 +225,18 @@ To create a Siddhi application via the source view of the Streaming Integrator T
 
 
 
-4. To save this Siddhi application, click **File**, and then click **Save**. By default siddhi applications are saved in the  `<SI_HOME>/wso2/editor/deployment/workspace` directory.
+5. To save this Siddhi application, click **File**, and then click **Save**. By default siddhi applications are saved in the  `<SI_HOME>/wso2/editor/deployment/workspace` directory.
 
-5.  To export the Siddhi application to your preferred location, click
+6.  To export the Siddhi application to your preferred location, click
     **File**, and then click **Export File**.
 
-6.  To see a graphical view of the event flow you defined in your Siddhi
+7.  To see a graphical view of the event flow you defined in your Siddhi
     application, click **Design View**.
-    
+
     ![Switch to Design View]({{base_path}}/assets/img/streaming/creating-siddhi-applications/design-view.png)
-    
-    The event flow is displayed as follows.  
-    
+
+    The event flow is displayed as follows.
+
     ![Siddhi Application in Design View]({{base_path}}/assets/img/streaming/creating-siddhi-applications/siddhi-application-design-view.png)
 
 ### Creating a Siddhi application in the design view
@@ -254,7 +260,7 @@ To create a Siddhi application via the design view of the Streaming Integrator T
 
 4.  To define the input stream into which the events to be processed via
     the Siddhi application should be received, drag and drop the stream
-    icon (shown below) into the grid.  
+    icon (shown below) into the grid.
     ![Stream Icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/stream-icon.png)
 
     Once the stream component is added to the grid, move the cursor over
@@ -262,12 +268,12 @@ To create a Siddhi application via the design view of the Streaming Integrator T
 
     ![Stream Settings]({{base_path}}/assets/img/streaming/creating-siddhi-applications/stream-settings.png)
 
-    As as result, the Stream Configuration form opens as follows.  
+    As as result, the Stream Configuration form opens as follows.
     ![Stream Configuration form]({{base_path}}/assets/img/streaming/creating-siddhi-applications/stream-configuration-form.png)
 
     Fill this form as follows to define a stream named `SweetProductionStream` with two attributes named
-    `name` and `amount`:  
-      
+    `name` and `amount`:
+
     1.  In the **Name** field, enter `SweetProductionStream`.
     2.  In the **Attributes** table, enter two attributes as follows.
         You can click **+Attribute** to add a new row in the table to
@@ -279,7 +285,7 @@ To create a Siddhi application via the design view of the Streaming Integrator T
         | `                 amount                ` | `                 double                ` |
 
     3.  Click **Submit** to save the new stream definition. As a result,
-        the stream is displayed on the grid with the `SweetProductionStream` label as shown below.  
+        the stream is displayed on the grid with the `SweetProductionStream` label as shown below.
         ![New stream added to the grid]({{base_path}}/assets/img/streaming/creating-siddhi-applications/stream-component.png)
 
 5.  To define the output stream to which the processed events need to be directed, drag and drop the
@@ -296,14 +302,14 @@ To create a Siddhi application via the design view of the Streaming Integrator T
     the **SweetProductionStream** input stream component. Therefore,
     place this source component to the left of the input stream
     component in the grid.<br/>
-    ![Source Icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/source-icon.png) 
+    ![Source Icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/source-icon.png)
     Once you add the source component, draw a line from it to the
     **SweetProductionStream** input stream component by dragging the
-    cursor as demonstrated below.  
-    ![Connect source]({{base_path}}/assets/img/streaming/creating-siddhi-applications/connect-source-component.gif)  
+    cursor as demonstrated below.
+    ![Connect source]({{base_path}}/assets/img/streaming/creating-siddhi-applications/connect-source-component.gif)
     Click the settings icon on the source component you added to open
     the **Source Configuration** form. Then enter information as
-    follows.  
+    follows.
     ![Source Configuration form]({{base_path}}/assets/img/streaming/creating-siddhi-applications/source-configuration.png)
     1.  In the **Source Type** field, select **tcp** .
 
@@ -316,15 +322,15 @@ To create a Siddhi application via the design view of the Streaming Integrator T
     4.  Click **Submit.**
 
 7.  To add a query that defines the execution logic, drag and drop the
-    projection query icon (shown below) to the grid.  
-    ![Projection Query Icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/projection-query-icon.png)  
-    The query uses the events in the `SweetProductionStream` input stream as inputs and directs the 
+    projection query icon (shown below) to the grid.
+    ![Projection Query Icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/projection-query-icon.png)
+    The query uses the events in the `SweetProductionStream` input stream as inputs and directs the
     processed events (which are its output) to the `ProductionAlertStream` output stream. Therefore,
-    create two connections as demonstrated below.  
+    create two connections as demonstrated below.
     ![Connecting the projection query]({{base_path}}/assets/img/streaming/creating-siddhi-applications/connect-projection-query.gif)
 8.  To define the execution logic, move the cursor over the query in the
     grid, and click on the settings icon that appears. This opens the
-    **Query Configuration** form. Enter information in it as follows:  
+    **Query Configuration** form. Enter information in it as follows:
     ![Configuring the projection query]({{base_path}}/assets/img/streaming/creating-siddhi-applications/projection-query-configuration.png)
     1.  Enter a name for the query in the **Name** field. In this example, let's enter `query` as the name.
     2.  In order to specify how each user defined attribute in the input
@@ -338,22 +344,22 @@ To create a Siddhi application via the design view of the Streaming Integrator T
             `name` as the expression for the `name` attribute.
         2.  To derive the value for the `totalProduction` attribute, the sum of the values for the `amount` attribute
             of input events need to be calculated. Therefore, enter the expression as follows to apply the `sum()`
-            Siddhi function to the `amount` attribute.  
+            Siddhi function to the `amount` attribute.
             `sum(amount)`
         3.  Leave the default values of the **Output** section unchanged.
-    3.  Click **Submit** to save the information.  
-          
+    3.  Click **Submit** to save the information.
+
 
 9.  To add a sink to publish the output events that are directed to the `ProductionAlertStream` output stream, drag and
-    drop the sink icon (shown below) into the grid.  
+    drop the sink icon (shown below) into the grid.
     ![Sink icon]({{base_path}}/assets/img/streaming/creating-siddhi-applications/sink-icon.png) <br/>
-    Draw an arrow from the `ProductionAlertStream` output stream to the sink component to connect them.  
-      
+    Draw an arrow from the `ProductionAlertStream` output stream to the sink component to connect them.
+
     Click the settings icon on the sink component you added to open the
-    **Sink Configuration** form. Then enter information as follows.  
-    
-    ![Configuring the sink]({{base_path}}/assets/img/streaming/creating-siddhi-applications/sink-configuration.png)  
-    
+    **Sink Configuration** form. Then enter information as follows.
+
+    ![Configuring the sink]({{base_path}}/assets/img/streaming/creating-siddhi-applications/sink-configuration.png)
+
     1.  In this example, let's assume that output needs to be generated
         as logs in the console. To indicate this, select `log` in the **Sink Type** field.
 
@@ -363,15 +369,15 @@ To create a Siddhi application via the design view of the Streaming Integrator T
 
 10. To align the Siddhi components that you have added to the grid,
     click **Edit** and then click **Auto-Align**. As a result, all the
-    components are horizontally aligned as shown below.  
-    
+    components are horizontally aligned as shown below.
+
     ![Aligned Siddhi components]({{base_path}}/assets/img/streaming/creating-siddhi-applications/siddhi-application-design-view.png)
-    
-11. Click **Source View**. The siddhi application is displayed as follows.  
+
+11. Click **Source View**. The siddhi application is displayed as follows.
 
     ![Source view]({{base_path}}/assets/img/streaming/creating-siddhi-applications/siddhi-application-source-view.png)
-    
-12. Click **File** and then click **Save as**. The **Save to Workspace** dialog box appears. In the **File Name** 
+
+12. Click **File** and then click **Save as**. The **Save to Workspace** dialog box appears. In the **File Name**
     field, enter `SweetProductionAnalysis` and click **Save**.
 
     ![Saving the Siddhi application]({{base_path}}/assets/img/streaming/creating-siddhi-applications/save-siddhi-application.png)

--- a/en/docs/develop/streaming-apps/streaming-integrator-studio-overview.md
+++ b/en/docs/develop/streaming-apps/streaming-integrator-studio-overview.md
@@ -9,7 +9,7 @@ The Streaming Integrator Tooling is a developer tool that is shipped with the St
 -   **Design View** :This interface visualizes the event flow of a
     Siddhi application, and allows you to compose the applications by
     dragging and dropping Siddhi components to a graph.
-    
+
 -   **Wizard View**: This is a wizard with a page for each component of a Siddhi application that displays the relevant configuration parameters as fields. This wizard can be directly accessed from the [Welcome Page](#welcome-page). Only ETL (Extract, Transform, Load) applications can be created/viewed in this interface. For a Siddhi application to be considered an ETL application, it must include all of the following components:<br/><br/> - A source configuration<br/><br/> - A sink configuration (the sink type can be any of the [supported sink types](https://siddhi.io/en/v5.1/docs/query-guide/#sink) other than `log`)<br/><br/> - A Siddhi query that performs a transformation. <br/><br/> For more information, see [Creating an ETL Application via SI Tooling tutorial]({{base_path}}/use-cases/streaming-tutorials/creating-etl-application-via-tooling).
 
 -   **Async API View**: This interface allows you to generate an asynchronous API definition from a Siddhi application that includes a source/sink of the `websocket-server`, `webhooks` or `sse` type. Once an API definition is generated, you can also edit it in this interface. It displays the API definition in code format in the left panel, and as a form in the right panel. For more information about accessing this view and creating/editing an asynchronous API definition in this view, see [Generating and Viewing Asynchronous API Definitions]({{base_path}}/develop/streaming-apps/working-with-the-async-api-view)
@@ -27,12 +27,10 @@ To start and access the Streaming Integrator Tooling, follow the steps below:
     -   For Windows: `tooling.bat`
     -   For Linux: `./tooling.sh`
 
-2.  Access the Streaming Integrator Tooling via the `http://localhost:/editor`
-    URL. The Streaming Integrator Tooling opens as shown below.
+2.  Access the Streaming Integration Tooling via the `http://<HOST_NAME>:<TOOLING_PORT>/editor` URL.
 
-    !!! info
-        The default URL is `http://localhost:9390/editor`. If required, you can change the host name (i.e., `localhost`) or the web UI application name (i.e., `editor`). For instructions, see [Changing the Host Name and Context Path of SI Tooling]({{base_path}}/setup/change-hostname-and-context-path).
-    
+    !!!info
+        The default URL is `http://<localhost:9390/editor`.
 
 ## Welcome Page
 
@@ -49,25 +47,25 @@ following:
     Click this to open a new untitled Siddhi file.
 
 -   **Open**
-    Click this to open a Siddhi file that is already saved in the `workspace` directory of the Streaming Integrator 
-    Tooling. If the file is already opened in a new tab, clicking **Open** does not open it again. The default path to 
+    Click this to open a Siddhi file that is already saved in the `workspace` directory of the Streaming Integrator
+    Tooling. If the file is already opened in a new tab, clicking **Open** does not open it again. The default path to
     the `workspace` directory is `<SI_Home>/wso2/server/deployment`.
-    
+
 -   **New ETL Flow**
     Click this to open a wizard with which you can create a Siddhi application with ETL functionality by entering values for the required parameters instead of constructing Siddhi queries by writing code or via a graphical interface. To understand how this is done, follow the [Creating an ETL Application via SI Tooling tutorial]({{base_path}}/use-cases/streaming-tutorials/creating-etl-application-via-tooling).
 
--   **Try out samples**  
+-   **Try out samples**
     The pre-created samples provided out of the box are listed in this
     section. When you click on a sample, it opens in a new tab without a
     title.
 
--   **More Samples**  
+-   **More Samples**
     Click this to view the complete list of samples in the samples
     directory. This allows you to access samples other than the ones that
     are displayed by default is the **Try out samples** section. When
     you click on a sample, it opens in a new tab without a title.
 
--   **Quick links**  
+-   **Quick links**
     This section provides links to more resources.
 
 ## Menu items
@@ -81,54 +79,54 @@ The **File** menu includes the following options.
 
 ![File menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/file-menu.png)
 
--   **New**  
+-   **New**
     Click this to open a new untitled Siddhi file. For more information, see the [Creating an ETL Application via SI Tooling tutorial]({{base_path}}/use-cases/streaming-tutorials/creating-etl-application-via-tooling).
-    
+
 -   **New ETL Flow**
-    Click this to create a new ETL application via the ETL wizard. For instructions, 
-    
--   **Open File** 
-    Click this to open a Siddhi file that is already saved in the `workspace` directory of the Streaming Integrator 
-    Tooling. If the file is already opened in a new tab, clicking **Open** does not open it again. The default path to 
-    the `workspace` directory is `<SI_Home>/wso2/server/deployment`.         ` .  
-      
-    When a Siddhi file is opened, its source view is displayed by default.  
-    ![The source view of a Siddhi application]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/siddhi-app-source-view.png)  
-    To view a design view where the elements of the Siddhi application are graphically represented, click 
-    **Design View**. As a result, a graphical view of the Siddhi application is displayed as shown in the following 
-    example.  
+    Click this to create a new ETL application via the ETL wizard. For instructions,
+
+-   **Open File**
+    Click this to open a Siddhi file that is already saved in the `workspace` directory of the Streaming Integrator
+    Tooling. If the file is already opened in a new tab, clicking **Open** does not open it again. The default path to
+    the `workspace` directory is `<SI_Home>/wso2/server/deployment`.         ` .
+
+    When a Siddhi file is opened, its source view is displayed by default.
+    ![The source view of a Siddhi application]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/siddhi-app-source-view.png)
+    To view a design view where the elements of the Siddhi application are graphically represented, click
+    **Design View**. As a result, a graphical view of the Siddhi application is displayed as shown in the following
+    example.
     ![The design view of Siddhi application]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/siddhi-app-design-view.png)
-     
--   **Import Sample**  
+
+-   **Import Sample**
     Click this to import a sample from the samples diretory to a new tab. The sample opens in an untitled Siddhi file.
-     Once you save it, it can be accessed from the `workspace` directory.  
-     
--   **Save**  
-    Click this to save an edited or new file to the `workspace` directory.  
-    
--   **Save As**  
-    Click this if you want to save an existing saved file with a different name. If you click this for an untitled 
-    Siddhi file, the normal save operation is executed (i.e., same operation carried out when you click **Save** ). 
-     
--   **Import File**  
+     Once you save it, it can be accessed from the `workspace` directory.
+
+-   **Save**
+    Click this to save an edited or new file to the `workspace` directory.
+
+-   **Save As**
+    Click this if you want to save an existing saved file with a different name. If you click this for an untitled
+    Siddhi file, the normal save operation is executed (i.e., same operation carried out when you click **Save** ).
+
+-   **Import File**
     Click this to open a file from a system location. This file is opened in a new tab in the saved state with the same
-     file name with which it is imported. 
-     
--   **Export File** 
+     file name with which it is imported.
+
+-   **Export File**
     Click this to export a saved file to a system location. This is only applicable to Siddhi application tabs that are
      in a saved state.
 
 -   **Close File**
-    Click this to close a currently active Siddhi application that is already open in a tab.  
-    
--   **Close All Files** 
-    Click this to close all the Siddhi files that are currently open. 
-    
--   **Delete File**  
+    Click this to close a currently active Siddhi application that is already open in a tab.
+
+-   **Close All Files**
+    Click this to close all the Siddhi files that are currently open.
+
+-   **Delete File**
     Click this to delete the currently active Siddhi file from the `workspace` directory. Only Siddhi files that are
     already saved can be deleted.
-    
--   **Settings**  
+
+-   **Settings**
     Click this to change the theme and the font size used in the Streaming Integrator Tooling. The default theme is **Twilight** .
 
 #### Edit menu Items
@@ -137,31 +135,31 @@ The **Edit** menu includes the following options.
 
 ![Edit menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/editor-menu.png)
 
--   **Undo**  
+-   **Undo**
     Click this to undo the last edit made to the Siddhi application that
     you are currently editing. Only unsaved edits can be undone.
-    
--   **Redo**  
+
+-   **Redo**
     Click this to redo the edit that was last undone in the Siddhi
     application that you are currently editing. The redo operation can
     be carried out only if you have not saved the Siddhi application
     after you undid the change.
-    
--   **Find** 
+
+-   **Find**
     Click this to search for a specific string in the currently
     active Siddhi application tab.
-      
--   **Find and Replace**  
+
+-   **Find and Replace**
     Click this to search for a specific string in the currently
     active Siddhi application tab, and replace it with another string.
-    
--   **Reformat Code**  
+
+-   **Reformat Code**
     Click this to reformat the Siddhi queries in the Siddhi
     application that you are currently creating/editing in the [source view](#StreamProcessorStudioOverview-SourceView).
 
     !!! info
         This menu option is only visible when you are working in the [source view](#StreamProcessorStudioOverview-SourceView).
-    
+
 -   **Auto-Align** <br/>
     Click this to horizontally align all the Siddhi components in a
     Siddhi application that you are creating/editing in the [design view](#StreamProcessorStudioOverview-DesignView).
@@ -176,18 +174,18 @@ The **Run** menu includes the following options.
 ![Run menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/run-menu-option.png)
 
 
--   **Run**  
+-   **Run**
     Click this to start the Siddhi application in the Run mode. Only
     saved Siddhi applications can be run.
 
     !!! info
         This menu option is enabled only when a Siddhi application is being created/edited in the [source view](#StreamProcessorStudioOverview-SourceView).
-    
 
--   **Stop**  
+
+-   **Stop**
     Click this to stop a Siddhi application that is already running.
 
-  
+
 
 #### Tools menu items
 
@@ -195,87 +193,87 @@ The **Tools** menu provides access to the following tools that are shipped with 
 
 ![Tools menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/tools-menu.png)
 
-- **File Explorer** 
+- **File Explorer**
 
     The file explorer. This is also avaible in the [Side Panel](#StreamProcessorStudioOverview-SidePanel).
-    
+
 - **Extension Installer**
 
     This opens the **Extension Installer** dialog box (shown below) where you can search for the required extension and install/uninstall it by clicking **Install** or **Uninstall** as appropriate. Once you install/uninstall an extension, you need to restart the Streaming Integrator Tooling. For detailed instructions, see [Installing Siddhi Extensions]({{base_path}}/develop/streaming-apps/installing-siddhi-extensions).
 
-     ![Extension Installer]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/extension-installer.png)   
-    
-- **Event Simulator**  
+     ![Extension Installer]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/extension-installer.png)
+
+- **Event Simulator**
 
     Simulation can be carried out in two ways:
 
     -   Single Simulation
     -   Feed Simulation
 
-    For detailed information about event simulation, see [Simulating Events](_Simulating_Events_).  
+    For detailed information about event simulation, see [Simulating Events](_Simulating_Events_).
     The event simulator can also be accessed from the [Side Panel](#StreamProcessorStudioOverview-SidePanel).
-    
+
 - **Error Store Explorer**
 
     This opens the Error Store Explorer in which you can view, correct and replay the streaming events with errors that are stored in the error store.
-    
+
     In order to use it, first you need to connect it to the SI server by clicking **Connect to Server** and then entering the server configurations in the dialog box that appears.
-    
+
     ![Connect to Server]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/connect-error-store-explorer.png)
-     
+
     Once the Error Store Explorer is connected to an SI server, you can get an overview of events with errors as shown in the example below.
-    
+
     ![Error Store Explorer]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/view-basic-error-info.png)
-    
+
     Here, you can do the following:
-    
+
     - **Fetch Errors**: At a given time, the Error Store Explorer displays the number of events with errors from the time it was last fetched/refreshed. To get the latest errors, select the required Siddhi application in the **Siddhi app** field and click **Fetch**.
-    
+
     - **View details**: To view details of a specific error, click **Detailed Info** for the relevant event. Then the details of the error are displayed in the **Error Entry** dialog box as shown in the example below.
            ![Error Entry]({{base_path}}/assets/img/streaming/handling-requests-with-errors/error-entry.png)
-           
+
     - **Replay events**: This can be done in one of the following three methods:
-    
+
         - To replay all the events for the selected Siddhi application without making any changes, click **Replay All**.
-        
+
         - To replay a single event without making any changes, click **Replay** for the specific event.
-        
+
         - To make any changes to the event before replaying, click **Detailed Info** for the relevant event and open the **Error Entry** dialog box. Then make the required changes to the event (which is displayed in an editable field) and click **Replay**.
-        
+
             !!!info
                 Note that only mapping errors can be corrected before replaying.
-        
+
             ![Correct and Replay Event]({{base_path}}/assets/img/streaming/handling-requests/correct-and-replay-event.png)
-            
+
     - **Discard events**: To discard all the erroneous events for the selected Siddhi application, click **Discard All**. To discard a specific erroneous event, click **Discard** for the relevant event.
-    
+
     - **Purge Events**: To periodically purge events, click **Purge**. This opens the **Purge Error Store** dialog box. In the **Retention Period (days)** field, enter the number of past days for which you want to retain the erroneous events in the store and then click **Purge**. As a result, all the events except the ones stored in the specified number of past days are removed from the error store.
-    
+
     To understand how to save messages with errors in the error store, see [Handling Errors]({{base_path}}/use-cases/streaming-usecase/handling-errors).
-    
+
     To try out an error handling tutorial, see [Handling Requests with Errors]({{base_path}}/use-cases/streaming-tutorials/handling-requests-with-errors).
-      
+
 - **Console**
 
     This is an output console that provides feedback on various user activities carried out on the Streaming Integration Tooling. It is accessible from the [Side Panel](#StreamProcessorStudioOverview-SidePanel).
-    
+
 - **Sample Event Generator**
 
-    This opens the Sample Event Generator as follows.  
-    ![Sample event generator]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/sample-event-generator.png)  
-    Here, you can generate sample events for a selected stream within a selected Siddhi application in a specified format.  
-      
+    This opens the Sample Event Generator as follows.
+    ![Sample event generator]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/sample-event-generator.png)
+    Here, you can generate sample events for a selected stream within a selected Siddhi application in a specified format.
+
 - **On-Demand Query**
 
     This opens the **On-Demand Query** dialog box.
-    
+
     ![Siddhi Store Query]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/on-demand-query.png)
     Here, you can select a Siddhi application, and then enter a query to
     manipulate the store in which that Siddhi Application saves data.
     You can enter queries that can update record, insert/update records,
     retrieve records and delete records. For more information about
     actions you can carry out for stores, see [Store APIs]({{base_path}}/develop/streaming-apps/store-apis).
-      
+
 - **Tour Guide**
 
     This opens a dialog box named **Welcome to the Streaming Integrator
@@ -284,7 +282,7 @@ The **Tools** menu provides access to the following tools that are shipped with 
 
 #### Deploy menu items
 
-The **Deploy** menu has the following option to select one or more Siddhi applications and deploy them to one or more 
+The **Deploy** menu has the following option to select one or more Siddhi applications and deploy them to one or more
 Streaming Integrator servers. For more information, see [Deploying Siddhi Applications]({{base_path}}/develop/streaming-apps/deploying-streaming-applications).
 
 ![Deploy menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/deploy-menu.png)
@@ -354,14 +352,14 @@ For more information about templated variables, see [Siddhi Documentation - Sidd
 
   ![Tool Bar menu]({{base_path}}/assets/img/streaming/streaming-integrator-studio-overview/editor-toolbar.png)
 
--   **Run icon**  
+-   **Run icon**
     Click this to start a currently open Siddhi application in the Run
-    mode. This icon is enabled only for saved Siddhi applications.  
+    mode. This icon is enabled only for saved Siddhi applications.
 
--   **Stop icon**  
+-   **Stop icon**
     Click this to stop a Siddhi application that is currently running.
 
--   **Revert icon**  
+-   **Revert icon**
     Click this to revert the unsaved changes in the Siddhi application
     that is currently being created/edited.
 


### PR DESCRIPTION
## Purpose
This PR fixes the SI Tooling URL at [1].

[1] https://apim.docs.wso2.com/en/latest/develop/streaming-apps/creating-a-siddhi-application/

Resolves https://github.com/wso2/docs-apim/issues/4562

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes