### PR TITLE
[4.1.0] Add heap dump docs for CC Router

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/troubleshooting/debug-memory.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/troubleshooting/debug-memory.md
@@ -40,11 +40,11 @@ Enforcer is implemented in Java and it is configured with required parameters to
 
 ## Taking a heap dump of Router
 
-Router uses the Envoy Proxy as the core component that does the traffic routing. The default Router which is used in you production environment is not supporting heap profiling and we have build a separate Router Docker image which enables heap profiling. Follow the steps below to take a heap profile of the Router.
+Router uses the Envoy Proxy as the core component that does the traffic routing. The default Router which is used in you production environment is not supporting heap profiling and we have built a separate Router Docker image which enables heap profiling. Follow the steps below to take a heap profile of the Router.
 
 ### Prerequisites
 
-1.  Install [pprof](https://github.com/google/pprof#readme) and [Graphviz](http://www.graphviz.org/).
+1.  Install [pprof](https://github.com/google/pprof#readme) and [Graphviz](http://www.graphviz.org/) in your local machine. **pprof** is used to analyze the heap profile and **Graphviz** enables to analyze them with graphs.
 
 2.  Build ***Router Debug Image***, if you are taking heap profile **on top of an updated Router image**.
 
@@ -113,7 +113,7 @@ Router uses the Envoy Proxy as the core component that does the traffic routing.
         --set wso2.deployment.gatewayRuntime.router.imageTag=<TAG>
     ```
 
-2.  Expose the admin portal port (port 9000) to the host.
+2.  Expose the admin portal port (port 9000) to your local machine.
 
     ```text tab="Docker Compose"
     Already done in the default Docker Compose setup.
@@ -133,7 +133,7 @@ Router uses the Envoy Proxy as the core component that does the traffic routing.
     curl -X POST -s "http://localhost:9000/heapprofiler?enable=n"
     ```
 
-5.  Copy profile data and envoy binary to the directory `./profile-data` in host.
+5.  Execute following commands to copy profile data and envoy binary to the directory `./profile-data` in you local machine.
 
     ```bash
     export POD_NAME=<K8S_CHOREO_CONNECT_GATEWAY_RUNTIME_POD_NAME>

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/troubleshooting/debug-memory.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/troubleshooting/debug-memory.md
@@ -37,3 +37,113 @@ Follow the steps below to take a heap dump of the Adapter.
 ## Taking a heap dump of Enforcer
 
 Enforcer is implemented in Java and it is configured with required parameters to dump the heap information when out of memory errors happen. The dump can be collected from `/home/wso2/logs/heap-dump.hprof`
+
+## Taking a heap dump of Router
+
+Router uses the Envoy Proxy as the core component that does the traffic routing. The default Router which is used in you production environment is not supporting heap profiling and we have build a separate Router Docker image which enables heap profiling. Follow the steps below to take a heap profile of the Router.
+
+### Prerequisites
+
+1.  Install [pprof](https://github.com/google/pprof#readme) and [Graphviz](http://www.graphviz.org/).
+
+2.  Build ***Router Debug Image***, if you are taking heap profile **on top of an updated Router image**.
+
+    !!! note
+        For the **GA version** of the Router docker image you can use `choreo-connect-router:{{choreo_connect.version}}-debug-{{choreo_connect.envoy_version}}` as the ***Router Debug Image***.
+
+    1.  Create a Dockerfile as follows. Here we create a custom docker image by replacing the envoy binary in default docker image with heap profile enabled envoy binary.
+
+        <!-- Following docker image "wso2am/choreo-connect-router" contains envoy version in its tag, it should be updated per router envoy version update -->
+
+        ```Dockerfile tab="Format"
+        FROM <ROUTER_DOCKER_IMAGE_WITH_WSO2_UPDATES>
+        COPY --from=wso2am/choreo-connect-router:{{choreo_connect.version}}-debug-{{choreo_connect.envoy_version}} /usr/local/bin/envoy /usr/local/bin/envoy
+        ```
+
+        ```Dockerfile tab="Sample Dockerfile"
+        FROM wso2/choreo-connect-router:{{choreo_connect.version}}.1 # for update level 1
+        COPY --from=wso2am/choreo-connect-router:{{choreo_connect.version}}-debug-{{choreo_connect.envoy_version}} /usr/local/bin/envoy /usr/local/bin/envoy
+        ```
+
+    2. Build an docker image and push it to a Docker registry that your K8s cluster can pull it.
+
+        ```bash tab="Format"
+        docker build -t <DOCKER_REGISTRY>/<DEBUG_IMAGE_NAME>:<TAG> .
+        ```
+
+        ```bash tab="Sample"
+        docker build -t sample.com/choreo-connect-router:{{choreo_connect.version}}.1-debug .
+        ```
+
+### Steps
+
+1.  Change the Router Docker image with the built ***Router Debug Image*** and mount a directory to `/var/log/envoy` to collect head profile data.
+
+    ```text tab="Docker Compose"
+    Update 'docker-compose.yaml' file as follows and start docker-compose setup.
+
+    router:
+      image: <DOCKER_REGISTRY>/<DEBUG_IMAGE_NAME>:<TAG> # change image name
+      volumes:
+        - ./data:/var/log/envoy # append this volume
+    ```
+
+    ```text tab="K8s YAML"
+    Update 'choreo-connect/choreo-connect-deployment.yaml' file as follows and apply it to the K8s cluster.
+
+    spec:
+      containers:
+        - name: choreo-connect-router
+          image: <DOCKER_REGISTRY>/<DEBUG_IMAGE_NAME>:<TAG>
+          volumeMounts:
+            - mountPath: /var/log/envoy
+              name: router-heap-profile-data
+      volumes:
+        - name: router-heap-profile-data
+          emptyDir: {}
+
+
+    ```
+
+    ```bash tab="K8s Helm"
+    helm upgrade --install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> \
+        --set wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir=true \
+        --set wso2.deployment.gatewayRuntime.router.dockerRegistry=<DOCKER_REGISTRY> \
+        --set wso2.deployment.gatewayRuntime.router.imageName=<DEBUG_IMAGE_NAME> \
+        --set wso2.deployment.gatewayRuntime.router.imageTag=<TAG>
+    ```
+
+2.  Expose the admin portal port (port 9000) to the host.
+
+    ```text tab="Docker Compose"
+    Already done in the default Docker Compose setup.
+    ```
+
+    ```bash tab="Kubernetes (for both YAML and Helm)"
+    kubectl port-forward -n <NAMESPACE> svc/<K8S_ROUTER_SERVICE_NAME> 9000:9000
+    ```
+
+3.  Start heap profiling. Execute the following command.
+    ```bash
+    curl -X POST -s "http://localhost:9000/heapprofiler?enable=y"
+    ```
+
+4.  End heap profiling. Execute the following command.
+    ```bash
+    curl -X POST -s "http://localhost:9000/heapprofiler?enable=n"
+    ```
+
+5.  Copy profile data and envoy binary to the directory `./profile-data` in host.
+
+    ```bash
+    export POD_NAME=<K8S_CHOREO_CONNECT_GATEWAY_RUNTIME_POD_NAME>
+    export NAMESPACE=<NAMESPACE>
+
+    kubectl cp -n $NAMESPACE $POD_NAME:/var/log/envoy profile-data -c choreo-connect-router
+    kubectl cp -n $NAMESPACE $POD_NAME:/usr/local/bin/envoy profile-data/lib/envoy -c choreo-connect-router
+    ```
+
+6.  Analyze the heap profile in the browser by running the following command.
+    ```bash
+    pprof -http=localhost:8000 profile-data/lib/envoy profile-data/envoy.prof.*
+    ```

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -2217,6 +2217,12 @@ extra:
           link: https://twitter.com/wso2
         - type: linkedin
           link: https://www.linkedin.com/company/wso2
+    choreo_connect:
+        version: 1.1.0
+        envoy_version: v1.20.2
+        helm_chart:
+            version: 1.1.0-3
+            git_tag: 1.1.0.3
     site_version: 4.1.0
     #base_path: http://localhost:8000
     base_path: https://apim.docs.wso2.com/en/4.1.0

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -2219,7 +2219,7 @@ extra:
           link: https://www.linkedin.com/company/wso2
     choreo_connect:
         version: 1.1.0
-        envoy_version: v1.20.2
+        envoy_version: v1.20.2 # for GA release
         helm_chart:
             version: 1.1.0-3
             git_tag: 1.1.0.3


### PR DESCRIPTION
## Purpose
$subject
Related to https://github.com/wso2/product-microgateway/issues/2997

Add following fields to mkdocs.yaml file, since there are many places Choreo Connect version is used in docs (for docker images)

```yaml
    choreo_connect:
        version: 1.1.0
        envoy_version: v1.20.2
        helm_chart:
            version: 1.1.0-3
            git_tag: 1.1.0.3
```

![image](https://user-images.githubusercontent.com/23183042/177991812-c934c8ec-4a84-45f1-b548-dc19af30ac36.png)
