### PR TITLE
[3.1.0] Add link to advanced throttling policies

### DIFF
--- a/en/docs/learn/rate-limiting/introducing-throttling-use-cases.md
+++ b/en/docs/learn/rate-limiting/introducing-throttling-use-cases.md
@@ -79,7 +79,10 @@ Here is a sample for configuring JWT claim condition by considering the version 
 Filtering based on query parameters almost always apply to HTTP GET requests when doing search type of operations. For example, if you have a search API with `category` as a query parameter, you can have different limits for searching different categories.
 
 ![](../../assets/img/learn/advanced-throttling-query-conidtion.png)
+
 Eg : 'sales' category can be allocated with more requests than 'hr' category
+
+For more information on how to define advanced throttling policies, see [Adding a new advanced rate limiting policy](../adding-new-throttling-policies/#adding-a-new-advanced-rate-limiting-policy).
 
 ### Implications on applications that consume APIs
 

--- a/en/docs/learn/rate-limiting/introducing-throttling-use-cases.md
+++ b/en/docs/learn/rate-limiting/introducing-throttling-use-cases.md
@@ -82,7 +82,7 @@ Filtering based on query parameters almost always apply to HTTP GET requests whe
 
 Eg : 'sales' category can be allocated with more requests than 'hr' category
 
-For more information on how to define advanced throttling policies, see [Adding a new advanced rate limiting policy](../adding-new-throttling-policies/#adding-a-new-advanced-rate-limiting-policy).
+For more information on how to define advanced throttling policies, see [Adding a new advanced rate limiting policy]({{base_path}}/learn/rate-limiting/adding-new-throttling-policies/#adding-a-new-advanced-rate-limiting-policy).
 
 ### Implications on applications that consume APIs
 


### PR DESCRIPTION
## Purpose
This PR adds the link to advanced throttling policies page from the throttling use cases page.

Fixes: https://github.com/wso2/docs-apim/issues/3285