### PR TITLE
[4.0.0] remove java 8 from QSG

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -4,7 +4,7 @@ This section is a step-by-step guide to create, publish, and invoke an API using
 
 ### Before you begin...
 
-1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 or 1.8 and set the `JAVA_HOME` environment variable.
+1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 and set the `JAVA_HOME` environment variable.
      
      For more information on setting the `JAVA_HOME` environment variable for different operating systems, see [Setup and Install]({{base_path}}/install-and-setup/install/installing-the-product/installing-api-m-runtime/).
 

--- a/en/docs/get-started/integration-quick-start-guide.md
+++ b/en/docs/get-started/integration-quick-start-guide.md
@@ -4,7 +4,7 @@ Let's get started with WSO2 Micro Integrator by running a simple integration use
 
 ## Before you begin...
 
-1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 or 1.8 and set the `JAVA_HOME` environment variable.
+1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 and set the `JAVA_HOME` environment variable.
    For more information on setting the `JAVA_HOME` environment variable for different operating systems, see [Setup and Install]({{base_path}}/install-and-setup/install/installing-the-product/installing-api-m-runtime/).
 2. Go to the [WSO2 Micro Integrator web page](https://wso2.com/integration/micro-integrator/#), click **Download**, and then click **Zip Archive** to download the Micro Integrator distribution as a ZIP file.
 3. Optionally, navigate to the [API Manager Tooling web page](https://wso2.com/api-management/tooling/), and download WSO2 Integration Studio.
@@ -233,7 +233,7 @@ Follow the steps given below to run the integration artifacts we developed on a 
        ]
     ]
     ```
-    Congratulation!
+    Congratulations!
     Now you have created your first integration service. Optionally, you can follow the steps given below to expose the service as a Managed API in API Manager.
     
 ## Exposing an Integration Service as a Managed API

--- a/en/docs/get-started/streaming-quick-start-guide.md
+++ b/en/docs/get-started/streaming-quick-start-guide.md
@@ -42,7 +42,7 @@ Let's create a simple Siddhi application that reads data from a XML file, does a
     !!! Tip
         Use `admin` as the username and password.
         
-click on `New`, and copy and paste the content given below.
+3. Click on `New`, and copy and paste the content given below.
     
     !!! tip
         Here, a sample Siddhi application is provided to minimize the time spent following this guide. However, WSO2 recommends that you use the Streaming Integration Tooling that offers features such as syntax checking, event simulation for testing purposes, reformatting code, the option to design applications in a graphical interface or by writing code, and many more. For more information on designing Siddhi applications, see [Streaming Integrator Tooling Overview]({{base_path}}/develop/streaming-apps/streaming-integrator-studio-overview).
@@ -73,15 +73,15 @@ click on `New`, and copy and paste the content given below.
     insert into ProductionAlertStream;
     ```
     
-3. Save this file as `ManageProductionStats.siddhi`.
+4. Save this file as `ManageProductionStats.siddhi`.
 
-4. Click on **Deploy** and then **Deploy To Server** to deploy the Siddhi Application in Streaming Integrator.
+5. Click on **Deploy** and then **Deploy To Server** to deploy the Siddhi Application in Streaming Integrator.
 
-4. Add Streaming Integrator server details by clicking on `Add New Server`
+6. Add Streaming Integrator server details by clicking on `Add New Server`
 
     Specify the Streaming Integrator host `localhost` and port `9443`.
     
-5. Select the `ManageProductionStats` and the `Server` and **Deploy**.
+7. Select the `ManageProductionStats` and the `Server` and **Deploy**.
 The following message appears to indicate that the Siddhi application deployed successfully in the Streaming Integrator console.
 
     ```INFO {org.wso2.carbon.streaming.integrator.core.internal.StreamProcessorService} - Siddhi App ManageProductionStats1 deployed successfully```

--- a/en/docs/get-started/streaming-quick-start-guide.md
+++ b/en/docs/get-started/streaming-quick-start-guide.md
@@ -12,6 +12,7 @@ Let's get started with WSO2 Streaming Integrator(SI) by running a simple streami
 ## What you'll build
 In this sample scenario, you aggregate the data relating to the raw material purchases of a sweet production factory and publish the data to a WebSocket server.
                                 
+![Scenario]({{base_path}}/assets/img/streaming/qsg/streaming-integration-qsg-diagram.png)
 
 ### Step 1: Start the Streaming Integrator
 
@@ -36,7 +37,12 @@ Let's create a simple Siddhi application that reads data from a XML file, does a
     !!! info
         In this example, the file is located in the `/Users/foo` directory.
 
-2. Navigate to `http://localhost:9390/editor`, click on `New`, and copy and paste the content given below.
+2. Navigate to `http://localhost:9390/editor`, 
+
+    !!! Tip
+        Use `admin` as the username and password.
+        
+click on `New`, and copy and paste the content given below.
     
     !!! tip
         Here, a sample Siddhi application is provided to minimize the time spent following this guide. However, WSO2 recommends that you use the Streaming Integration Tooling that offers features such as syntax checking, event simulation for testing purposes, reformatting code, the option to design applications in a graphical interface or by writing code, and many more. For more information on designing Siddhi applications, see [Streaming Integrator Tooling Overview]({{base_path}}/develop/streaming-apps/streaming-integrator-studio-overview).
@@ -96,7 +102,7 @@ You can see the following message in the SI console log.
 ```
 
 </br>
- Congratulations!
+ **Congratulations!**
  Now, you have created your first Streaming service. Optionally, you can follow the steps given below to expose the service as a Managed API in API Manager.
       
 ## Exposing an Streaming Service as a Managed API
@@ -147,7 +153,7 @@ The `ManageProductionStats` Siddhi Application you deployed in the Micro Integra
     1.  Sign in to the API Publisher portal: `https://localhost:9443/publisher`. 
 
     !!! Tip
-        Use `admin` as the user name and password.
+        Use `admin` as the username and password.
 
     2.  You can also click the **hamburger** icon on the upper-left and click **Services** to see the available services.
 

--- a/en/docs/get-started/streaming-quick-start-guide.md
+++ b/en/docs/get-started/streaming-quick-start-guide.md
@@ -4,7 +4,7 @@ Let's get started with WSO2 Streaming Integrator(SI) by running a simple streami
 
 ## Before you begin...
 
-1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 or 1.8 and set the `JAVA_HOME` environment variable.
+1. Install [Oracle Java SE Development Kit (JDK)](http://java.sun.com/javase/downloads/index.jsp) version 11 and set the `JAVA_HOME` environment variable.
    For more information on setting the `JAVA_HOME` environment variable for different operating systems, see [Setup and Install]({{base_path}}/install-and-setup/install/installing-the-product/installing-api-m-runtime/).
 2. Download the Streaming Integrator and Streaming Integrator Tooling distributions from the [WSO2 Streaming Integrator site](https://wso2.com/integration/streaming-integrator/) and extract them to a location of your choice. Hereafter, the extracted location is referred to as `<SI_HOME>` and `<SIT_HOME>` respectively.<br/><br/>
 3. Optionally, go to the [WSO2 API Manager website](https://wso2.com/api-management/), click **TRY IT NOW**, and then click **Zip Archive** to download the API Manager distribution as a ZIP file.

--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -22,15 +22,15 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Linux/OS X"
 
     1.  In your home directory, open the BASHRC file (.bash\_profile file on Mac) using editors such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
         On Linux:
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
              
         On OS X:
-        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/1.8.0.jdk/Contents/Home
+        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
 
     3.  Save the file.
@@ -56,16 +56,12 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Solaris"
 
     1.  In your home directory, open the BASHRC file in your favorite text editor such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
         ```
-
-        The file should now look like this:
-
-        ![]({{base_path}}/assets/attachments/103334399/103334401.png)
 
     3.  Save the file.
 
@@ -84,7 +80,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
 ??? note "On Windows"
 
-    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk1.8.0_xx`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
+    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk-11.0.x`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
 
     You set up `JAVA_HOME` using the System Properties, as described below. Alternatively, if you just want to set `JAVA_HOME` temporarily for the current command prompt window, set it at the command prompt.
 
@@ -104,7 +100,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
     4.  Enter the following information:
         -   In the **Variable name** field, enter: `JAVA_HOME`
-        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk1.8.0_xx           `
+        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk-11.0.x         `
 
     The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the `JAVA_HOME` variable to take effect, or manually set the `JAVA_HOME` variable in those command prompt windows as described in the next section. To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter**) and execute the following command:
 

--- a/en/docs/install-and-setup/install/installing-the-product/installing-mi-dashboard.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-mi-dashboard.md
@@ -30,15 +30,15 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Linux/OS X"
 
     1.  In your home directory, open the BASHRC file (.bash\_profile file on Mac) using editors such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11.0.x in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
         On Linux:
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
              
         On OS X:
-        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/1.8.0.jdk/Contents/Home
+        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
 
     3.  Save the file.
@@ -64,16 +64,12 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Solaris"
 
     1.  In your home directory, open the BASHRC file in your favorite text editor such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11.0.x in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
         ```
-
-        The file should now look like this:
-
-        ![]({{base_path}}/assets/attachments/103334399/103334401.png)
 
     3.  Save the file.
 
@@ -92,7 +88,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
 ??? note "On Windows"
 
-    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk1.8.0_xx`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
+    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk-11.0.x`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
 
     You set up `JAVA_HOME` using the System Properties, as described below. Alternatively, if you just want to set `JAVA_HOME` temporarily for the current command prompt window, set it at the command prompt.
 
@@ -112,7 +108,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
     4.  Enter the following information:
         -   In the **Variable name** field, enter: `JAVA_HOME`
-        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk1.8.0_xx           `
+        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk-11.0.x           `
 
     The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the `JAVA_HOME` variable to take effect, or manually set the `JAVA_HOME` variable in those command prompt windows as described in the next section. To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter**) and execute the following command:
 

--- a/en/docs/install-and-setup/install/installing-the-product/installing-mi.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-mi.md
@@ -22,15 +22,15 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Linux/OS X"
 
     1.  In your home directory, open the BASHRC file (.bash\_profile file on Mac) using editors such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
         On Linux:
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
              
         On OS X:
-        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/1.8.0.jdk/Contents/Home
+        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
 
     3.  Save the file.
@@ -56,16 +56,12 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Solaris"
 
     1.  In your home directory, open the BASHRC file in your favorite text editor such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
         ```
-
-        The file should now look like this:
-
-        ![]({{base_path}}/assets/attachments/103334399/103334401.png)
 
     3.  Save the file.
 
@@ -84,7 +80,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
 ??? note "On Windows"
 
-    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk1.8.0_xx`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
+    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk-11.0.x`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
 
     You set up `JAVA_HOME` using the System Properties, as described below. Alternatively, if you just want to set `JAVA_HOME` temporarily for the current command prompt window, set it at the command prompt.
 
@@ -104,7 +100,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
     4.  Enter the following information:
         -   In the **Variable name** field, enter: `JAVA_HOME`
-        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk1.8.0_xx           `
+        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk-11.0.x           `
 
     The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the `JAVA_HOME` variable to take effect, or manually set the `JAVA_HOME` variable in those command prompt windows as described in the next section. To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter**) and execute the following command:
 

--- a/en/docs/install-and-setup/install/installing-the-product/installing-si-as-a-linux-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-si-as-a-linux-service.md
@@ -4,7 +4,7 @@ WSO2 Streaming Integrator can be run as a Linux service.
 
 ## Before you begin
 
-Install JDK version 1.8.0_144 and set the `JAVA_HOME` variable.
+Install JDK version 11 and set the `JAVA_HOME` variable.
 
 ## Download and install the Streaming Integrator
 

--- a/en/docs/install-and-setup/install/installing-the-product/installing-si.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-si.md
@@ -22,15 +22,15 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Linux/OS X"
 
     1.  In your home directory, open the BASHRC file (.bash\_profile file on Mac) using editors such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
         On Linux:
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
              
         On OS X:
-        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/1.8.0.jdk/Contents/Home
+        export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
 
     3.  Save the file.
@@ -56,10 +56,10 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 ??? note "On Solaris"
 
     1.  In your home directory, open the BASHRC file in your favorite text editor such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 1.8.0\_xx in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk1.8.0_xx` with the actual directory where the JDK is installed.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
 
         ``` java
-        export JAVA_HOME=/usr/java/jdk1.8.0_xx
+        export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
         ```
 
@@ -84,7 +84,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
 ??? note "On Windows"
 
-    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk1.8.0_xx`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
+    Typically, the JDK is installed in a directory under `C:/Program Files/Java` , such as `C:/Program Files/Java/jdk-11.0.x`. If you have multiple versions installed, choose the latest one, which you can find by sorting by date.
 
     You set up `JAVA_HOME` using the System Properties, as described below. Alternatively, if you just want to set `JAVA_HOME` temporarily for the current command prompt window, set it at the command prompt.
 
@@ -104,7 +104,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
     4.  Enter the following information:
         -   In the **Variable name** field, enter: `JAVA_HOME`
-        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk1.8.0_xx           `
+        -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk-11.0.x           `
 
     The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the `JAVA_HOME` variable to take effect, or manually set the `JAVA_HOME` variable in those command prompt windows as described in the next section. To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter**) and execute the following command:
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -481,7 +481,7 @@ Given below are the security guidelines for the Micro Integrator runtime.
             <p><br /></p>
          </td>
          <td>
-            <p>The recommended JDK version is JDK 1.8 or 1.11. See the <a href="{{base_path}}/install-and-setup/install/installation-prerequisites/">installation pre-requisites</a> for more information.</p>
+            <p>The recommended JDK version is JDK 11. See the <a href="{{base_path}}/install-and-setup/install/installation-prerequisites/">installation pre-requisites</a> for more information.</p>
             <p><strong>Tip</strong>: To run the JVM with 2 GB (-Xmx2048m), you should ideally have about 4GB of memory on the physical machine.</p>
          </td>
       </tr>

--- a/en/docs/install-and-setup/setup/security/enabling-java-security-manager.md
+++ b/en/docs/install-and-setup/setup/security/enabling-java-security-manager.md
@@ -5,7 +5,7 @@ The Java Security Manager is used to define various security policies that pre
 !!! info
     **Before you begin**
 
-    * Ensure that you have Java 1.8 or Java 11 installed.
+    * Ensure that you have Java 11 installed.
     * Note that you need to use a keystore for signing JARs using the Java security manager. In this example, you will be using the default keystore in your WSO2 product ( `wso2carbon.jks` ). You can read about the recommendations for using keystores from [here]({{base_path}}/administer/product-security/configuring-keystores/keystore-basics/about-asymetric-cryptography/).
 
 

--- a/en/docs/streaming/getting-started/download-install-and-start-si.md
+++ b/en/docs/streaming/getting-started/download-install-and-start-si.md
@@ -3,7 +3,7 @@
 First, you are required to download the Streaming Integrator and the other software needed for the scenario you are trying out. To do this, follow the topics below.
 
 !!! tip "Before you begin:"
-    - Install [Oracle Java SE Development Kit (JDK) version 1.8](https://www.oracle.com/technetwork/java/javase/downloads/index.html).<br/>
+    - Install [Oracle Java SE Development Kit (JDK) version 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html).<br/>
     - [Set the Java home](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) environment variable.<br/>
     
 ## Downloading the Streaming Integrator runtime and tooling


### PR DESCRIPTION
## Purpose
> We need to remove java 8 from QSG as we no longer recommend,