### PR TITLE
[CC 1.0.0] Fixing typos in CC configurations [4.0.0]

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
@@ -225,7 +225,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Position should be the final position (including already available filters) after all the filters engaged. Position starts from 1.</p>
+                                        <p>Position should be the final position (including already available filters) after all the filters are engaged. Position starts from 1.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -244,7 +244,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted</p>
+                                        <p>Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted.</p>
                                     </div>
                                 </div>
                             </div>
@@ -569,7 +569,7 @@ password = "admin"</code></pre>
                             <code>[management]</code>
                             <span class="badge-required">Required</span>
                             <p>
-                                The configuration for admin credentials of the Enforcer
+                                The configurations for the Enforcer admin credentials.
                             </p>
                         </div>
                         <div class="params-wrap">

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
@@ -446,7 +446,7 @@ See the example .toml file given below.
                             <code>[router.upstream.health]</code>
                             
                             <p>
-                                Health configuration for upstream clusters
+                                Health configuration for upstream clusters.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -466,7 +466,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time in seconds to wait for a health check response</p>
+                                        <p>Time in seconds to wait for a health check response.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -485,7 +485,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Interval betweenn health checks in seconds</p>
+                                        <p>Interval between health checks in seconds.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -504,7 +504,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Number of unhealthy health checks required before a host is marked unhealthy</p>
+                                        <p>Number of unhealthy health checks required before a host is marked as unhealthy.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -523,7 +523,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Number of healthy health checks required before a host is marked healthy</p>
+                                        <p>Number of healthy health checks required before a host is marked as healthy.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
@@ -68,14 +68,14 @@
               "type": "integer",
               "required": true,
               "default": "",
-              "description": "Position should be the final position (including already available filters) after all the filters engaged. Position starts from 1."
+              "description": "Position should be the final position (including already available filters) after all the filters are engaged. Position starts from 1."
             },
             {
               "name": "configProperties",
               "type": "string",
               "required": false,
               "default": "",
-              "description": "Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted"
+              "description": "Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted."
             }
           ]
         }
@@ -190,7 +190,7 @@
         {
           "name": "management",
           "required": true,
-          "description": "The configuration for admin credentials of the Enforcer",
+          "description": "The configurations for the Enforcer admin credentials.",
           "params": [
             {
               "name": "username",

--- a/en/tools/config-catalog-generator-cc/data/router/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/router/configs.json
@@ -143,35 +143,35 @@
         {
           "name": "router.upstream.health",
           "required": false,
-          "description": "Health configuration for upstream clusters",
+          "description": "Health configuration for upstream clusters.",
           "params": [
             {
               "name": "timeout",
               "type": "integer",
               "required": false,
               "default": 1,
-              "description": "Time in seconds to wait for a health check response"
+              "description": "Time in seconds to wait for a health check response."
             },
             {
               "name": "interval",
               "type": "integer",
               "required": false,
               "default": 10,
-              "description": "Interval betweenn health checks in seconds"
+              "description": "Interval between health checks in seconds."
             },
             {
               "name": "unhealthyThreshold",
               "type": "integer",
               "required": false,
               "default": 2,
-              "description": "Number of unhealthy health checks required before a host is marked unhealthy"
+              "description": "Number of unhealthy health checks required before a host is marked as unhealthy."
             },
             {
               "name": "healthyThreshold",
               "type": "integer",
               "required": false,
               "default": 2,
-              "description": "Number of healthy health checks required before a host is marked healthy"
+              "description": "Number of healthy health checks required before a host is marked as healthy."
             }
           ]
         }

--- a/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
@@ -225,7 +225,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Position should be the final position (including already available filters) after all the filters engaged. Position starts from 1.</p>
+                                        <p>Position should be the final position (including already available filters) after all the filters are engaged. Position starts from 1.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -244,7 +244,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted</p>
+                                        <p>Filter specific custom configurations. Only `(string, string)` key-value pairs are accepted.</p>
                                     </div>
                                 </div>
                             </div>
@@ -569,7 +569,7 @@ password = "admin"</code></pre>
                             <code>[management]</code>
                             <span class="badge-required">Required</span>
                             <p>
-                                The configuration for admin credentials of the Enforcer
+                                The configurations for the Enforcer admin credentials.
                             </p>
                         </div>
                         <div class="params-wrap">

--- a/en/tools/config-catalog-generator-cc/dist/router-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/router-configurations.md
@@ -446,7 +446,7 @@ See the example .toml file given below.
                             <code>[router.upstream.health]</code>
                             
                             <p>
-                                Health configuration for upstream clusters
+                                Health configuration for upstream clusters.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -466,7 +466,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time in seconds to wait for a health check response</p>
+                                        <p>Time in seconds to wait for a health check response.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -485,7 +485,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Interval betweenn health checks in seconds</p>
+                                        <p>Interval between health checks in seconds.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -504,7 +504,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Number of unhealthy health checks required before a host is marked unhealthy</p>
+                                        <p>Number of unhealthy health checks required before a host is marked as unhealthy.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -523,7 +523,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Number of healthy health checks required before a host is marked healthy</p>
+                                        <p>Number of healthy health checks required before a host is marked as healthy.</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Purpose
Fixing typos related to configurations of CC. 

PR comments - https://github.com/wso2/docs-apim/pull/5039/files
