### PR TITLE
[4.1.0] Add docs for publishing custom analytics data

### DIFF
--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -1,0 +1,178 @@
+---
+title: Publishing Custom Analytics Events Data - API Manager Documentation 4.0.0
+---
+
+# Publishing Custom Analytics Events Data
+
+## Introduction
+
+Instead of publishing already available analytics events data, it is also possible to publish custom analytics data with the existing event schema. This guide will explain the steps required to do it.
+
+!!! Important
+    - Only the latest APIM-4.0.0 updates include this feature support.
+    - You can check if this feature is available in your current pack by viewing the trace logs without adding the jar containing the implemented class as [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#build-the-project).
+    - If the feature is available in the pack you will be able to see a property object named `property` which includes `apiContext` and `userName` as default values.
+
+    ```json
+    "properties":{
+        "apiContext":"/api/1.0.0",
+        "userName":"admin@carbon.super"
+    },
+    ```
+
+This section will cover the steps required to create a sample and configure the created sample with WSO2 API-M.
+
+## Creating the Sample
+
+You have to create a new `Java/Maven project`. 
+
+There is an already [created sample](https://github.com/wso2/samples-apim/tree/4.0.0/analytics-custom-data-provider) and if you wish to use that sample instead of developing the sample from scratch, then you can ignore the steps of creating the sample and start from [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#build-the-project).
+
+This section will cover how to configure the `pom.xml`, class implementations and building the created sample.
+
+### Configuring pom.xml
+
+Add wso2-nexus repository to `pom.xml`,
+
+    <repository>
+        <id>wso2-nexus</id>
+        <name>WSO2 internal Repository</name>
+        <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+        <releases>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy>
+        </releases>
+    </repository>
+
+Add dependencies,
+
+    <dependency>
+        <groupId>org.wso2.carbon.apimgt</groupId>
+        <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+        <version>${carbon.apimgt.gateway.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.wso2.carbon.apimgt</groupId>
+        <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
+        <version>${carbon.apimgt.common.analytics.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.synapse</groupId>
+        <artifactId>synapse-extensions</artifactId>
+        <version>${synapse.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.synapse</groupId>
+        <artifactId>synapse-core</artifactId>
+        <version>${synapse.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.axis2</groupId>
+                <artifactId>axis2-codegen</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.wso2.orbit.com.github.fge</groupId>
+                <artifactId>json-schema-validator-all</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+
+!!! Info
+
+	- The versions for ${carbon.apimgt.gateway.version}, ${carbon.apimgt.common.analytics.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.0.0 package.
+
+### Implementing Required Class
+
+#### AnalyticsCustomDataProvider Implementation Class
+
+Custom analytics data can be added to the existing event schema with the use of a class of type `AnalyticsCustomDataProvider`. Therefore, it is required to implement a class from the `AnalyticsCustomDataProvider` interface. By overriding the `getCustomProperties` method it is possible to push custom analytics data.
+
+In order to achieve this behavior, create a class implementing the `AnalyticsCustomDataProvider` Interface of `org.wso2.carbon.apimgt.common.analytics.collectors`.
+
+Implementation of this class should look something similar to [this](https://github.com/wso2/samples-apim/blob/4.0.0/analytics-custom-data-provider/src/main/java/org/wso2/carbon/apimgt/gateway/sample/publisher/CustomDataProvider.java).
+
+#### Build the Project
+
+Build the project using,
+
+    mvn clean install
+
+## Configuring the Sample
+
+This section will cover the steps required to configure WSO2 API-M Gateway for the sample created above. The steps covered are adding the .jar file, configuring the deployment.toml file, and enabling the logs.
+
+!!! Warning
+    Note that WSO2 API Manager 3.0.0, 3.1.0, 3.2.0, and 4.0.0 are affected by the **Log4j2 zero-day** vulnerability, which has been reported to WSO2 on 10th December 2021. You can mitigate this vulnerability in your product by following our [instructions and guidelines](https://docs.wso2.com/pages/viewpage.action?pageId=180948677).
+
+1. Adding the .jar file.
+
+    Place the created .jar file inside the `wso2am-4.0.0/repository/components/lib` directory.
+
+2. Configuring the deployment.toml file.
+
+    Edit `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.0.0/repository/conf` with the following configuration.
+
+        [apim.analytics]
+        enable = true
+        properties."publisher.custom.data.provider.class" = "<FullyQualifiedClassNameOfAnalyticsCustomDataProviderImplClass>"
+        type = "elk"
+
+    !!! Important
+        Type should be given as `elk` as this property value is filtered out in cloud implementation.
+
+3. Enabling Logs
+
+    To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit `log4j2.properties` file located inside `wso2am-4.0.0/repository/conf` directory. 
+
+    a) Add a reporter to the loggers list:
+
+        loggers = org-wso2-analytics-publisher, ...(list of other available loggers)
+
+    b) Add the following configurations after the loggers:
+
+        logger.org-wso2-analytics-publisher.name = org.wso2.am.analytics.publisher
+        logger.org-wso2-analytics-publisher.level = TRACE
+        logger.org-wso2-analytics-publisher.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+4. Now you can trigger an event and check the `<WSO2AM-4.0.0-HOME>/repository/logs/wso2carbon-trace-messages.log` to find the event object passed out from API Manager.
+
+```log
+TRACE {org.wso2.am.analytics.publisher.client.EventHubClient} - [{ Cloud-Analytics-Queue-Worker-pool-2-thread-1 }] - 
+ Adding event: 
+ {
+    "apiName":"API1",
+    "proxyResponseCode":200,
+    "destination":"https://run.mocky.io/v3/d14fad1d-d57b-41bc-8be3-146b6aaddfaf",
+    "apiCreatorTenantDomain":"carbon.super",
+    "platform":"Linux",
+    "apiMethod":"GET",
+    "apiVersion":"2.0.0",
+    "gatewayType":"SYNAPSE",
+    "apiCreator":"admin",
+    "responseCacheHit":false,
+    "backendLatency":1866,
+    "correlationId":"00a94b54-5579-4f5d-95c1-4bd909fd4c20",
+    "requestMediationLatency":578,
+    "keyType":"SANDBOX",
+    "apiId":"fd5a22ee-144f-4fc1-9f22-ce5ff0382023",
+    "applicationName":"AppUser",
+    "targetResponseCode":200,
+    "requestTimestamp":"2022-07-18T06:49:19Z",
+    "applicationOwner":"admin",
+    "userAgent":"Chrome",
+    "eventType":"response",
+    "apiResourceTemplate":"/test",
+    "properties":{
+         "tokenIssuer":"https://localhost:9443/oauth2/token",
+         "apiContext":"/api1/2.0.0",
+         "userName":"admin@carbon.super"
+    },
+    "responseLatency":2446,
+    "regionId":"default",
+    "responseMediationLatency":2,
+    "userIp":"127.0.0.1",
+    "applicationId":"5d6d0135-810a-4b4e-8f9a-45187e943fff",
+    "apiType":"HTTP"
+ }
+```

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -102,9 +102,6 @@ Build the project using,
 
 This section will cover the steps required to configure WSO2 API-M Gateway for the sample created above. The steps covered are adding the .jar file, configuring the deployment.toml file, and enabling the logs.
 
-!!! Warning
-    Note that WSO2 API Manager 3.0.0, 3.1.0, 3.2.0, and 4.1.0 are affected by the **Log4j2 zero-day** vulnerability, which has been reported to WSO2 on 10th December 2021. You can mitigate this vulnerability in your product by following our [instructions and guidelines](https://docs.wso2.com/pages/viewpage.action?pageId=180948677).
-
 1. Adding the .jar file.
 
     Place the created .jar file inside the `wso2am-4.1.0/repository/components/lib` directory.

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -50,12 +50,12 @@ Add dependencies,
     <dependency>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
-        <version>${carbon.apimgt.gateway.version}</version>
+        <version>${carbon.apimgt.version}</version>
     </dependency>
     <dependency>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
-        <version>${carbon.apimgt.common.analytics.version}</version>
+        <version>${carbon.apimgt.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.synapse</groupId>
@@ -80,7 +80,22 @@ Add dependencies,
 
 !!! Info
 
-	- The versions for ${carbon.apimgt.gateway.version}, ${carbon.apimgt.common.analytics.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.1.0 package.
+	- The versions for ${carbon.apimgt.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.1.0 package.
+    - Since this feature support available in the latest update levels, you have to follow the below steps to add the required artifacts to the local m2 repository and point it as a repository in pom file.
+        1. Add org.wso2.carbon.apimgt.gateway and org.wso2.carbon.apimgt.common.analytics jars to the local m2 manually.
+        ```code
+        mvn install:install-file -Dfile=<PATH_TO_FILE>/org.wso2.carbon.apimgt.gateway_<COMPENENT_VERSION>.jar -DgroupId=org.wso2.carbon.apimgt -DartifactId=org.wso2.carbon.apimgt.gateway -Dversion=<COMPENENT_VERSION> -Dpackaging=jar
+        mvn install:install-file -Dfile=<PATH_TO_FILE>/org.wso2.carbon.apimgt.common.analytics_<COMPENENT_VERSION>.jar -DgroupId=org.wso2.carbon.apimgt -DartifactId=org.wso2.carbon.apimgt.common.analytics -Dversion=<COMPENENT_VERSION> -Dpackaging=jar
+        ```
+        2. Point local m2 repository in project pom
+        ```code
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://home/user/.m2/repository</url>
+        </repository>
+        ```
+        Follow the URL pattern when providing the repo url
+    
 
 ### Implementing Required Class
 

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -34,49 +34,53 @@ This section will cover how to configure the `pom.xml`, class implementations an
 
 Add wso2-nexus repository to `pom.xml`,
 
-    <repository>
-        <id>wso2-nexus</id>
-        <name>WSO2 internal Repository</name>
-        <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-        <releases>
-            <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
-            <checksumPolicy>ignore</checksumPolicy>
-        </releases>
-    </repository>
+```code
+<repository>
+    <id>wso2-nexus</id>
+    <name>WSO2 internal Repository</name>
+    <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+    <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+    </releases>
+</repository>
+```
 
 Add dependencies,
 
-    <dependency>
-        <groupId>org.wso2.carbon.apimgt</groupId>
-        <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
-        <version>${carbon.apimgt.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.wso2.carbon.apimgt</groupId>
-        <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
-        <version>${carbon.apimgt.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.synapse</groupId>
-        <artifactId>synapse-extensions</artifactId>
-        <version>${synapse.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.synapse</groupId>
-        <artifactId>synapse-core</artifactId>
-        <version>${synapse.version}</version>
-        <exclusions>
-            <exclusion>
-                <groupId>org.apache.axis2</groupId>
-                <artifactId>axis2-codegen</artifactId>
-            </exclusion>
-            <exclusion>
-                <groupId>org.wso2.orbit.com.github.fge</groupId>
-                <artifactId>json-schema-validator-all</artifactId>
-            </exclusion>
-        </exclusions>
-    </dependency>
+```code
+<dependency>
+    <groupId>org.wso2.carbon.apimgt</groupId>
+    <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+    <version>${carbon.apimgt.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.wso2.carbon.apimgt</groupId>
+    <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
+    <version>${carbon.apimgt.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.apache.synapse</groupId>
+       <artifactId>synapse-extensions</artifactId>
+       <version>${synapse.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.apache.synapse</groupId>
+    <artifactId>synapse-core</artifactId>
+    <version>${synapse.version}</version>
+    <exclusions>
+        <exclusion>
+            <groupId>org.apache.axis2</groupId>
+            <artifactId>axis2-codegen</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.wso2.orbit.com.github.fge</groupId>
+            <artifactId>json-schema-validator-all</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
 
 !!! Info
 
@@ -91,11 +95,11 @@ Add dependencies,
         3. Point local m2 repository in project pom
         ```code
         <repository>
-            <id>local-maven-repo</id>
-            <url>file://home/user/.m2/repository</url>
+            <id> local-maven-repo </id>
+            <url> file://home/user/.m2/repository </url>
         </repository>
         ```
-        Follow the URL pattern when providing the repo url
+        Follow the same URL pattern when providing the repo url
     
 
 ### Implementing Required Class
@@ -112,13 +116,15 @@ Implementation of this class should look something similar to [this](https://git
 
 Build the project using,
 
-    mvn clean install
+```code
+mvn clean install
+```
 
 ## Configuring the Sample
 
 This section will cover the steps required to configure WSO2 API-M Gateway for the sample created above. The steps covered are adding the .jar file, configuring the deployment.toml file, and enabling the logs.
 
-1. Adding the .jar file.
+1. Adding the jar file created in the target directory after building the project.
 
     Place the created .jar file inside the `wso2am-4.1.0/repository/components/lib` directory.
 
@@ -126,10 +132,14 @@ This section will cover the steps required to configure WSO2 API-M Gateway for t
 
     Edit `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.1.0/repository/conf` with the following configuration.
 
-        [apim.analytics]
-        enable = true
-        properties."publisher.custom.data.provider.class" = "<FullyQualifiedClassNameOfAnalyticsCustomDataProviderImplClass>"
-        type = "elk"
+    ```code
+    [apim.analytics]
+    enable = true
+    properties."publisher.custom.data.provider.class" = "<FullyQualifiedClassNameOfAnalyticsCustomDataProviderImplClass>"
+    type = "elk"
+    ```
+
+    This configuration will be used when engaging the custom data provider class.
 
     !!! Important
         Type should be given as `elk` as this property value is filtered out in cloud implementation.
@@ -138,15 +148,16 @@ This section will cover the steps required to configure WSO2 API-M Gateway for t
 
     To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit `log4j2.properties` file located inside `wso2am-4.1.0/repository/conf` directory. 
 
-    a) Add a reporter to the loggers list:
-
-        loggers = org-wso2-analytics-publisher, ...(list of other available loggers)
-
-    b) Add the following configurations after the loggers:
-
-        logger.org-wso2-analytics-publisher.name = org.wso2.am.analytics.publisher
-        logger.org-wso2-analytics-publisher.level = TRACE
-        logger.org-wso2-analytics-publisher.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+    1. Add new publisher to the loggers list:
+    ```code
+    loggers = org-wso2-analytics-publisher, ...(list of other available loggers)
+    ```
+    2. Add the following configurations after the loggers: 
+    ```code
+    logger.org-wso2-analytics-publisher.name = org.wso2.am.analytics.publisher
+    logger.org-wso2-analytics-publisher.level = TRACE
+    logger.org-wso2-analytics-publisher.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+    ```
 
 4. Now you can trigger an event and check the `<WSO2AM-4.1.0-HOME>/repository/logs/wso2carbon-trace-messages.log` to find the event object passed out from API Manager.
 

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -32,7 +32,7 @@ This section will cover how to configure the `pom.xml`, class implementations an
 
 ### Configuring pom.xml
 
-Add wso2-nexus repository to `pom.xml`,
+Add wso2-nexus repository to `pom.xml`.
 
 ```code
 <repository>
@@ -124,13 +124,13 @@ mvn clean install
 
 This section will cover the steps required to configure WSO2 API-M Gateway for the sample created above. The steps covered are adding the .jar file, configuring the deployment.toml file, and enabling the logs.
 
-1. Adding the jar file created in the target directory after building the project.
+1. Add the jar file created in the target directory after building the project.
 
     Place the created .jar file inside the `wso2am-4.1.0/repository/components/lib` directory.
 
-2. Configuring the deployment.toml file.
+2. Configure the deployment.toml file.
 
-    Edit `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.1.0/repository/conf` with the following configuration.
+    Edit the `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.1.0/repository/conf` with the following configuration.
 
     ```code
     [apim.analytics]
@@ -144,9 +144,9 @@ This section will cover the steps required to configure WSO2 API-M Gateway for t
     !!! Important
         Type should be given as `elk` as this property value is filtered out in cloud implementation.
 
-3. Enabling Logs
+3. Enable Logs
 
-    To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit `log4j2.properties` file located inside `wso2am-4.1.0/repository/conf` directory. 
+    To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit the `log4j2.properties` file located inside `wso2am-4.1.0/repository/conf` directory. 
 
     1. Add new publisher to the loggers list:
     ```code

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -1,5 +1,5 @@
 ---
-title: Publishing Custom Analytics Events Data - API Manager Documentation 4.0.0
+title: Publishing Custom Analytics Events Data - API Manager Documentation 4.1.0
 ---
 
 # Publishing Custom Analytics Events Data
@@ -9,8 +9,8 @@ title: Publishing Custom Analytics Events Data - API Manager Documentation 4.0.0
 Instead of publishing already available analytics events data, it is also possible to publish custom analytics data with the existing event schema. This guide will explain the steps required to do it.
 
 !!! Important
-    - Only the latest APIM-4.0.0 updates include this feature support.
-    - You can check if this feature is available in your current pack by viewing the trace logs without adding the jar containing the implemented class as [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#build-the-project).
+    - Note that, support for publishing custom analytics events data has been introduced to WSO2 API Manager 4.1.0 via an U2 update (Update level 21).
+    - You can check if this feature is available in your current pack by viewing the trace logs without adding the jar containing the implemented class as [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#configuring-the-sample).
     - If the feature is available in the pack you will be able to see a property object named `property` which includes `apiContext` and `userName` as default values.
 
     ```json
@@ -26,7 +26,7 @@ This section will cover the steps required to create a sample and configure the 
 
 You have to create a new `Java/Maven project`. 
 
-There is an already [created sample](https://github.com/wso2/samples-apim/tree/4.0.0/analytics-custom-data-provider) and if you wish to use that sample instead of developing the sample from scratch, then you can ignore the steps of creating the sample and start from [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#build-the-project).
+There is an already [created sample](https://github.com/wso2/samples-apim/tree/4.1.0/analytics-custom-data-provider) and if you wish to use that sample instead of developing the sample from scratch, then you can ignore the steps of creating the sample and start from [here]({{base_path}}/api-analytics/samples/publishing-custom-analytics-data/#build-the-project).
 
 This section will cover how to configure the `pom.xml`, class implementations and building the created sample.
 
@@ -80,7 +80,7 @@ Add dependencies,
 
 !!! Info
 
-	- The versions for ${carbon.apimgt.gateway.version}, ${carbon.apimgt.common.analytics.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.0.0 package.
+	- The versions for ${carbon.apimgt.gateway.version}, ${carbon.apimgt.common.analytics.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.1.0 package.
 
 ### Implementing Required Class
 
@@ -90,7 +90,7 @@ Custom analytics data can be added to the existing event schema with the use of 
 
 In order to achieve this behavior, create a class implementing the `AnalyticsCustomDataProvider` Interface of `org.wso2.carbon.apimgt.common.analytics.collectors`.
 
-Implementation of this class should look something similar to [this](https://github.com/wso2/samples-apim/blob/4.0.0/analytics-custom-data-provider/src/main/java/org/wso2/carbon/apimgt/gateway/sample/publisher/CustomDataProvider.java).
+Implementation of this class should look something similar to [this](https://github.com/wso2/samples-apim/blob/4.1.0/analytics-custom-data-provider/src/main/java/org/wso2/carbon/apimgt/gateway/sample/publisher/CustomDataProvider.java).
 
 #### Build the Project
 
@@ -103,15 +103,15 @@ Build the project using,
 This section will cover the steps required to configure WSO2 API-M Gateway for the sample created above. The steps covered are adding the .jar file, configuring the deployment.toml file, and enabling the logs.
 
 !!! Warning
-    Note that WSO2 API Manager 3.0.0, 3.1.0, 3.2.0, and 4.0.0 are affected by the **Log4j2 zero-day** vulnerability, which has been reported to WSO2 on 10th December 2021. You can mitigate this vulnerability in your product by following our [instructions and guidelines](https://docs.wso2.com/pages/viewpage.action?pageId=180948677).
+    Note that WSO2 API Manager 3.0.0, 3.1.0, 3.2.0, and 4.1.0 are affected by the **Log4j2 zero-day** vulnerability, which has been reported to WSO2 on 10th December 2021. You can mitigate this vulnerability in your product by following our [instructions and guidelines](https://docs.wso2.com/pages/viewpage.action?pageId=180948677).
 
 1. Adding the .jar file.
 
-    Place the created .jar file inside the `wso2am-4.0.0/repository/components/lib` directory.
+    Place the created .jar file inside the `wso2am-4.1.0/repository/components/lib` directory.
 
 2. Configuring the deployment.toml file.
 
-    Edit `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.0.0/repository/conf` with the following configuration.
+    Edit `apim.analytics` configurations in the `deployment.toml` file located inside `wso2am-4.1.0/repository/conf` with the following configuration.
 
         [apim.analytics]
         enable = true
@@ -123,7 +123,7 @@ This section will cover the steps required to configure WSO2 API-M Gateway for t
 
 3. Enabling Logs
 
-    To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit `log4j2.properties` file located inside `wso2am-4.0.0/repository/conf` directory. 
+    To [enable trace logs]({{base_path}}/administer/logging-and-monitoring/logging/configuring-logging/#enabling-logs-for-a-component) for the component: `org.wso2.am.analytics.publisher`, edit `log4j2.properties` file located inside `wso2am-4.1.0/repository/conf` directory. 
 
     a) Add a reporter to the loggers list:
 
@@ -135,7 +135,7 @@ This section will cover the steps required to configure WSO2 API-M Gateway for t
         logger.org-wso2-analytics-publisher.level = TRACE
         logger.org-wso2-analytics-publisher.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
 
-4. Now you can trigger an event and check the `<WSO2AM-4.0.0-HOME>/repository/logs/wso2carbon-trace-messages.log` to find the event object passed out from API Manager.
+4. Now you can trigger an event and check the `<WSO2AM-4.1.0-HOME>/repository/logs/wso2carbon-trace-messages.log` to find the event object passed out from API Manager.
 
 ```log
 TRACE {org.wso2.am.analytics.publisher.client.EventHubClient} - [{ Cloud-Analytics-Queue-Worker-pool-2-thread-1 }] - 

--- a/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
+++ b/en/docs/api-analytics/samples/publishing-custom-analytics-data.md
@@ -82,12 +82,13 @@ Add dependencies,
 
 	- The versions for ${carbon.apimgt.version}, and ${synapse.version} can be found in the jar versions available in the current API Manager 4.1.0 package.
     - Since this feature support available in the latest update levels, you have to follow the below steps to add the required artifacts to the local m2 repository and point it as a repository in pom file.
-        1. Add org.wso2.carbon.apimgt.gateway and org.wso2.carbon.apimgt.common.analytics jars to the local m2 manually.
+        1. Find the `org.wso2.carbon.apimgt.gateway` and `org.wso2.carbon.apimgt.common.analytics` jars inside the `<APIM_HOME>/repository/components/plugins` directory in latest U2 updated APIM pack.
+        2. Add the above jars to the local m2 manually.
         ```code
         mvn install:install-file -Dfile=<PATH_TO_FILE>/org.wso2.carbon.apimgt.gateway_<COMPENENT_VERSION>.jar -DgroupId=org.wso2.carbon.apimgt -DartifactId=org.wso2.carbon.apimgt.gateway -Dversion=<COMPENENT_VERSION> -Dpackaging=jar
         mvn install:install-file -Dfile=<PATH_TO_FILE>/org.wso2.carbon.apimgt.common.analytics_<COMPENENT_VERSION>.jar -DgroupId=org.wso2.carbon.apimgt -DartifactId=org.wso2.carbon.apimgt.common.analytics -Dversion=<COMPENENT_VERSION> -Dpackaging=jar
         ```
-        2. Point local m2 repository in project pom
+        3. Point local m2 repository in project pom
         ```code
         <repository>
             <id>local-maven-repo</id>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -827,6 +827,7 @@ nav:
                 #- Analytics API Guide: api-analytics/analytics-api-guide.md
                 #- Troubleshooting Analytics: add this infor in the main troubleshooting page GW> Analytics
             - Publish Analytics Events to External Systems: api-analytics/samples/publishing-analytics-events-to-external-systems.md
+            - Publish Custom Analytics Events Data: api-analytics/samples/publishing-custom-analytics-data.md
             - Architecture: api-analytics/api-analytics-architecture.md
         - MI Analytics:
             - Set up: mi-analytics/setting-up-mi-analytics.md


### PR DESCRIPTION
### Purpose
This PR will introduce a new tab under `api-analytics/samples` to guide programmers to publish custom analytics data.

### UI
![localhost_8000_api-analytics_samples_publishing-custom-analytics-data_ (3)](https://user-images.githubusercontent.com/28702407/181725144-4abcfc7f-e6dc-4f3f-8cc9-78bd2cc636b5.png)


