### PR TITLE
Adding documentation on configuring different endpoint types from the API Controller 3.1.0

### DIFF
--- a/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
@@ -1,0 +1,255 @@
+#  Configuring Different Endpoint Types
+
+When there are multiple environments, to allow easily configuring environment-specific details, apictl supports an additional parameter file named `api_params.yaml`. (Please refer [Configuring Environment Specific Parameters]({{base_path}}/learn/api-controller/advanced-topics/configuring-environment-specific-parameters) for more information). You can specify different types of endpoints in this file, as discussed in this section.
+
+API Manager supports four (4) main types of endpoints as follows.
+
+1. HTTP/REST Endpoints
+2. HTTP/SOAP Endpoints
+3. Dynamic Endpoints
+4. AWS Lambda Endpoints
+
+!!! info
+    The following fields should be specified as your requirement when setting up different endpoints in `api_params.yaml` file.
+    
+    -   **endpointType**
+        
+        To specify the type of the endpoint. Values can be `rest`, `soap`, `dynamic` or `aws`. (For HTTP/REST Endpoints, you can specify the type as `rest`. But even if you do not specify the field `endpointType` at all in the `api_params.yaml` file, by default it takes the type as `rest`)
+    
+    -   **endpointRoutingPolicy**
+    
+        To specify the routing policy to be used. Values can be `load_balanced` or `failover`.
+    
+    -   **loadBalanceEndpoints** field should be specified if the `endpointRoutingPolicy` is `load_balanced`. This field contains the following.
+
+        - `production`: An array which consists the multiple production endpoints
+        - `sandbox`: An array which consists the multiple sandbox endpoints
+        - `sessionManagement` (Optional): Values can be `none`, `transport`, `soap`, `simpleClientSession` and if not specified the default value is `transport`
+        - `sessionTimeOut` (Optional): The number of milliseconds after which the session would time out
+
+    -   **failoverEndpoints** field should be specified if the `endpointRoutingPolicy` is `failover`. This field contains the following.
+
+        - `production`: The primary production endpoint (not an array)
+        - `sandbox`: The primary sandbox endpoint (not an array)
+        - `productionFailovers`: An array which consists failover production endpoints
+        - `sandboxFailovers`: An array which consists failover sandbox endpoints
+
+    -   **awsLambdaEndpoints** field should be specified if the `endpointType` is `aws`. This field contains the following.
+
+        - `accessMethod`: The access method of awslambda endpoint. Mandatory to specify. (Values can be `role_supplied` or `stored`)
+        - `amznRegion`: Region where the endpoint is located. Can be chosen from [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints)
+        - `amznAccessKey`: Access Key for endpoint
+        - `amznSecretKey`: Access Secret for endpoint
+
+Let us discuss configuring each of the above endpoint type with examples, seperately, in the following sections.
+
+### HTTP/REST Endpoints
+
+This can be subdivided into three (3) main scenarios.
+
+#### 1. HTTP/REST Endpoint - Without load balancing or failover
+
+The following is an example `api_params.yaml` file for this scenario. (Note that you can ignore specifying the `endpointType` field if you want, because by default it contains the value as `rest`.)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: rest
+        endpoints:
+            production:
+                url: https://dev.wso2.com
+            sandbox:
+                url: https://dev.sandbox.wso2.com
+    ```
+
+#### 2. HTTP/REST Endpoint - With load balancing
+
+The following is an example `api_params.yaml` file for this scenario. (Note that, as mentioned in the above section, you can ignore specifying the `endpointType` field if you want, because by default it contains the value as `rest`.)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: rest
+        endpointRoutingPolicy: load_balanced
+        loadBalanceEndpoints:
+            production:
+                - url: https://dev1.wso2.com
+                - url: https://dev2.wso2.com
+            sandbox:
+                - url: https://dev1.sandbox.wso2.com
+                - url: https://dev2.sandbox.wso2.com
+            sessionManagement: transport
+            sessionTimeOut: 5000
+    ```
+
+#### 3. HTTP/REST Endpoint - With failover
+
+The following is an example `api_params.yaml` file for this scenario. (Note that, as mentioned in the above sections, you can ignore specifying the `endpointType` field if you want, because by default it contains the value as `rest`.)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: rest
+        endpointRoutingPolicy: failover
+        failoverEndpoints:
+            production:
+                url: https://dev.wso2.com
+            productionFailovers:
+                - url: https://dev1.wso2.com
+                - url: https://dev2.wso2.com
+            sandbox:
+                url: https://dev.sandbox.wso2.com
+            sandboxFailovers:
+                - url: https://dev1.sandbox.wso2.com
+                - url: https://dev2.sandbox.wso2.com
+    ```
+
+### HTTP/SOAP Endpoints
+
+This too can be subdivided into three (3) main scenarios like in the previous section.
+
+#### 1. HTTP/SOAP Endpoint - Without load balancing or failover
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `soap`)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: soap
+        endpoints:
+            production:
+                url: https://dev.wso2.com
+            sandbox:
+                url: https://dev.sandbox.wso2.com
+    ```
+
+#### 2. HTTP/SOAP Endpoint - With load balancing
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `soap`)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: soap
+        endpointRoutingPolicy: load_balanced
+        loadBalanceEndpoints:
+            production:
+                - url: https://dev1.wso2.com
+                - url: https://dev2.wso2.com
+            sandbox:
+                - url: https://dev1.sandbox.wso2.com
+                - url: https://dev2.sandbox.wso2.com
+            sessionManagement: soap
+            sessionTimeOut: 5000
+    ```
+
+#### 3. HTTP/SOAP Endpoint - With failover
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `soap`)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: dev
+        endpointType: soap
+        endpointRoutingPolicy: failover
+        failoverEndpoints:
+            production:
+                url: https://dev.wso2.com
+            productionFailovers:
+                - url: https://dev1.wso2.com
+                - url: https://dev2.wso2.com
+            sandbox:
+                url: https://dev.sandbox.wso2.com
+            sandboxFailovers:
+                - url: https://dev1.sandbox.wso2.com
+                - url: https://dev2.sandbox.wso2.com
+    ```
+
+### Dynamic Endpoints
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `dynamic`)
+
+!!! example
+    ```go   
+    environments:
+        - name: test
+          endpoints:
+              production:
+              sandbox:
+        - name: development
+          endpointType: dynamic
+    ```
+
+!!! tip
+    When importing an API, if you are specifying the endpoint type as `dynamic`, you can include a message mediation policy with a `To` header inside the `Sequences` directory of your API Project. (Refer [Adding Dynamic Endpoints]({{base_path}}/learn/api-gateway/message-mediation/adding-dynamic-endpoints/#adding-dynamic-endpoints) to learn more about Dynamic endpoints and message mediations associated with that.)
+
+### AWS Lambda Endpoints
+
+This can be subdivided into three (2) main scenarios.
+
+#### 1. AWS Lambda - Using IAM role-supplied temporary AWS credentials
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `aws`)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: development
+        endpointType: aws
+        awsLambdaEndpoints:
+            accessMethod: role_supplied
+    ```
+
+#### 2. AWS Lambda - Using stored AWS credentials
+
+The following is an example `api_params.yaml` file for this scenario. (Make sure to specify the `endpointType` as `aws`)
+
+!!! example
+    ```go   
+    environments:
+      - name: test
+        endpoints:
+            production:
+            sandbox:
+      - name: development
+        endpointType: aws
+        awsLambdaEndpoints:
+            accessMethod: stored
+            amznRegion: us-west-1
+            amznAccessKey: jdej3kj34jk3l353k553535b353
+            amznSecretKey: 453653nk46j43kewrkj35j2kk32
+    ```

--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -87,21 +87,19 @@ The following code snippet contains sample configuration of the parameter file.
               production:
                   url: 'https://test.wso2.com'
                   config:
-                    factor: 3
-                    suspendMaxDuration: 25000
-                    suspendDuration: 45000
-                    suspendErrorCode: 
-                        - "101504"
-                        - "101501"
-                    retryTimeOut: $RETRY
-                    retryDelay: 23000
-                    retryErroCode:
-                        - "101503" 
-                        - "101504"
-                    actionSelect: discard
-                    actionDuration: 75000
-              sandbox:
-                  url: 'https://test.sandbox.wso2.com'
+                      factor: 3
+                      suspendMaxDuration: 25000
+                      suspendDuration: 45000
+                      suspendErrorCode: 
+                          - "101504"
+                          - "101501"
+                      retryTimeOut: $RETRY
+                      retryDelay: 23000
+                      retryErroCode:
+                          - "101503" 
+                          - "101504" 
+                      actionSelect: discard
+                      actionDuration: 75000           
           security:
               enabled: true
               type: digest

--- a/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -13,15 +13,43 @@ environments:
           production:
               url: <production_endpoint_url>
               config:
+                  factor: <suspension_factor>
+                  suspendMaxDuration: <maximum_suspend_time_duration>
+                  suspendDuration: <suspend_time_duration>
+                  suspendErrorCode: 
+                      - <suspend_error_code_1>
+                      - <suspend_error_code_2>
+                      - ......................
+                      - <suspend_error_code_n>
                   retryTimeOut: <no_of_retries_before_suspension>
                   retryDelay: <retry_delay_in_ms>
-                  factor: <suspension_factor>
+                  retryErroCode:
+                      - <retry_error_code_1>
+                      - <retry_error_code_2>
+                      - ....................
+                      - <retry_error_code_n>
+                  actionSelect: <action_discard_or_fault>
+                  actionDuration: <action_time_duration>
           sandbox:
               url: <sandbox_endpoint_url>
               config:
+                  factor: <suspension_factor>
+                  suspendMaxDuration: <maximum_suspend_time_duration>
+                  suspendDuration: <suspend_time_duration>
+                  suspendErrorCode: 
+                      - <suspend_error_code_1>
+                      - <suspend_error_code_2>
+                      - ......................
+                      - <suspend_error_code_n>
                   retryTimeOut: <no_of_retries_before_suspension>
                   retryDelay: <retry_delay_in_ms>
-                  factor: <suspension_factor>
+                  retryErroCode:
+                      - <retry_error_code_1>
+                      - <retry_error_code_2>
+                      - ....................
+                      - <retry_error_code_n>
+                  actionSelect: <action_discard_or_fault>
+                  actionDuration: <action_time_duration>
       security:
           enabled: <whether_security_is_enabled>
           type: <endpoint_authentication_type_basic_or_digest>
@@ -59,7 +87,19 @@ The following code snippet contains sample configuration of the parameter file.
               production:
                   url: 'https://test.wso2.com'
                   config:
-                      retryTimeOut: $RETRY
+                    factor: 3
+                    suspendMaxDuration: 25000
+                    suspendDuration: 45000
+                    suspendErrorCode: 
+                        - "101504"
+                        - "101501"
+                    retryTimeOut: $RETRY
+                    retryDelay: 23000
+                    retryErroCode:
+                        - "101503" 
+                        - "101504"
+                    actionSelect: discard
+                    actionDuration: 75000
               sandbox:
                   url: 'https://test.sandbox.wso2.com'
           security:

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -43,7 +43,7 @@ theme:
     tabs: true
   language: 'en'
 #Breaks build if there's a warning
-strict: false
+strict: true
 # Navigation
 nav:
   - Welcome to WSO2 API Manager Documentation: index.md

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -43,7 +43,7 @@ theme:
     tabs: true
   language: 'en'
 #Breaks build if there's a warning
-strict: true
+strict: false
 # Navigation
 nav:
   - Welcome to WSO2 API Manager Documentation: index.md
@@ -275,6 +275,7 @@ nav:
           - Advanced Topics:
               - Creating Custom Users to Perform API Controller Operations: learn/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations.md
               - Configuring Environment Specific Parameters: learn/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+              - Configuring Different Endpoint Types: learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
               - Using Dynamic Data in API Controller Projects: learn/api-controller/advanced-topics/using-dynamic-data-in-api-controller-projects.md
       - Kubernetes Operators:
           - K8s API Operator: learn/kubernetes-operators/k8s-api-operator.md


### PR DESCRIPTION
## Purpose
Documentation on setting up `api_params` with multi endpoint configurations.

## Goals

- Add documentation for configuring the four (4) main types of endpoint types using the api_params.yaml file from the API Controller.
- Update `Configuring Environment Specific Parameters` document with added configuration parameters.

## User stories
Setting up the endpoints with respect to the below nine (9) user scenarios have been documented for the reference of the user.

1. HTTP/REST Endpoint - Without load balancing or failover (the usual way)
2. HTTP/REST Endpoint - With load balancing
3. HTTP/REST Endpoint - With failover
4. HTTP/SOAP Endpoint - Without load balancing or failover
5. HTTP/SOAP Endpoint - With load balancing
6. HTTP/REST Endpoint - With failover
7. Dynamic Endpoint
8. AWS Lambda - Using IAM role-supplied temporary AWS credentials
9. AWS Lambda - Using stored AWS credentials

## Related PRs
- https://github.com/wso2/docs-apim/pull/1391

## Related Issues
 - https://github.com/wso2/api-manager/issues/172