### PR TITLE
Update passing-enduser-attributes-to-the-backend-via-api-gateway.md

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway.md
@@ -113,7 +113,7 @@ Follow the instructions below if you want to pass additional attributes to the b
      ```
      
      !!! note
-         Note that CustomTokenGenerator is for opaque tokens only and public class CustomGatewayJWTGenerator is for JWT.
+         Note that `CustomTokenGenerator` is for opaque tokens only and public class `CustomGatewayJWTGenerator` is for JWT.
 
 4.  Set the `apim.jwt.enable` element to **true** in the `deployment.toml` file.
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway.md
@@ -111,6 +111,9 @@ Follow the instructions below if you want to pass additional attributes to the b
      ...
      generator_impl = "org.wso2.carbon.test.CustomTokenGenerator"
      ```
+     
+     !!! note
+         Note that CustomTokenGenerator is for opaque tokens only and public class CustomGatewayJWTGenerator is for JWT.
 
 4.  Set the `apim.jwt.enable` element to **true** in the `deployment.toml` file.
 


### PR DESCRIPTION
Adds the following note:

!!! note
         Note that CustomTokenGenerator is for opaque tokens only and public class CustomGatewayJWTGenerator is for JWT.

Fixes https://github.com/wso2/docs-apim/issues/5502