### PR TITLE
[3.1.0][APICTL] Fix ./ issue in getting started page of APICTL

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -21,7 +21,7 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
         From API Manager Tooling 3.1.0 version onwards, the names of the endpoints have been modified and this causes changing the syntax in `/home/<user>/.wso2apictl/main_config.yaml` file. If you have an older file, you'll get an error while executing the apictl commands due to this. To avoid that, backup and remove `/home/<user>/.wso2apictl/main_config.yaml` file and reconfigure the environments using new commands as explained below in [Add an environment](#add-an-environment) section.
     
     ``` go
-    ./apictl
+    apictl
     ```
     The directory structure for the configuration files ( `<USER_HOME>/.wso2apictl` ) will be created upon the execution of the `apictl` command.
 


### PR DESCRIPTION
## Purpose
As per the change introduced by [1] for apictl getting started doc, it confuses Linux/Mac users, as this leads to errors unless you've already added the ctl to the PATH. In order to fix this issue, switch steps 4 and 5 for consistency across all environments.


![ScreenShot Tool -20211028143428](https://user-images.githubusercontent.com/42435576/139224380-bba490ec-41d4-41de-96e6-ba997f058d9c.png)




## Goal 
Fixes https://github.com/wso2/docs-apim/issues/3205 for 3.1.0 Docs.

## Related PRs
1. https://github.com/wso2/docs-apim/pull/3176