### PR TITLE
[3.2.0] Fixes #3324 issue

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
@@ -12,6 +12,18 @@ In API Manager, access logs can be configured for both servlet transport and Pas
 
 In WSO2 API Manager, the access logs can be generated for HTTP servlet transport which works on 9443/9763 default ports. HTTP servlet transport access logs are useful for analysing operational/admin-level access details. 
 
+In the API Manager access logs of applications get recorded or written into the `<APIM_HOME>repository/logs/http_access_.log` file. The following config enables a new valve which allows logs to get written into the `<APIM_HOME>repository/logs/wso2carbon.log` or any other log file and show up on the console.
+
+1. Open the <IS_HOME>/repository/conf/deployment.toml file.
+
+2. Add the following configuration.
+
+    ```properties
+    [http_access_log]
+    useLogger = true
+    ```
+3. Restart the server.
+
 Following is a sample of access log entries which can be monitored via `<APIM_HOME>repository/logs/http_access_.log` file by default.
 
 ```
@@ -25,7 +37,7 @@ Following is a sample of access log entries which can be monitored via `<APIM_HO
 - 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /am/sample/pizzashack/v1/api/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Synapse-PT-HttpComponents-NIO"
 ```
 
-As the runtime of WSO2 API Manager   is based on Apache Tomcat, you can use the `Access_Log_Valve` variable in Tomcat as explained below to configure access logs to the HTTP servlet transport:
+As the runtime of WSO2 API Manager   is based on Apache Tomcat, you can use the `Access_Log_Valve` variable in Tomcat as explained below to configure access logs to the HTTP servlet transport.
 
 ##Configuring access logs for PassThrough or NIO transports in API Gateway
 

--- a/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
@@ -37,7 +37,7 @@ Following is a sample of access log entries which can be monitored via `<APIM_HO
 - 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /am/sample/pizzashack/v1/api/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Synapse-PT-HttpComponents-NIO"
 ```
 
-As the runtime of WSO2 API Manager   is based on Apache Tomcat, you can use the `Access_Log_Valve` variable in Tomcat as explained below to configure access logs to the HTTP servlet transport.
+As the runtime of WSO2 API Manager is based on Apache Tomcat, you can use the `Access_Log_Valve` variable in Tomcat as explained below to configure access logs to the HTTP servlet transport.
 
 ##Configuring access logs for PassThrough or NIO transports in API Gateway
 

--- a/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
@@ -14,7 +14,7 @@ In WSO2 API Manager, the access logs can be generated for HTTP servlet transport
 
 In the API Manager, access logs of applications get recorded or written into the `<APIM_HOME>repository/logs/http_access_.log` file. The following config enables a new valve that allows logs to get written into the `<APIM_HOME>repository/logs/wso2carbon.log` or any other log file and show up on the console.
 
-1. Open the <IS_HOME>/repository/conf/deployment.toml file.
+1. Open the <APIM_HOME>/repository/conf/deployment.toml file.
 
 2. Add the following configuration.
 
@@ -22,6 +22,7 @@ In the API Manager, access logs of applications get recorded or written into the
     [http_access_log]
     useLogger = true
     ```
+    
 3. Restart the server.
 
 Following is a sample of access log entries which can be monitored via `<APIM_HOME>repository/logs/http_access_.log` file by default.

--- a/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
@@ -12,7 +12,7 @@ In API Manager, access logs can be configured for both servlet transport and Pas
 
 In WSO2 API Manager, the access logs can be generated for HTTP servlet transport which works on 9443/9763 default ports. HTTP servlet transport access logs are useful for analysing operational/admin-level access details. 
 
-In the API Manager access logs of applications get recorded or written into the `<APIM_HOME>repository/logs/http_access_.log` file. The following config enables a new valve which allows logs to get written into the `<APIM_HOME>repository/logs/wso2carbon.log` or any other log file and show up on the console.
+In the API Manager, access logs of applications get recorded or written into the `<APIM_HOME>repository/logs/http_access_.log` file. The following config enables a new valve that allows logs to get written into the `<APIM_HOME>repository/logs/wso2carbon.log` or any other log file and show up on the console.
 
 1. Open the <IS_HOME>/repository/conf/deployment.toml file.
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -13627,3 +13627,57 @@ key_password = "wso2carbon"</code></pre>
     </section>
 </div>
 
+## HTTP Access Logs
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="91" type="checkbox" id="_tab_91">
+                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[http_access_log]
+useLogger = true</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[http_access_log]</code>
+                            
+                            <p>
+                                This includes configuration for HTTP access log records. 
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>useLogger</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Allows logs to get written into the `<APIM_HOME>repository/logs/wso2carbon.log` or any other log file and show up on the console.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+


### PR DESCRIPTION
## Purpose
Add configuration to this doc [1] for the change done in this PR [2].

With the existing access log valve, the application's access logs get recorded or written into the http_access.log. file. This config enables a new valve that allows logs to get written into the wso2carbon.log or any other log file and show up on the console.

```
[http_access_log]
useLogger = true
```
[1].https://apim.docs.wso2.com/en/3.2.0/administer/logging-and-monitoring/logging/monitoring-http-access-logs/#configuring-access-logs-for-the-http-servlet-transport
[2]. https://github.com/wso2/carbon-kernel/pull/2661

## Goals

1. Add the new config under the relevant topic in 3.2.0 docs.
2. Add new config into configuration catalog [3].
3. Fixes #3324 for 3.2.0 documentation.

[3]. https://apim.docs.wso2.com/en/3.2.0/reference/config-catalog/

## Approach

![ScreenShot Tool -20210924114125](https://user-images.githubusercontent.com/42435576/134627761-09db417d-872e-4ae6-bc14-7601ea4115e7.png)

![ScreenShot Tool -20210924114636](https://user-images.githubusercontent.com/42435576/134627769-376a94a7-5284-4826-afdb-a17983605532.png)

