### PR TITLE
Fixed broken YAML url

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-operators/k8s-api-operator/install.md
+++ b/en/docs/install-and-setup/setup/kubernetes-operators/k8s-api-operator/install.md
@@ -18,7 +18,7 @@ Follow the steps given below to install the operator in standalone mode.
 1. Install the API Operator: 
 
     ```shell
-    kubectl apply -f https://github.com/wso2/k8s-api-operator/releases/download/v2.0.2/api-operator-configs.yaml
+    kubectl apply -f https://github.com/wso2/k8s-api-operator/releases/download/2.0.2/api-operator-configs.yaml
     ```
 
 2. Verify the installation:


### PR DESCRIPTION
The API Operator installation command contains a broken url to the YAML file that returns 404, I replaced it with the correct one which was just to replace v2.0.2 by 2.0.2

## Purpose
Link inside API Operator installation gives a 404

## Goals
fixed the url by the one provided inside the download page of github

