### PR TITLE
[3.0.0][APICTL] Fix ./ issue in getting started page of APICTL

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -18,7 +18,7 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
 5.  Execute the following command to start the CTL Tool.
 
     ``` go
-    ./apictl
+    apictl
     ```
     The directory structure for the configuration files ( `<USER_HOME>/.wso2apictl` ) will be created upon the execution of the `apictl` command.
 


### PR DESCRIPTION
## Purpose
As per the change introduced by [1] for apictl getting started doc, it confuses Linux/Mac users, as this leads to errors unless you've already added the ctl to the PATH. In order to fix this issue, switch steps 4 and 5 for consistency across all environments.


![ScreenShot Tool -20211028143428](https://user-images.githubusercontent.com/42435576/139224368-89671cd7-c285-4daa-9f2d-172b21a2d2de.png)



## Goal 
Fixes https://github.com/wso2/docs-apim/issues/3205 for 3.0.0 Docs.

## Related PRs
1. https://github.com/wso2/docs-apim/pull/3176