### PR TITLE
[MI-4.0.0] Add note for evaluating JSONPath expression against a property

### DIFF
--- a/en/docs/integrate/examples/json_examples/json-examples.md
+++ b/en/docs/integrate/examples/json_examples/json-examples.md
@@ -478,7 +478,7 @@ The following table summarizes sample JSONPath expressions and their outputs:
 </table>
 
 !!! Info
-    During mediation evaluating a JSONPath expression against a property does not modify the original payload. The changes will be reflected within the property itself.
+    During mediation, evaluating expressions against a property does not modify the original payload. The changes will be reflected within the property itself and hence, it cannot be expected to get applied for the rest of the mediation similar to payload modification.
     
 We can also evaluate a JSONPath expression against a property that contains a JSON payload.
 


### PR DESCRIPTION
## Purpose
This PR adds a note in the JSON Examples documentation, explaining the usage of json-eval() expression against synapse properties.