### PR TITLE
[4.0.0] Add a note stating the requirement to change template file before using in Dev first approach

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -91,6 +91,9 @@
         !!! note
             You can define scopes for a resource when defining a Swagger2 or OpenAPI3 specification to generate an API.
 
+            !!! note
+                The following example is a template file. Please do the necessary changes to the template file before use this example to generate an API.
+
             !!! example
                 ```yaml
                 openapi: 3.0.0

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -92,7 +92,7 @@
             You can define scopes for a resource when defining a Swagger2 or OpenAPI3 specification to generate an API.
 
             !!! note
-                The following example is a template file. Please do the necessary changes to the template file before use this example to generate an API.
+                The following example is a template file. Please do the necessary changes to the template file before using this example to generate an API.
 
             !!! example
                 ```yaml


### PR DESCRIPTION

## Purpose
Add a note stating the requirement to change template file before using in Dev first approach to avoid confusion.

Affected Page: https://apim.docs.wso2.com/en/latest/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach/

## Goals
Fixes https://github.com/wso2/docs-apim/issues/4433 for APIM 4.0.0 Docs

## Approach
![ScreenShot Tool -20210909160215](https://user-images.githubusercontent.com/42435576/132671230-5c06606b-f438-41b1-a29a-90cada97c1c8.png)
