### PR TITLE
Remove obsolete contact us info

### DIFF
--- a/en/docs/reference/connectors/connector-usage.md
+++ b/en/docs/reference/connectors/connector-usage.md
@@ -146,8 +146,3 @@ Start the server with `./integrator.sh -debug <port>` and connect to that port f
 Click on the **Report Issue** button on the connector store page for the connector. You will get diverted to the GitHub repository of the connector. Please report your issues there. 
 
 It is preferable to create another issue at WSO2 Micro Integrator project and link that issue. Specify the title of the issue as `[Connector]<title>`.
-
-## Contact Us
-
-* Mailing list: dev@wso2.org
-* Slack channel: [https://wso2-ei.slack.com/](https://wso2-ei.slack.com/)


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Contact Us links mentioned in the Connector usage doc are outdated as both the mailing list and the EI slack channel are not functional now.

Resolves #4841