### PR TITLE
[3.0.0] Add missing commands related to the Windows environment

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -21,6 +21,17 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
     ```
     The directory structure for the configuration files ( `<USER_HOME>/.wso2apictl` ) will be created upon the execution of the `apictl` command.
 
+    !!! Tip
+        If you want to change the default location for the .wso2apictl directory, set an environment variable (**APICTL_CONFIG_DIR**) as follows with the path for the desired location.
+
+        ```go tab="Linux/Mac"
+        export APICTL_CONFIG_DIR="/home/wso2user/CLI"
+        ```
+
+        ```go tab="Windows"
+        set APICTL_CONFIG_DIR=C:\Users\wso2user\CLI
+        ```
+
 5.  Add the location of the extracted folder to your system's `$PATH` variable to be able to access the executable from anywhere.
 
 


### PR DESCRIPTION
## Purpose
Adding the missing config for Windows setup to change the default export directory using environment variables.

Affected Page:
https://apim.docs.wso2.com/en/3.0.0/learn/api-controller/getting-started-with-wso2-api-controller/

## Goals
Fixes  https://github.com/wso2/docs-apim/issues/3173 for 3.0.0.

## Approach

### Linux/MacOS Config
![ScreenShot Tool -20210909152116](https://user-images.githubusercontent.com/42435576/132664404-4dbd64c1-0d62-4bd4-a7ce-a39c6e8eb65c.png)


### Windows Config
![ScreenShot Tool -20210909152105](https://user-images.githubusercontent.com/42435576/132664393-df0adebd-fb98-4976-acc4-32c663853562.png)


## Test environment
Windows 10
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.