### PR TITLE
fixes https://github.com/wso2/docs-apim/issues/5080 #5081

### DIFF
--- a/en/docs/develop/product-apis/advanced-configurations.md
+++ b/en/docs/develop/product-apis/advanced-configurations.md
@@ -16,7 +16,7 @@ By default, each of the above Product REST APIs allows requests from all origins
 
 The origin will have the following syntax.
 
-``` tab="Origin Format"
+``` tab="Format"
 <scheme>"://"<hostname>[ ":" <port> ]
 ```
 

--- a/en/docs/develop/product-apis/advanced-configurations.md
+++ b/en/docs/develop/product-apis/advanced-configurations.md
@@ -17,7 +17,7 @@ By default, each of the above Product REST APIs allows requests from all origins
 The origin will have the following syntax.
 
 ``` tab="Format"
-<scheme>"://"<hostname>[ ":" <port> ]
+<scheme>://<hostname>[ :<port> ]
 ```
 
 ``` tab="Example"

--- a/en/docs/develop/product-apis/advanced-configurations.md
+++ b/en/docs/develop/product-apis/advanced-configurations.md
@@ -1,0 +1,56 @@
+# Advanced Configurations
+
+The following sections explain the advanced configurations with regard to WSO2 API Manager REST APIs.
+
+## Configuring Allowed Origins
+
+The Cross Origin Resource Sharing (CORS) `allowedOrigins` property can be used to specify the origins which should be allowed access to the Publisher, Developer Portal and API Gateway REST APIs of WSO2 API Manager (WSO2 API-M). The `allowedOrigins` property reads values from the system parameters. The defined system parameters are as follows:
+
+| **REST API** | **Parameter** |
+|----------|-----------|
+| Publisher | `rest.api.publisher.allowed.origins` |
+| Developer Portal | `rest.api.devportal.allowed.origins` |
+| API Gateway | `rest.api.gateway.allowed.origins` |
+
+By default, each of the above Product REST APIs allows requests from all origins. However, if you need to only allow a specific set of origins to access a Product REST API, you need to configure the allowed origins as a system parameter for that particular REST API. You can use one of the following methods:
+
+The origin will have the following syntax.
+
+``` tab="Origin Format"
+<scheme>"://"<hostname>[ ":" <port> ]
+```
+
+``` tab="Example"
+https://myorg1.publisher.example.com
+```
+
+### Method 1 - Defining the allowed origins before starting the server
+
+1. Navigate to the `<API-M_HOME>/repository/conf/deployment.toml` file.
+2. Enter the following configuration under the `[system.parameter]` configurations.
+
+     ``` tab="Format"
+     [system.parameter]
+     'rest.api.publisher.allowed.origins' = "<comma-separated-origins>"
+     'rest.api.devportal.allowed.origins' = "<comma-separated-origins>"
+     'rest.api.gateway.allowed.origins' = "<comma-separated-origins>"
+     ```
+
+     ``` tab="Example"
+     [system.parameter]
+     'rest.api.publisher.allowed.origins' = "https://myorg1.publisher.example.com"
+     'rest.api.devportal.allowed.origins' = "https://myorg1.devportal.example.com,https://myorg2.devportal.example.com"
+     'rest.api.gateway.allowed.origins' = "https://myorg1.gateway.example.com,https://myorg3.gateway.example.com"
+     ```
+
+### Method 2 - Defining the allowed origins when starting the server
+
+You can start the WSO2 API Manager server as follows so that the allowed origins are defined at the point of starting the server.
+
+``` tab="Format"
+sh wso2server.sh -Drest.api.publisher.allowed.origins=<comma-separated-origins> -Drest.api.devportal.allowed.origins=<comma-separated-origins> -Drest.api.gateway.allowed.origins=<comma-separated-origins>
+```
+
+``` tab="Example"
+sh wso2server.sh -Drest.api.publisher.allowed.origins=https://myorg1.publisher.example.com -Drest.api.devportal.allowed.origins=https://myorg1.devportal.example.com,https://myorg2.devportal.example.com -Drest.api.gateway.allowed.origins=https://myorg1.gateway.example.com,https://myorg3.gateway.example.com
+```

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -329,6 +329,7 @@ nav:
             - Admin APIs:
                 - Admin API v0.15:
                     - Admin API v0.15: develop/product-apis/admin-apis/admin-v0.15/admin-v0.15.md
+            - Advanced Configurations: develop/product-apis/advanced-configurations.md
         - Admin Services: develop/wso2-admin-services.md
         - Working with the Source Code: develop/working-with-the-source-code.md
         - Java Documentation: develop/java-documentation.md


### PR DESCRIPTION
## Purpose
- fixes CORS Configuration not available in APIM 3.1.0 and 3.0.0 documentation #5080
![Advanced-Configurations-WSO2-API-Manager-Documentation-3-0-0](https://user-images.githubusercontent.com/5195851/143840602-f23c9678-4296-4fd1-9d54-14892f583b7c.png)

