### PR TITLE
Update sending-a-simple-message-to-a-datasource.md

### DIFF
--- a/en/docs/tutorials/integration-tutorials/sending-a-simple-message-to-a-datasource.md
+++ b/en/docs/tutorials/integration-tutorials/sending-a-simple-message-to-a-datasource.md
@@ -168,7 +168,7 @@ configured in the previous step:
             </tr>
             <tr class="odd">
             <td>SQL Type</td>
-            <td>SCALAR</td>
+            <td>STRING</td>
             </tr>
             </tbody>
             </table>


### PR DESCRIPTION

## Purpose
>Fix typo

## PR Summary 
There is no type as SCALAR in SQL. It should be STRING


![Capture](https://user-images.githubusercontent.com/31257148/145723785-f9114658-cc76-4a3c-95da-afea4c5c3e85.PNG)

