### PR TITLE
Add quotes to passwoard in params.yaml

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-different-endpoint-security-types.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-different-endpoint-security-types.md
@@ -23,13 +23,13 @@ The following is an example parameters file of an API for this scenario.
                 production:
                     enabled: true
                     type: digest
-                    username: admin
-                    password: admin
+                    username: 'admin'
+                    password: 'admin'
                 sandbox:
                     enabled: true
                     type: basic
-                    username: admin
-                    password: admin
+                    username: 'admin'
+                    password: 'admin'
     ```
 
 Under the security field, if the `enabled` attribute is `true`, you must specify the `username`, `password` and the `type` (can be either only `basic` or `digest`). If the `enabled` attribute is `false`, then none of the security parameters will be set. If the `enabled` attribute is not set (blank), then the security parameters in `api.yaml` file will be considered.
@@ -62,8 +62,8 @@ The following is an example parameters file of an API for this scenario.
                 sandbox:
                     enabled: true
                     type: oauth
-                    username: admin
-                    password: password
+                    username: 'admin'
+                    password: 'password'
                     tokenUrl: https://sand.token.com
                     clientId: Fcd7i6mTj0ac3LyTW0szFzdt1asd
                     clientSecret: rfDEOOjlY0kgClxVlntwWVFve56f

--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -242,8 +242,8 @@ The following code snippet contains sample configuration of the parameters file 
                 production:
                     enabled: true
                     type: basic
-                    username: admin
-                    password: admin
+                    username: 'admin'
+                    password: 'admin'
             certs:
                 - hostName: 'https://dev.wso2.com'
                   alias: Dev
@@ -270,7 +270,7 @@ The following code snippet contains sample configuration of the parameters file 
                         suspendErrorCode: 
                             - "101504"
                             - "101501"
-                        retryTimeOut: $RETRY
+                        retryTimeOut: ${RETRY}
                         retryDelay: 23000
                         retryErroCode:
                             - "101503" 
@@ -283,13 +283,13 @@ The following code snippet contains sample configuration of the parameters file 
                 production:
                     enabled: true
                     type: digest
-                    username: admin
-                    password: admin
+                    username: 'admin'
+                    password: 'admin'
                 sandbox:
                     enabled: true
                     type: basic
-                    username: admin
-                    password: admin
+                    username: 'admin'
+                    password: 'admin'
         - name: production
           configs:
             endpoints:
@@ -316,7 +316,8 @@ You can provide the parameters file using `--params` flag when importing an API.
 
 -   You can deploy an API project which does not include `deployment_environments.yaml` (working copy of the API or a revision without deployment environments) by specifying the `deploymentEnvironments` fields in the parameters file.
 -   Production/Sandbox backends for each environment can be specified in the parameters file with additional configurations, such as timeouts.
--   The parameters file supports detecting environment variables during the API import process. You can use the usual notation. For example, `url: $DEV_PROD_URL`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
+-   When defining passwords in parameters file, quotes are mandatory if `password` contains special characters.
+-   The parameters file supports detecting environment variables during the API import process. You can use the usual notation as described [here]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects/). For example, `url: ${DEV_PROD_URL}`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
 -   To learn about setting up different endpoint types such as HTTP/REST, HTTP/SOAP (with load balancing and failover), Dynamic and AWS Lambda, see [Configuring Different Endpoint Types]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-different-endpoint-types).
 -   To learn about setting up different endpoint security types such as Basic, Digest and OAuth 2.0, refer the section [Configuring Different Endpoint Security Types]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/configuring-different-endpoint-security-types).
 -   You can define the subscription level policies of an API using the field `policies`. There you can specify one or more subscription level policies that is available in the particular environment where you are importing the API to.
@@ -535,7 +536,7 @@ The following code snippet contains sample configuration of the parameters file 
                                   suspendErrorCode: 
                                       - "101504"
                                       - "101501"
-                                  retryTimeOut: $RETRY
+                                  retryTimeOut: ${RETRY}
                                   retryDelay: 23000
                                   retryErroCode:
                                       - "101503" 
@@ -548,8 +549,8 @@ The following code snippet contains sample configuration of the parameters file 
                           production:
                               enabled: true
                               type: basic
-                              username: admin
-                              password: admin
+                              username: 'admin'
+                              password: 'admin'
                       certs:
                           - hostName: https://prod1.wso2.com
                             alias: alice
@@ -567,13 +568,13 @@ The following code snippet contains sample configuration of the parameters file 
                           production:
                               enabled: true
                               type: digest
-                              username: admin
-                              password: admin
+                              username: 'admin'
+                              password: 'admin'
                           sandbox:
                               enabled: true
                               type: basic
-                              username: admin
-                              password: admin
+                              username: 'admin'
+                              password: 'admin'
                       certs:
                           - hostName: https://prod1.wso2.com
                             alias: bob
@@ -622,7 +623,7 @@ You can provide the parameters file using `--params` flag when importing an API 
 -   The parameters file of an API Product does not support the fields `endpoints`, `security` and `certs` like in the parameters file of an API. It only supports the fields `deploymentEnvironments`, `policies`, `mutualSslCerts` and another special field named `dependentAPIs`.
 -   The field `dependentAPIs` can be used to specify the parameters of dependent APIs. The parameters of a particular dependent API of an API Product is similar to the parameters of an API, but there is no use of specifying the `deploymentEnvironments` field under a dependent API. The reason for that is, the deployment environments of the API Product will be considered for dependent APIs as well.
 -   You can deploy an API Product which does not include `deployment_environments.yaml` (working copy of the API Product or a revision without deployment environments) by specifying the `deploymentEnvironments` fields in the parameters file.
--   The parameters file supports detecting environment variables during the API Product import process. You can use the usual notation. For example, `url: $DEV_PROD_URL`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
+-   The parameters file supports detecting environment variables during the API Product import process. You can use the usual notation as described [here]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects/). For example, `url: ${DEV_PROD_URL}`.  If an environment variable is not set, the tool will fail. In addition, the system will also request for a set of required environment variables.
 -   Refer the section [Handling the certificates using the parameters file](#handling-the-certificates-using-the-params-file) to learn how to configure certificates using the parameters file.
 
 ## Handling the certificates using the parameters file


### PR DESCRIPTION
Add quotes to password in api_params.yaml file, add instruction to mandate quotes if password contains special characters and fixed environment variable syntax in https://apim.docs.wso2.com/en/latest/install-and-setup/setup/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects/.