### PR TITLE
Update HTTP endpoint OAuth Configs

### DIFF
--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -540,7 +540,14 @@ The following is an HTTP endpoint configured with basic authentication.
 The following properties <b>only</b> apply to HTTP endpoint. 
 
 !!! Note
-      You can also use environment variables for these parameters. For more information, see [Injecting Parameters]({{base_path}}/integrate/develop/injecting-parameters).
+      1. You can also use environment variables for these parameters. For more information, see [Injecting Parameters]({{base_path}}/integrate/develop/injecting-parameters).
+      2. You can use dynamic values for OAuth configurations such as XPATH, JSON expressions or vault-lookup. For more information, see [Define dynamic expressions]({{base_path}}/reference/synapse-properties/endpoint-properties/#define-dynamic-expressions).
+      3. You can send additional parameters as well in the OAuth request body. For more information, see [Send additional parameters in the OAuth request body]({{base_path}}/reference/synapse-properties/endpoint-properties/#send-additional-parameters-in-the-oauth-request-body).
+
+
+!!! Tip
+      You can configure the OAuth cache timeout (in seconds) by setting the following property in `<MI_HOME>/conf/synapse.properties` file. The default timeout will be 3000 seconds.
+      `synapse.endpoint.http.oauth.cache.timeout=500`
 
 #### Authorization Code/Refresh Token grant type
 
@@ -550,11 +557,15 @@ The `authorizationCode` element contains the following parameters that are used 
     <tr>
         <th>Property</th>
         <th>Description</th>
+        <th>Required</th>
     </tr>
     <tr>
         <td>clientId</td>
         <td>
             Client ID that is provided by the third-party service when you registered your application.
+        </td>
+        <td>
+            Yes
         </td>
     </tr>
     <tr>
@@ -562,17 +573,35 @@ The `authorizationCode` element contains the following parameters that are used 
         <td>
             Client Secret that is provided by the third-party service when you registered your application.
         </td>
+        <td>
+            Yes
+        </td>
     </tr>
     <tr>
         <td>refreshToken</td>
         <td>
             Refresh token obtained from the third-party service by using Authorization Code grant flow.
         </td>
+        <td>
+            Yes
+        </td>
     </tr>
     <tr>
         <td>tokenUrl</td>
         <td>
             Token endpoint provided by the third-party service to obtain access tokens.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>authMode</td>
+        <td>
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+        </td>
+        <td>
+            Optional
         </td>
     </tr>
 </table>
@@ -604,11 +633,15 @@ The `clientCredentials` element contains the following parameters that are used 
     <tr>
         <th>Property</th>
         <th>Description</th>
+        <th>Required</th>
     </tr>
     <tr>
         <td>clientId</td>
         <td>
             Client ID provided by the third-party service when you registered your application.
+        </td>
+        <td>
+            Yes
         </td>
     </tr>
     <tr>
@@ -616,11 +649,26 @@ The `clientCredentials` element contains the following parameters that are used 
         <td>
             Client Secret provided by the third-party service when you registered your application.
         </td>
+        <td>
+            Yes
+        </td>
     </tr>
     <tr>
         <td>tokenUrl</td>
         <td>
             Token endpoint provided by the third-party service to obtain access tokens.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>authMode</td>
+        <td>
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+        </td>
+        <td>
+            Optional
         </td>
     </tr>
 </table>
@@ -636,6 +684,139 @@ The following is an HTTP endpoint configured with the client credentials grant t
                     <clientId>K2RbnGP7VS</clientId>
                     <clientSecret>9zLrZAYR5b</clientSecret>
                     <tokenUrl>http://localhost:8678/token</tokenUrl>
+                </clientCredentials>
+            </oauth>
+        </authentication>
+    </http>
+</endpoint>
+```
+
+#### Password grant type
+
+The `passwordCredentials` element contains the following parameters that are used to configure OAuth for the endpoint.
+
+<table>
+    <tr>
+        <th>Property</th>
+        <th>Description</th>
+        <th>Required</th>
+    </tr>
+    <tr>
+        <td>clientId</td>
+        <td>
+            Client ID provided by the third-party service when you registered your application.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>clientSecret</td>
+        <td>
+            Client Secret provided by the third-party service when you registered your application.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>username</td>
+        <td>
+            Username of the user.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>password</td>
+        <td>
+            Password of the user.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>tokenUrl</td>
+        <td>
+            Token endpoint provided by the third-party service to obtain access tokens.
+        </td>
+        <td>
+            Yes
+        </td>
+    </tr>
+    <tr>
+        <td>authMode</td>
+        <td>
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+        </td>
+        <td>
+            Optional
+        </td>
+    </tr>
+</table>
+
+The following is an HTTP endpoint configured with the password grant type.
+
+```xml
+<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
+    <http method="get" uri-template="http://localhost:9192/service/foodservice">
+        <authentication>
+            <oauth>
+                <passwordCredentials>
+                    <clientId>K2RbnGP7VS</clientId>
+                    <clientSecret>9zLrZAYR5b</clientSecret>
+                    <username>internal-user</username>
+                    <password>abc@123</password>
+                    <tokenUrl>http://localhost:8678/token</tokenUrl>
+                </passwordCredentials>
+            </oauth>
+        </authentication>
+    </http>
+</endpoint>
+```
+
+#### Send additional parameters in the OAuth request body
+
+By default the `grant_type`, `client_id`, and `client_secret` parameters are sent in the OAuth request body. To send additional parameters you can define them as a list of parameters under the `requestParameters` tag as shown in the example below.
+
+```xml
+<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
+    <http method="get" uri-template="http://localhost:9192/service/foodservice">
+        <authentication>
+            <oauth>
+                <clientCredentials>
+                    <clientId>K2RbnGP7VS</clientId>
+                    <clientSecret>9zLrZAYR5b</clientSecret>
+                    <tokenUrl>http://localhost:8678/token</tokenUrl>
+                    <requestParameters>
+                        <parameter name="scope">read_only</parameter>
+                        <parameter name="user_role">tester</parameter>
+                    </requestParameters>
+                </clientCredentials>
+            </oauth>
+        </authentication>
+    </http>
+</endpoint>
+```
+
+#### Define dynamic expressions
+
+You can use dynamic values for OAuth configurations such as XPATH, JSON expressions or vault-lookup to get data from a secure vault. Make sure you define the elements within curly brackets.
+
+```xml
+<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
+    <http method="get" uri-template="http://localhost:9192/service/foodservice">
+        <authentication>
+            <oauth>
+                <clientCredentials>
+                    <clientId>K2RbnGP7VS</clientId>
+                    <clientSecret>{hashicorp:vault-lookup('secret/hello', 'clientSecret')}</clientSecret>
+                    <tokenUrl>http://localhost:8678/token</tokenUrl>
+                    <requestParameters>
+                        <parameter name="scope">{ctx:oauth_scope}</parameter>
+                    </requestParameters>
                 </clientCredentials>
             </oauth>
         </authentication>

--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -749,7 +749,7 @@ The `passwordCredentials` element contains the following parameters that are use
     <tr>
         <td>authMode</td>
         <td>
-            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header, which is the default.
         </td>
         <td>
             Optional

--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -665,7 +665,7 @@ The `clientCredentials` element contains the following parameters that are used 
     <tr>
         <td>authMode</td>
         <td>
-            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header, which is the default.
         </td>
         <td>
             Optional

--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -598,7 +598,7 @@ The `authorizationCode` element contains the following parameters that are used 
     <tr>
         <td>authMode</td>
         <td>
-            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header which is the default.
+            Indicate how the client credentials are passed to the token endpoint. If the authMode is <code>payload</code> they are passed in the request payload. If the authMode is <code>header</code> the client credentials are passed in the authentication header, which is the default.
         </td>
         <td>
             Optional

--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -546,7 +546,7 @@ The following properties <b>only</b> apply to HTTP endpoint.
 
 
 !!! Tip
-      You can configure the OAuth cache timeout (in seconds) by setting the following property in `<MI_HOME>/conf/synapse.properties` file. The default timeout will be 3000 seconds.
+      You can configure the OAuth cache timeout (in seconds) by setting the following property in the `<MI_HOME>/conf/synapse.properties` file. The default timeout will be 3000 seconds.
       `synapse.endpoint.http.oauth.cache.timeout=500`
 
 #### Authorization Code/Refresh Token grant type


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/docs-apim/issues/5250
Fixes https://github.com/wso2/docs-apim/issues/4957

## Goals
This PR will update the OAuth config section of HTTP endpoints with the following,
- Password grant configs for MI OAuth HTTP endpoints.
- Expression support for OAuth Configs.
- Option to specify custom params in OAuth request body.
- Indicate how the client credentials are passed to the token endpoint with the `authMode` property.
- Option to configure the OAuth cache timeout

## User stories

![synapse-properties_endpoint](https://user-images.githubusercontent.com/18748929/163937143-b3dae4e2-daff-4be1-af24-74f566f56afe.png)
