### PR TITLE
Fix Error from executing Oracle DB Scripts: APIM 2.6.0 to 4.0.0 Migration

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
@@ -2111,6 +2111,10 @@ Follow the instructions below to move all the existing API Manager configuration
             ADD COMMENT_ID VARCHAR(255) DEFAULT (SYS_GUID()) NOT NULL
         /
 
+        ALTER TABLE AM_API_COMMENTS
+            ADD CONSTRAINT add_pk PRIMARY KEY (COMMENT_ID)
+        /
+
         ALTER TABLE AM_API_RATINGS
             DROP COLUMN RATING_ID
         /


### PR DESCRIPTION
## Purpose
To fix the ORA-02270: no matching unique or primary key for this column-list error when running the Oracle DB Script against the WSO2AM_DB database.

## Approach
- There is a missed primary key constraint to the column: COMMENT_ID for Oracle DB in the doc [1]. 
- When analyzing with the MSSQL script in the same doc [1], we have given the primary key constraint to the column: COMMENT_ID.
- Hence adding these changes.

[1] https://apim.docs.wso2.com/en/latest/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400/#step-2-upgrade-api-manager-to-400