### PR TITLE
Add tip for the Authorization Code Grant related consent page

### DIFF
--- a/en/docs/design/api-security/oauth2/grant-types/authorization-code-grant.md
+++ b/en/docs/design/api-security/oauth2/grant-types/authorization-code-grant.md
@@ -122,7 +122,15 @@ The steps below show how access tokens are generated for the authorization code 
 8.  Select **Remember my consent** to remember the access to your profile information.
 
     [![Provide Consent]({{base_path}}/assets/img/learn/authorization-code-consent-page.png)]({{base_path}}/assets/img/learn/authorization-code-consent-page.png)   
-    
+
+    !!! tip
+        If you want the consent page to show the **application name** as the **display name**, add the following entry to the `deployment.toml` file in the `<API-M_HOME>/repository/conf/` folder.
+
+        ``` toml
+        [oauth]
+        show_display_name_in_consent_page = true
+        ```
+
 9.  Provide following information in the redirected page and click on **Get Access token**.
 
     <table>


### PR DESCRIPTION
## Purpose
- Resolves https://github.com/wso2/product-apim/issues/11620

Adds the config that is needed to show **Application Name** as the display name in Authorization Code Grant related **consent page**.

<img width="855" alt="Screenshot 2021-10-06 at 23 43 39" src="https://user-images.githubusercontent.com/30475839/136314160-e9b543ec-9222-49da-9e8d-7b0b88f285ff.png">

