### PR TITLE
Add proxy username and password configs to MI catalog

### DIFF
--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -39,7 +39,7 @@ algorithm = "AES"
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="2" type="checkbox" id="_tab_2">
                 <label class="tab-selector" for="_tab_2"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -234,7 +234,7 @@ enable_swa=false
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="3" type="checkbox" id="_tab_3">
                 <label class="tab-selector" for="_tab_3"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -354,7 +354,7 @@ password = "$secret{password}"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="4" type="checkbox" id="_tab_4">
                 <label class="tab-selector" for="_tab_4"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -474,7 +474,7 @@ node_id = "dev_node_2"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="5" type="checkbox" id="_tab_5">
                 <label class="tab-selector" for="_tab_5"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -612,7 +612,7 @@ key_password = "wso2carbon"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="6" type="checkbox" id="_tab_6">
                 <label class="tab-selector" for="_tab_6"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -750,7 +750,7 @@ key_password = "wso2carbon"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="7" type="checkbox" id="_tab_7">
                 <label class="tab-selector" for="_tab_7"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -806,7 +806,7 @@ org.wso2.SecureVaultPasswordRegEx = "any_valid_regex"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="8" type="checkbox" id="_tab_8">
                 <label class="tab-selector" for="_tab_8"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -924,7 +924,7 @@ alias="symmetric.key.value"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="9" type="checkbox" id="_tab_9">
                 <label class="tab-selector" for="_tab_9"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -1062,7 +1062,7 @@ user.password = "pwd-2"
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="10" type="checkbox" id="_tab_10">
                 <label class="tab-selector" for="_tab_10"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -1756,7 +1756,7 @@ connection_retry_delay = "120000"
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="11" type="checkbox" id="_tab_11">
                 <label class="tab-selector" for="_tab_11"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -2428,7 +2428,7 @@ pool_options.testOnBorrow = true</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="12" type="checkbox" id="_tab_12">
                 <label class="tab-selector" for="_tab_12"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -2595,7 +2595,7 @@ token_config.size= "2048"
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="13" type="checkbox" id="_tab_13">
                 <label class="tab-selector" for="_tab_13"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -2688,7 +2688,7 @@ path = "/apis"
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="14" type="checkbox" id="_tab_14">
                 <label class="tab-selector" for="_tab_14"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -2788,7 +2788,7 @@ allowed_headers = "Authorization"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="15" type="checkbox" id="_tab_15">
                 <label class="tab-selector" for="_tab_15"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3020,7 +3020,7 @@ application_binary = "org.apache.axis2.format.BinaryBuilder"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="16" type="checkbox" id="_tab_16">
                 <label class="tab-selector" for="_tab_16"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3063,7 +3063,7 @@ application_binary = "org.apache.axis2.format.BinaryBuilder"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="17" type="checkbox" id="_tab_17">
                 <label class="tab-selector" for="_tab_17"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3339,7 +3339,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="18" type="checkbox" id="_tab_18">
                 <label class="tab-selector" for="_tab_18"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3384,7 +3384,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="19" type="checkbox" id="_tab_19">
                 <label class="tab-selector" for="_tab_19"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3462,7 +3462,7 @@ class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="20" type="checkbox" id="_tab_20">
                 <label class="tab-selector" for="_tab_20"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3498,7 +3498,7 @@ class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="21" type="checkbox" id="_tab_21">
                 <label class="tab-selector" for="_tab_21"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3576,7 +3576,7 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="22" type="checkbox" id="_tab_22">
                 <label class="tab-selector" for="_tab_22"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3612,7 +3612,7 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="23" type="checkbox" id="_tab_23">
                 <label class="tab-selector" for="_tab_23"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -3694,7 +3694,7 @@ class = "org.wso2.micro.integrator.transport.handlers.requestprocessors.swagger.
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="24" type="checkbox" id="_tab_24">
                 <label class="tab-selector" for="_tab_24"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -4228,6 +4228,48 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The username for authenticating the HTTP proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The password for authenticating the HTTP proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
                                   <span class="param-name-wrap"> <code>sender.secured_proxy_host</code> </span>
                                 </div>
                                 <div class="param-info">
@@ -4266,6 +4308,48 @@ force_json_validation = false</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>The port through which the target proxy (specified by the &#39;sender.secured_proxy_port&#39; parameter) accepts HTTPS traffic.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.secured_proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The username for authenticating the HTTPS proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.secured_proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The password for authenticating the HTTPS proxy server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -4578,7 +4662,7 @@ force_json_validation = false</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="25" type="checkbox" id="_tab_25">
                 <label class="tab-selector" for="_tab_25"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -4978,7 +5062,7 @@ sender.so_timeout = 60000</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.secured_proxy_host</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.proxy_username</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
@@ -4994,17 +5078,17 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>If the outgoing messages should be sent through an HTTPS proxy server (in blocking mode), use this parameter to specify the target proxy.</p>
+                                        <p>The username for authenticating the proxy server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.secured_proxy_port</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.proxy_password</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
                                         <p>
-                                            <span class="param-type string"> integer </span>
+                                            <span class="param-type string"> string </span>
                                             
                                         </p>
                                         <div class="param-default">
@@ -5015,7 +5099,7 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The port through which the target proxy (specified by the &#39;sender.secured_proxy_host&#39; parameter) accepts HTTPS traffic (in blocking mode).</p>
+                                        <p>The username to authenticate to the target proxy.</p>
                                     </div>
                                 </div>
                             </div>
@@ -5034,7 +5118,7 @@ sender.so_timeout = 60000</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="26" type="checkbox" id="_tab_26">
                 <label class="tab-selector" for="_tab_26"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5179,7 +5263,7 @@ bypass_hosts = ["xxx.sample.com"]</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="27" type="checkbox" id="_tab_27">
                 <label class="tab-selector" for="_tab_27"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5345,7 +5429,7 @@ bypass_hosts = ["xxx.sample.com"]</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="28" type="checkbox" id="_tab_28">
                 <label class="tab-selector" for="_tab_28"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5538,7 +5622,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="29" type="checkbox" id="_tab_29">
                 <label class="tab-selector" for="_tab_29"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5731,7 +5815,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="30" type="checkbox" id="_tab_30">
                 <label class="tab-selector" for="_tab_30"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5810,7 +5894,7 @@ parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="31" type="checkbox" id="_tab_31">
                 <label class="tab-selector" for="_tab_31"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -5847,7 +5931,7 @@ parameter.customParameter = "value"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="32" type="checkbox" id="_tab_32">
                 <label class="tab-selector" for="_tab_32"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -6036,7 +6120,7 @@ parameter.from = "demo_user@wso2.com"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="33" type="checkbox" id="_tab_33">
                 <label class="tab-selector" for="_tab_33"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -6073,7 +6157,7 @@ parameter.customParameter = "value"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="34" type="checkbox" id="_tab_34">
                 <label class="tab-selector" for="_tab_34"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -6883,7 +6967,7 @@ parameter.consume_error_progression = "2.0"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="35" type="checkbox" id="_tab_35">
                 <label class="tab-selector" for="_tab_35"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -6957,7 +7041,7 @@ parameter.consume_error_progression = "2.0"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="36" type="checkbox" id="_tab_36">
                 <label class="tab-selector" for="_tab_36"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -7832,7 +7916,7 @@ parameter.vender_class_loader = false</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="37" type="checkbox" id="_tab_37">
                 <label class="tab-selector" for="_tab_37"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -7907,7 +7991,7 @@ parameter.vender_class_loader = false</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="38" type="checkbox" id="_tab_38">
                 <label class="tab-selector" for="_tab_38"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -7985,7 +8069,7 @@ TopicConnectionFactory = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://l
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="39" type="checkbox" id="_tab_39">
                 <label class="tab-selector" for="_tab_39"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -8042,7 +8126,7 @@ StockQuotesQueue = "StockQuotesQueue"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="40" type="checkbox" id="_tab_40">
                 <label class="tab-selector" for="_tab_40"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -8098,7 +8182,7 @@ MyTopic = "example.MyTopic"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="41" type="checkbox" id="_tab_41">
                 <label class="tab-selector" for="_tab_41"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -8147,7 +8231,7 @@ parameter.truststore_password = "$ref{truststore.password}"</code></pre>
                             <code>[[transport.rabbitmq.listener]]</code>
                             <span class="badge-required">Required</span>
                             <p>
-                                This configuration header is required if you are configuring WSO2 Micro Integrator to receive messages from a RabbitMQ client. Read more about <a href='{{base_path}}/install-and-setup/setup/mi-setup/brokers/configure-with-rabbitmq'>connecting the Micro Integrator with RabbitMQ</a>.
+                                This configuration header is required if you are configuring WSO2 Micro Integrator to receive messages from a RabbitMQ client. Read more about <a href='../../setup/brokers/configure-with-rabbitMQ'>connecting the Micro Integator with RabbitMQ</a>.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -8816,7 +8900,7 @@ parameter.truststore_password = "$ref{truststore.password}"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="42" type="checkbox" id="_tab_42">
                 <label class="tab-selector" for="_tab_42"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -8851,7 +8935,7 @@ parameter.connection_pool_size = 10</code></pre>
                             <code>[transport.rabbitmq]</code>
                             
                             <p>
-                                This configuration header is required for enabling the RabbitMQ listener in the Micro Integrator. Read more about <a href='{{base_path}}/install-and-setup/setup/mi-setup/brokers/configure-with-rabbitmq'>connecting the Micro Integrator with RabbitMQ</a>.
+                                This configuration header is required for enabling the RabbitMQ listener in the Micro Integrator. Read more about <a href='../../setup/brokers/configure-with-rabbitMQ'>connecting the Micro Integator with RabbitMQ</a>.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -8881,7 +8965,7 @@ parameter.connection_pool_size = 10</code></pre>
                             <code>[[transport.rabbitmq.sender]]</code>
                             
                             <p>
-                                This configuration header is optional when you have the RabbitMQ sender enabled ([transport.rabbitmq]. Read more about <a href='{{base_path}}/install-and-setup/setup/mi-setup/brokers/configure-with-rabbitmq'>connecting the Micro Integrator with RabbitMQ</a>.
+                                This configuration header is optional when you have the RabbitMQ sender enabled ([transport.rabbitmq]. Read more about <a href='../../setup/brokers/configure-with-rabbitMQ'>connecting the Micro Integator with RabbitMQ</a>.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -9321,7 +9405,7 @@ parameter.connection_pool_size = 10</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="43" type="checkbox" id="_tab_43">
                 <label class="tab-selector" for="_tab_43"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -9402,7 +9486,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="44" type="checkbox" id="_tab_44">
                 <label class="tab-selector" for="_tab_44"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -9416,7 +9500,7 @@ listener.server_port = 1883
 listener.client_id = "client-id-1234"
 listener.topic_name = "esb.test"
 
-# not required parameter list
+# not reqired parameter list
 listener.subscription_qos = 0
 listener.session_clean = false
 listener.enable_ssl = false
@@ -9648,7 +9732,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="45" type="checkbox" id="_tab_45">
                 <label class="tab-selector" for="_tab_45"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -9863,7 +9947,7 @@ sender.bapi.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="46" type="checkbox" id="_tab_46">
                 <label class="tab-selector" for="_tab_46"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -9967,7 +10051,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="47" type="checkbox" id="_tab_47">
                 <label class="tab-selector" for="_tab_47"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10137,7 +10221,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="48" type="checkbox" id="_tab_48">
                 <label class="tab-selector" for="_tab_48"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10175,13 +10259,13 @@ sender.parameter.customParameter = ""</code></pre>
 </div>
 
 
-## WebSocket Transport
+## Websocket Transport
 
 <div class="mb-config-catalog">
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="49" type="checkbox" id="_tab_49">
                 <label class="tab-selector" for="_tab_49"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10298,13 +10382,13 @@ sender.parameter.customParameter = ""</code></pre>
 </div>
 
 
-## Secure WebSocket Transport
+## Secure Websocket Transport
 
 <div class="mb-config-catalog">
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="50" type="checkbox" id="_tab_50">
                 <label class="tab-selector" for="_tab_50"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10472,7 +10556,7 @@ sender.truststore_password = "$ref{truststore.password}"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="51" type="checkbox" id="_tab_51">
                 <label class="tab-selector" for="_tab_51"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10554,7 +10638,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="52" type="checkbox" id="_tab_52">
                 <label class="tab-selector" for="_tab_52"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10594,7 +10678,7 @@ sender.parameter.customParameter = ""</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="53" type="checkbox" id="_tab_53">
                 <label class="tab-selector" for="_tab_53"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10672,7 +10756,7 @@ protocol = "hl7"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="54" type="checkbox" id="_tab_54">
                 <label class="tab-selector" for="_tab_54"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -10750,7 +10834,7 @@ protocol = "hl7"</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="55" type="checkbox" id="_tab_55">
                 <label class="tab-selector" for="_tab_55"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -11086,7 +11170,7 @@ inbound.max_threads = 100</code></pre>
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="56" type="checkbox" id="_tab_56">
                 <label class="tab-selector" for="_tab_56"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
@@ -11159,13 +11243,13 @@ class = <handler_class>
 </div>
 
 
-## External Vault Configurations
+## External Valut Configurations
 
 <div class="mb-config-catalog">
     <section>
         <div class="mb-config-options">
             <div class="superfences-tabs">
-            
+
             <input name="57" type="checkbox" id="_tab_57">
                 <label class="tab-selector" for="_tab_57"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">

--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -5099,7 +5099,7 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The username to authenticate to the target proxy.</p>
+                                        <p>The password for authenticating the proxy server.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator-mi/data/configs.json
+++ b/en/tools/config-catalog-generator-mi/data/configs.json
@@ -1510,6 +1510,22 @@
                             "description": "The port through which the target proxy (specified by the 'sender.proxy_port' parameter) accepts HTTP traffic."
                         },
                         {
+                            "name": "sender.proxy_username",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "The username for authenticating the HTTP proxy server."
+                        },
+                        {
+                            "name": "sender.proxy_password",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "The password for authenticating the HTTP proxy server."
+                        },
+                        {
                             "name": "sender.secured_proxy_host",
                             "type": "string",
                             "required": false,
@@ -1524,6 +1540,22 @@
                             "default": "-",
                             "possible": "-",
                             "description": "The port through which the target proxy (specified by the 'sender.secured_proxy_port' parameter) accepts HTTPS traffic."
+                        },
+                        {
+                            "name": "sender.secured_proxy_username",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "The username for authenticating the HTTPS proxy server."
+                        },
+                        {
+                            "name": "sender.secured_proxy_password",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "The password for authenticating the HTTPS proxy server."
                         },
                         {
                             "name": "sender.non_proxy_hosts",
@@ -1780,20 +1812,20 @@
                             "description": "The port through which the target proxy (specified by the 'sender.proxy_host' parameter) accepts HTTP traffic (in blocking mode)."
                         },
                         {
-                            "name": "sender.secured_proxy_host",
+                            "name": "sender.proxy_username",
                             "type": "string",
                             "required": false,
                             "default": "-",
                             "possible": "-",
-                            "description": "If the outgoing messages should be sent through an HTTPS proxy server (in blocking mode), use this parameter to specify the target proxy."
+                            "description": "The username for authenticating the proxy server."
                         },
                         {
-                            "name": "sender.secured_proxy_port",
-                            "type": "integer",
+                            "name": "sender.proxy_password",
+                            "type": "string",
                             "required": false,
                             "default": "-",
                             "possible": "-",
-                            "description": "The port through which the target proxy (specified by the 'sender.secured_proxy_host' parameter) accepts HTTPS traffic (in blocking mode)."
+                            "description": "The username to authenticate to the target proxy."
                         }
                     ]
                 }

--- a/en/tools/config-catalog-generator-mi/data/configs.json
+++ b/en/tools/config-catalog-generator-mi/data/configs.json
@@ -1825,7 +1825,7 @@
                             "required": false,
                             "default": "-",
                             "possible": "-",
-                            "description": "The username to authenticate to the target proxy."
+                            "description": "The password for authenticating the proxy server."
                         }
                     ]
                 }

--- a/en/tools/config-catalog-generator-mi/dist/config-catalog.md
+++ b/en/tools/config-catalog-generator-mi/dist/config-catalog.md
@@ -5099,7 +5099,7 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The username to authenticate to the target proxy.</p>
+                                        <p>The password for authenticating the proxy server.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator-mi/dist/config-catalog.md
+++ b/en/tools/config-catalog-generator-mi/dist/config-catalog.md
@@ -935,6 +935,7 @@ enable = true
 [[internal_apis.users]]
 user.name = "user-1"
 user.password = "pwd-1"
+user.is_admin = true
 
 [[internal_apis.users]]
 user.name = "user-2"
@@ -1022,6 +1023,27 @@ user.password = "pwd-2"
                                     </div>
                                     <div class="param-description">
                                         <p>Enter a password for the user specified by &#39;user.name&#39;. Note that this will overwrite the default &#39;admin&#39; password that is stored in the user store.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>user.is_admin</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>&quot;true&quot; or &quot;false&quot;</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Specifies whether or not the user has admin privileges.</p>
                                     </div>
                                 </div>
                             </div>
@@ -4206,6 +4228,48 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The username for authenticating the HTTP proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The password for authenticating the HTTP proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
                                   <span class="param-name-wrap"> <code>sender.secured_proxy_host</code> </span>
                                 </div>
                                 <div class="param-info">
@@ -4244,6 +4308,48 @@ force_json_validation = false</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>The port through which the target proxy (specified by the &#39;sender.secured_proxy_port&#39; parameter) accepts HTTPS traffic.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.secured_proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The username for authenticating the HTTPS proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.secured_proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The password for authenticating the HTTPS proxy server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -4956,7 +5062,7 @@ sender.so_timeout = 60000</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.secured_proxy_host</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.proxy_username</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
@@ -4972,17 +5078,17 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>If the outgoing messages should be sent through an HTTPS proxy server (in blocking mode), use this parameter to specify the target proxy.</p>
+                                        <p>The username for authenticating the proxy server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.secured_proxy_port</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.proxy_password</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
                                         <p>
-                                            <span class="param-type string"> integer </span>
+                                            <span class="param-type string"> string </span>
                                             
                                         </p>
                                         <div class="param-default">
@@ -4993,7 +5099,7 @@ sender.so_timeout = 60000</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The port through which the target proxy (specified by the &#39;sender.secured_proxy_host&#39; parameter) accepts HTTPS traffic (in blocking mode).</p>
+                                        <p>The username to authenticate to the target proxy.</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Purpose
The following configurations are added to the MI config catalog.

Fixes https://github.com/wso2/docs-apim/issues/6032

For non-blocking service calls through a proxy server.
```
[transport.http]
sender.proxy_username = "admin"
sender.proxy_password = "admin"
```
For secured non-blocking service calls through a proxy server.
```
[transport.http]
sender.secured_proxy_username = "admin"
sender.secured_proxy_password = "admin"
```
For blocking service calls through a proxy server.
```
[transport.blocking.http]
sender.proxy_host = "localhost"
sender.proxy_port = 8080
sender.proxy_username = "admin"
sender.proxy_password = "admin"
```