### PR TITLE
fixes https://github.com/wso2/docs-apim/issues/5795

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-rest-api-with-mock-impl.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-rest-api-with-mock-impl.md
@@ -1,6 +1,6 @@
 # Deploying a REST API with a Mock Implementation
 
-In addition to exposing an existing backend implementation as an API, Choreo Connect is also capable of responding to HTTP requests even without a backend. By changing the endpoint type to **Mock Implementation**, you can make Choreo Connect read the examples you have provided in the OpenAPI Definition and respond to each HTTP request accordingly. While it supports default responses, you can also request specific responses using the HTTP headers `Prefer` and `Accept`.
+In addition to exposing an existing backend implementation as an API, Choreo Connect is also capable of responding to HTTP requests even without a backend. By changing the endpoint type to **Mock Implementation**, you can make Choreo Connect read the examples you have provided in the OpenAPI definition and respond to each HTTP request accordingly. While it supports default responses, you can also request specific responses using the HTTP headers `Prefer` and `Accept`.
 
 Pick a method given below to start creating an API with a Mock Implementation.
 

--- a/en/docs/design/endpoints/endpoint-types.md
+++ b/en/docs/design/endpoints/endpoint-types.md
@@ -25,14 +25,19 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
-<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more details of configuring APIs to change the default mediation flow, see <a href="{{base_path}}/deploy-and-publish/deploy-on-gateway/api-gateway/message-mediation/changing-the-default-mediation-flow-of-api-requests">Changing the Default Mediation Flow of API Requests</a>.</td>
+<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/design/api-policies/gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
 </tr>
 <tr><td>Mock Implementation</td>
-<td>The Mock Implementation uses the built-in JavaScript engine of Synapse to mock the responses and can be used per HTTP resource of the API. For more information on the Mock Implementation, see <a href="{{base_path}}/design/prototype-api/create-a-prototype-api/#mock-implementation">Create a Prototype API</a>.</br>
+<td>
+<ul>
+<li><a href="{{base_path}}/design/prototype-api/create-mocked-js-api/">Mock implementation with API Gateway</a> - The Mock Implementation uses the built-in JavaScript engine of Synapse to mock the responses and can be used per HTTP resource of the API.</br>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>The <b>Mock Implementation</b> will be only available for APIs that are in the <b>CREATED</b> or <b>PROTOTYPED</b> state.</p>
-</div> 
+<p>The <b>Mock Implementation</b> will be only available for APIs that are in the <b>CREATED</b> or <b>PRE-RELEASED</b> state.</p>
+</div></li>
+<li>
+<a href="{{base_path}}/design/prototype-api/create-mocked-oas-api/">Mock implementation with Choreo Connect</a> - When using the Mock Implementation in Choreo Connect, you can generate mock responses based on the examples provided in the OpenAPI specification and directly get the response. For non-default cases, the exact response can be requested using the <code>Prefer</code> and <code>Accept</code> headers.
+</li>
 </td>
 </tr>
 <tr><td>AWS Lambda</td><td>An AWS Lambda endpoint can be used to invoke AWS Lambda functions through WSO2 API Gateway. For more information on creating APIs with AWS Lambda endpoint, see <a href="{{base_path}}/tutorials/create-and-publish-awslambda-api/">Create and Publish an AWS Lambda API</a>.</td>

--- a/en/docs/tutorials/develop-an-integration-with-a-managed-api.md
+++ b/en/docs/tutorials/develop-an-integration-with-a-managed-api.md
@@ -62,7 +62,7 @@ Let’s create an API in WSO2 API Manager.
 
 	 [![Add GET resource]({{base_path}}/assets/img/tutorials/querydocter-resource.png)]({{base_path}}/assets/img/tutorials/querydocter-resource.png)
 
-5.	You can manage the API the way you want and test out the resource by adding a [Mock Implementation]({{base_path}}/design/prototype-api/create-a-prototype-api/#mock-implementation).
+5.	You can manage the API the way you want and test out the resource by adding a [Mock Implementation]({{base_path}}/design/prototype-api/create-mocked-js-api).
 
 ## Step 2 - Develop the integration service
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -81,9 +81,10 @@ nav:
         - Change the Thumbnail of an API: design/create-api/change-api-thumbnail.md
         - Create Prototype APIs: 
             - Overview: design/prototype-api/overview.md
-            - Mock Implementation with API Gateway: design/prototype-api/create-mocked-js-api.md
-            - Mock Implementation with Choreo Connect: design/prototype-api/create-mocked-oas-api.md
-            - Expose an Existing Backend Implementation as a Prototype API: design/prototype-api/backend-url-prototype-api.md
+            - Mock Implementation: 
+                - With API Gateway: design/prototype-api/create-mocked-js-api.md
+                - With Choreo Connect: design/prototype-api/create-mocked-oas-api.md
+            - Existing Backend Implementation as a Prototype API: design/prototype-api/backend-url-prototype-api.md
         - Create API Products:
                 - API Product Overview: design/create-api-product/api-product-overview.md
                 - Create an API Product: design/create-api-product/create-api-product.md
@@ -262,7 +263,7 @@ nav:
                     - Expose via Custom Hostnames: deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-api-with-custom-hostnames.md
                     - Immutable Gateway:
                         - Deploy as an Immutable Gateway: deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-apis-as-immutable-gateway.md
-                    - Rest API with a Mock Implementation: deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-rest-api-with-mock-impl.md
+                    - REST API with a Mock Implementation: deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-rest-api-with-mock-impl.md
                 - Security:
                     - API Authentication:
                         - Overview: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/api-authentication.md
@@ -2173,6 +2174,7 @@ plugins:
               'install-and-setup/setup/mi-setup/observability/observability-deployment-strategy.md': 'https://apim.docs.wso2.com/en/4.1.0/observe/micro-integrator/cloud-native-observability-overview/'
               'design/prototype-api/create-a-mock-api-with-an-inline-script.md': 'https://apim.docs.wso2.com/en/4.1.0/design/prototype-api/create-a-prototype-api/'
               'design/prototype-api/deploy-and-test-mock-apis.md': 'https://apim.docs.wso2.com/en/4.1.0/design/prototype-api/create-a-prototype-api/'
+              'design/prototype-api/create-a-prototype-api.md': 'https://apim.docs.wso2.com/en/4.1.0/design/prototype-api/overview/'
               'deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/configure-log4j.md': 'https://apim.docs.wso2.com/en/4.1.0/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/configure-log4j2/'
               'deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/configure-log4j.md': 'https://apim.docs.wso2.com/en/4.1.0/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/configure-log4j2/'
               'deploy-and-publish/deploy-on-gateway/choreo-connect/concepts/inter-component-communication.md': 'https://apim.docs.wso2.com/en/4.1.0/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/choreo-connect-overview/#communication-between-the-components'


### PR DESCRIPTION
## Purpose
- fixes https://github.com/wso2/docs-apim/issues/5795
- Details with regard to the fix
  - As the 'design/prototype-api/create-a-prototype-api.md` page has been removed, a redirection was added for it.
  - Fixed the broken links.

## Output
<img width="1680" alt="Screenshot 2022-05-12 at 4 17 18 PM" src="https://user-images.githubusercontent.com/5195851/168068336-068d10ba-3b52-45d4-ae9c-98b38868a1af.png">

