### PR TITLE
[3.2.0][APICTL] Update getting-started-with-wso2-api-controller.md

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -14,7 +14,8 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
 
 2.  Extract the downloaded archive of the CTL Tool to the desired location.
 3.  Navigate to the working directory where the executable CTL Tool resides.
-4.  Execute the following command to start the CTL Tool.
+4.  Add the current working directory to your system's `$PATH` variable to be able to access the executable from anywhere.
+5.  Execute the following command to start the CTL Tool.
 
     !!! Warn
         From API Manager Tooling 3.1.0 version onwards, the names of the endpoints have been modified and this causes changing the syntax in `/home/<user>/.wso2apictl/main_config.yaml` file. If you have an older file, you'll get an error while executing the apictl commands due to this. To avoid that, backup and remove `/home/<user>/.wso2apictl/main_config.yaml` file and reconfigure the environments using new commands as explained below in [Add an environment](#add-an-environment) section.
@@ -35,15 +36,11 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
         set APICTL_CONFIG_DIR=C:\Users\wso2user\CLI
         ```
 
-5.  Add the location of the extracted folder to your system's `$PATH` variable to be able to access the executable from anywhere.
-
-
     !!! Tip    
         For further instructions, execute the following command.
         ``` go
         apictl --help
         ```
-
 
 ## Global flags for CTL Tool
 


### PR DESCRIPTION
## Purpose
As per the change introduced by [1] for apictl getting started doc, it confuses Linux/Mac users, as this leads to errors unless you've already added the ctl to the PATH. In order to fix this issue, switching steps 4 and 5 for consistency across all environments.

## Related PRs
1. https://github.com/wso2/docs-apim/pull/3176