### PR TITLE
Add quotes to passwoard in api_params.yaml

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-security-types.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-security-types.md
@@ -21,8 +21,8 @@ The following is an example `api_params.yaml` file for this scenario.
           security:
               enabled: true
               type: basic
-              username: admin
-              password: admin
+              username: 'admin'
+              password: 'admin'
     ```
 
 Under the security field, if the `enabled` attribute is `true`, you must specify the `username`, `password` and the `type` (can be either only `basic` or `digest`). If the `enabled` attribute is `false`, then none of the security parameters will be set. If the `enabled` attribute is not set (blank), then the security parameters in api.yaml file will be considered.
@@ -62,8 +62,8 @@ The following is an example `api_params.yaml` file for this scenario.
               sandbox:
                   enabled: true
                   type: oauth
-                  username: admin
-                  password: password
+                  username: 'admin'
+                  password: 'password'
                   tokenUrl: https://sand.token.com
                   clientId: Fcd7i6mTj0ac3LyTW0szFzdt1asd
                   clientSecret: rfDEOOjlY0kgClxVlntwWVFve56f

--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -81,8 +81,8 @@ The following code snippet contains sample configuration of the parameter file.
           security:
               enabled: true
               type: basic
-              username: admin
-              password: admin
+              username: 'admin'
+              password: 'admin'
           certs:
               - hostName: 'https://dev.wso2.com'
                 alias: Dev
@@ -115,8 +115,8 @@ The following code snippet contains sample configuration of the parameter file.
           security:
               enabled: true
               type: digest
-              username: admin
-              password: admin
+              username: 'admin'
+              password: 'admin'
         - name: production
           endpoints:
             production:
@@ -144,6 +144,7 @@ Instead of the default `api_params.yaml`, you can provide a custom parameter fil
 
 !!! info
     -   Production/Sandbox backends for each environment can be specified in the parameter file with additional configurations, such as timeouts.
+    -   Quotes are mandatory if `password` contains special characters.
     -   Certificates (Endpoint certificates and MutualSSL certificates) for each URL can be configured in the parameter file. For certificates, a valid path to the certificate file is required. 
     -   The parameter file supports detecting environment variables during the API import process. You can use the usual notation. For example, `url: $DEV_PROD_URL`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
     - To learn about setting up different endpoint types such as HTTP/REST, HTTP/SOAP (with load balancing and failover), Dynamic and AWS Lambda, refer the section [Configuring Different Endpoint Types]({{base_path}}/learn/api-controller/advanced-topics/configuring-different-endpoint-types).


### PR DESCRIPTION
Add quotes to password in api_params.yaml file and add instruction to mandate quotes if password contains special characters in https://apim.docs.wso2.com/en/3.2.0/learn/api-controller/advanced-topics/configuring-environment-specific-parameters/.