### PR TITLE
reduced size of search icon and text

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -99,6 +99,16 @@
 #apimdocsearch > button {
     width: 100%;
 }
+
+span.DocSearch-Button-Placeholder {
+    font-size: 0.7rem;
+}
+
+svg.DocSearch-Search-Icon {
+    width: 16px;
+    height: 16px;
+}
+
 /* END of - Algolia docsearch related styling overrides */
 
 .md-header__version-select .mb-tabs__dropdown .mb-tabs__dropdown-content,


### PR DESCRIPTION
## Purpose
- fixed font and icon size of search
- fix related to https://github.com/wso2/docs-apim/issues/5395
<img width="1680" alt="Screenshot 2022-03-08 at 6 58 08 PM" src="https://user-images.githubusercontent.com/5195851/157247361-941e87b8-2a80-401d-92da-85ead0592653.png">

