### PR TITLE
[4.0.0][APICTL] Fix ./ issue in getting started page of APICTL

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -15,7 +15,7 @@
 2.  Extract the downloaded archive of the apictl to the desired location.
 3.  Navigate to the working directory where the executable apictl resides.
 4.  Add the current working directory to your system's `$PATH` variable to be able to access the executable from anywhere.
-5.  Execute the following command to start the CTL Tool.
+5.  Execute the following command to start the apictl.
 
     !!! Warn
         If you have previously used an apictl old version, backup and remove `/home/<user>/.wso2apictl` directory and reconfigure the environments using the commands as explained below in [Add an environment](#add-an-environment) section.


### PR DESCRIPTION
## Purpose
As per the change introduced by [1] for apictl getting started doc, it confuses Linux/Mac users, as this leads to errors unless you've already added the ctl to the PATH. In order to fix this issue, switch steps 4 and 5 for consistency across all environments.

![ScreenShot Tool -20211028143428](https://user-images.githubusercontent.com/42435576/139224425-5b7763a4-16e8-44dd-a404-ef99459eeb79.png)



## Goal 
Fixes https://github.com/wso2/docs-apim/issues/3205 for 4.0.0 Docs.

## Related PRs
1. https://github.com/wso2/docs-apim/pull/3176