### PR TITLE
fixes https://github.com/wso2/docs-apim/issues/5317

### DIFF
--- a/en/docs/reference/connectors/exporting-artifacts.md
+++ b/en/docs/reference/connectors/exporting-artifacts.md
@@ -6,18 +6,18 @@
 
 To bundle a Connector into a CApp, a `Connector Exporter Project` is required. 
 
-1. Navigate to **File** -> **New** -> **Other** -> **WSO2** -> **Extensions** -> **Project Types** -> **Connector Exporter Project**.<br> 
-  <a href="{{base_path}}/assets/img/integrate/connectors/connector-exporter-project-1.png"><img src="{{base_path}}/assets/img/integrate/connectors/connector-exporter-project-1.png" title="Add Connector Exporter Project" width="400" alt="Add Connector Exporter Project" /></a>
+1. Navigate to **File** -> **New** -> **Other** -> **WSO2** -> **Extensions** -> **Project Types** -> **Connector Exporter Project**.</br>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/connector-exporter-project-1.jpg"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/connector-exporter-project-1.jpg" title="Add Connector Exporter Project" width="60%" alt="Add Connector Exporter Project" /></a>
 
 2. Enter a name for the Connector Exporter Project. 
 
-3. In the next screen select, **Specify the parent from workspace** and select the specific Integration Project you created from the dropdown. 
-  <a href="{{base_path}}/assets/img/integrate/connectors/connector-exporter-project-naming.png"><img src="{{base_path}}/assets/img/integrate/connectors/connector-exporter-project-naming.png" title="Naming Connector Exporter Project" width="400" alt="Naming Connector Exporter Project" /></a>
+3. In the next screen select, **Specify the parent from workspace** and select the specific Integration Project you created from the dropdown.</br>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/connector-exporter-project-naming.png"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/connector-exporter-project-naming.png" title="Naming Connector Exporter Project" width="60%" alt="Naming Connector Exporter Project" /></a>
 
 4. Now you need to add the Connector to Connector Exporter Project that you just created. Right-click the Connector Exporter Project and select, **New** -> **Add Remove Connectors** -> **Add Connector** -> **Add from Workspace** -> **Connector**
 
-5. Once you are directed to the workspace, it displays all the connectors that exist in the workspace. You can select the relevant connector and click **Ok**. 
-  <a href="{{base_path}}/assets/img/integrate/connectors/adding-connector-to-exporter-project-3.png"><img src="{{base_path}}/assets/img/integrate/connectors/adding-connector-to-exporter-project-3.png" title="Selecting Connector from Workspace" width="400" alt="Selecting Connector from Workspace" />
+5. Once you are directed to the workspace, it displays all the connectors that exist in the workspace. You can select the relevant connector and click **Ok**.</br>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/adding-connector-to-exporter-project-3.jpg"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/adding-connector-to-exporter-project-3.jpg" title="Selecting Connector from Workspace" width="60%" alt="Selecting Connector from Workspace" />
 
 ### Creating a Composite Application Project
 
@@ -25,10 +25,10 @@ To export the `Integration Project` as a CApp, a `Composite Application Project`
 
 ### Exporting the Composite Application Project
 
-1. Right-click the Composite Application Project and click **Export Composite Application Project**.
-  <img src="{{base_path}}/assets/img/integrate/connectors/capp-project1.png" title="Export as a Carbon Application" width="400" alt="Export as a Carbon Application" />
+1. Right-click the Composite Application Project and click **Export Composite Application Project**.</br>
+   <img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/capp-project1.jpg" title="Export as a Carbon Application" width="40%" alt="Export as a Carbon Application" />
 
 2. Select an **Export Destination** where you want to save the .car file. 
 
-3. In the next **Create a deployable CAR file** screen, select both the created Integration Project and the Connector Exporter Project to save and click **Finish**. The CApp is created at the specified location provided at the previous step. 
-  <a href="{{base_path}}/assets/img/integrate/connectors/saving-projects.png"><img src="{{base_path}}/assets/img/integrate/connectors/saving-projects.png" title="Create a deployable CAR file" width="600" alt="Create a deployable CAR file" /></a>
+3. In the next **Create a deployable CAR file** screen, select both the created Integration Project and the Connector Exporter Project to save and click **Finish**. The CApp is created at the specified location provided at the previous step.</br>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/saving-projects.png"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/saving-projects.png" title="Create a deployable CAR file" width="80%" alt="Create a deployable CAR file" /></a>

--- a/en/docs/reference/connectors/importing-connector-to-integration-studio.md
+++ b/en/docs/reference/connectors/importing-connector-to-integration-studio.md
@@ -1,14 +1,14 @@
 1. Open WSO2 Integration Studio and create an **Integration Project**.
-  <a href="{{base_path}}/assets/img/integrate/new-project/new-integration-project.png"><img src="{{base_path}}/assets/img/integrate/new-project/new-integration-project.png" title="Creating a new Integration Project" width="800" alt="Creating a new Integration Project" /></a>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/new-project/new-integration-project.png"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/new-project/new-integration-project.png" title="Creating a new Integration Project" width="800" alt="Creating a new Integration Project" /></a>
 
 2. Right-click the project that you created and click on **Add or Remove Connector** -> **Add Connector**. You will get directed to the WSO2 Connector Store.
 
 3. Search for the specific connector required for your integration scenario and download it to the workspace.
-  <a href="{{base_path}}/assets/img/integrate/connectors/search-connector.png"><img src="{{base_path}}/assets/img/integrate/connectors/search-connector.png" title="Search Connector in the Connector Store" width="400" alt="Search Connector in the Connector Store" /></a>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/search-connector.png"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/search-connector.png" title="Search Connector in the Connector Store" width="40%" alt="Search Connector in the Connector Store" /></a>
 
 4. Click **Finish**, and your Integration Project is ready. The downloaded connector is displayed on the side palette with its operations. 
 
 5. You can drag and drop the operations to the design canvas and build your integration logic.
-  <a href="{{base_path}}/assets/img/integrate/connectors/drag-connector-operation.png"><img src="{{base_path}}/assets/img/integrate/connectors/drag-connector-operation.png" title="Drag connector operations" width="800" alt="Drag connector operations" /></a>
+   <a href="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/drag-connector-operation.png"><img src="https://apim.docs.wso2.com/en/4.1.0/assets/img/integrate/connectors/drag-connector-operation.png" title="Drag connector operations" alt="Drag connector operations" /></a>
   
 6. Right click on the created Integration Project and select **New** -> **Rest API** to create the REST API. 


### PR DESCRIPTION
## Purpose
- fixes https://github.com/wso2/docs-apim/issues/5317
- {{base_path}} does not work in these instances when single sourcing content and including (pulling) pages so that it can be displayed in other pages. Therefore, the URLs had to be hardcoded it in for the images to appear.