### PR TITLE
[3.2.0] Update listing formats section in APICTL

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -770,6 +770,17 @@ Output of `list envs`, `list apis` and `list apps` can be formatted with Go Temp
             </td>
         </tr>
         <tr class="odd">
+            <td>jsonArray</td>
+            <td>Outputs a human-readable JSON Array with indented by 2 spaces</td>
+            <td>
+                <div style="width: 100%; display: block; overflow: auto;">
+                    ``` 
+                    --format "jsonArray" 
+                    ```
+                </div>
+            </td>
+        </tr>
+        <tr class="odd">
             <td>upper</td>
             <td>Convert string to uppercase</td>
             <td>


### PR DESCRIPTION
## Purpose
Update the **Formatting the outputs of list** [1] section in **Getting Started with WSO2 API Controller**[2] to add newly supported "jsonArray" format type.

[1] https://apim.docs.wso2.com/en/3.2.0/learn/api-controller/getting-started-with-wso2-api-controller/#formatting-the-outputs-of-list
[2] https://apim.docs.wso2.com/en/3.2.0/learn/api-controller/getting-started-with-wso2-api-controller/

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/857 for 3.2.0

## Approach
![ScreenShot Tool -20220126104614](https://user-images.githubusercontent.com/42435576/151128768-5e8276e4-ad82-4b1d-9e1e-4490b1962b0b.png)



