### PR TITLE
Fix the config ordering issue

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -82,11 +82,11 @@ Use the `<API-M_HOME>/bin/chpasswd.sh` script.
     ``` toml
     [tenant_mgt]
     enable_email_domain= true
-
-    [apim.throttling.policy_deploy]
-    username = "$ref{super_admin.username}@carbon.super"
-
+   
     [apim.throttling]
+    username = "$ref{super_admin.username}@carbon.super"
+   
+    [apim.throttling.policy_deploy]
     username = "$ref{super_admin.username}@carbon.super"
 
     [apim.throttling.jms]


### PR DESCRIPTION
Throttling config has to be defined before its child configurations. Otherwise, there will be failures at the startup. This has to be fixed in all the other docs including 4.0.0, 3.2.0 and rest. 