### PR TITLE
[Master] Add missing commands related to the Windows environment

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -28,8 +28,12 @@
     !!! Tip
         If you want to change the default location for the .wso2apictl directory, set an environment variable (**APICTL_CONFIG_DIR**) as follows with the path for the desired location.
 
-        ```
+        ```go tab="Linux/Mac"
         export APICTL_CONFIG_DIR="/home/wso2user/CLI"
+        ```
+
+        ```go tab="Windows"
+        set APICTL_CONFIG_DIR=C:\Users\wso2user\CLI
         ```
 
 5.  Add the location of the extracted folder to your system's `$PATH` variable to be able to access the executable from anywhere.


### PR DESCRIPTION
## Purpose
Adding the missing config for Windows setup to change the default export directory using environment variables.

Affected Page:
https://apim.docs.wso2.com/en/latest/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller/

## Goals
Fixes  https://github.com/wso2/docs-apim/issues/3173 for Master.

## Approach

### Linux/MacOS Config
![ScreenShot Tool -20210909134729 (1)](https://user-images.githubusercontent.com/42435576/132650193-eadd82f4-8241-4883-9123-61c9df3edc55.png)

### Windows Config
![ScreenShot Tool -20210909134354](https://user-images.githubusercontent.com/42435576/132650205-c3f500cc-8c5c-4de4-a9b4-c39870aee9d4.png)


## Test environment
Windows 10
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.