### PR TITLE
Updated the log output command

### DIFF
--- a/en/docs/tutorials/scenarios/scenario-overview.md
+++ b/en/docs/tutorials/scenarios/scenario-overview.md
@@ -28,7 +28,7 @@ A basic infrastructure has already been created for you to try out the scenarios
 
 1. Clone https://github.com/wso2/samples-apim/tree/master/apim-tutorial 
 2. Start the setup using the command `docker-compose up -d`.
-3. You can view the logs using the command `docker-compose logs -d`.
+3. You can view the logs using the command `docker-compose logs -f`.
 4. It might take 5-10 minutes for setup to complete (if it is the first time, based on your download speed it might take longer). 
 5. When you see the below log you can start working on the scenarios.
     ```


### PR DESCRIPTION
Changed docker-compose logs -d to docker-compose logs -f in order to display the log output.

## Purpose
The existing `docker-compose logs -d` doesn't give the log output. So updated the document with the correct command `docker-compose logs -f`.

## Goals
The existing `docker-compose logs -d` command didn't give the logout. It returned the following message in the terminal.
```docker-compose logs -d
View output from containers.

Usage: logs [options] [--] [SERVICE...]

Options:
    --no-color              Produce monochrome output.
    -f, --follow            Follow log output.
    -t, --timestamps        Show timestamps.
    --tail="all"            Number of lines to show from the end of the logs
                            for each container.
    --no-log-prefix         Don't print prefix in logs.
```