### PR TITLE
[4.1.0] Use placeholder for Choreo Connect version

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-apis-as-immutable-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/deploy-api/deploy-apis-as-immutable-gateway.md
@@ -5,6 +5,7 @@ For that, the apictl projects needs to be mounted to the `docker-compose/resourc
 (default location) of the adapter. 
 At the startup of the adapter, it picks the projects and deploys them. After startup, APIs should be added using apictl.
 
+For deploying APIs as immutable gateway using Helm chart, please refer [Deploy APIs as Immutable Gateway in Production Deployment]({{base_path}}/deploy-and-publish/deploy-on-gateway/choreo-connect/production-deployment-guideline/#deploy-apis-as-immutable-gateway).
 
 ## Step 1 - Download apictl and set the path variable 
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/extensions/custom-filters.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/extensions/custom-filters.md
@@ -21,7 +21,7 @@ Interface, the classloading happens in the enforcer. See the following sections 
    <dependency>
        <groupId>org.wso2.choreo.connect</groupId>
        <artifactId>org.wso2.choreo.connect.enforcer.commons</artifactId>
-       <version>1.1.0</version>
+       <version>{{choreo_connect.version}}</version>
    </dependency>
    ```
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-as-a-standalone-gateway-on-kubernetes-helm-artifacts.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-as-a-standalone-gateway-on-kubernetes-helm-artifacts.md
@@ -45,21 +45,21 @@ Execute the following command to install the Helm Cart by selecting the helm ver
 -   Using **Helm v2**
 
     ```bash tab='Format'
-    helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE>
+    helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
     ```
 
     ```bash tab='Sample'
-    helm install --name my-release wso2/choreo-connect --version 1.1.0-1 --namespace cc
+    helm install --name my-release wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace cc
     ```
 
 -   Using **Helm v3**
 
     ``` tab='Format'
-    helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace
+    helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
     ```
 
     ``` tab='Sample'
-    helm install my-release wso2/choreo-connect --version 1.1.0-1 --namespace cc --create-namespace
+    helm install my-release wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace cc --create-namespace
     ```
 
 The above steps will deploy Choreo Connect using WSO2 product Docker images available at DockerHub.
@@ -71,7 +71,7 @@ Please see the following example.
 -   Using **Helm v2**
 
     ```bash tab='Format'
-    helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> \
+    helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> \
         --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> \
         --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
     ```
@@ -79,7 +79,7 @@ Please see the following example.
 -   Using **Helm v3**
 
     ```bash tab='Format'
-    helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace \
+    helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace \
         --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> \
         --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
     ```
@@ -98,7 +98,7 @@ Check out the Helm Resources for the Choreo Connect Git repository.
 
     ```bash
     git clone https://github.com/wso2/kubernetes-microgateway.git
-    git checkout tags/v1.1.0.1
+    git checkout tags/{{choreo_connect.helm_chart.git_tag}}
     ```
 
 This creates a local copy of [wso2/kubernetes-microgateway](https://github.com/wso2/kubernetes-microgateway), which includes all the Helm Resources for Choreo Connect.
@@ -112,7 +112,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
 1.  Open the `values.yaml` file in the `<KUBERNETES_HOME>/helm/choreo-connect` directory of your local copy.
 
     !!! Info
-        Before you do any changes, go through the [default configurations](https://github.com/wso2/kubernetes-microgateway/tree/v1.1.0.1/helm/choreo-connect) in this file.
+        Before you do any changes, go through the [default configurations](https://github.com/wso2/kubernetes-microgateway/tree/{{choreo_connect.helm_chart.git_tag}}/helm/choreo-connect) in this file.
 
 2.  Use the following guidelines to update the deployment configurations:
 
@@ -129,7 +129,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
 
         Alternatively, you can skip this step and pass your subscription details at the time of deploying (see the next step for details).
 
-    -   You can update [other configurations](https://github.com/wso2/kubernetes-microgateway/tree/v1.1.0.1/helm/choreo-connect/README.md) as required.
+    -   You can update [other configurations](https://github.com/wso2/kubernetes-microgateway/tree/{{choreo_connect.helm_chart.git_tag}}/helm/choreo-connect/README.md) as required.
 
 3.  Save the `values.yaml` file.
 
@@ -146,13 +146,13 @@ Once you have set up your Helm resources locally, follow the instructions given 
     -   Using **Helm v2**
 
         ```bash
-        helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE>
+        helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
         ```
 
     -   Using **Helm v3**
 
         ```bash
-        helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace
+        helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
         ```
 
 #### Update configurations during deployment

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-as-a-standalone-gateway-on-kubernetes-helm-artifacts.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-as-a-standalone-gateway-on-kubernetes-helm-artifacts.md
@@ -137,7 +137,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
 
 Once you have set up your Helm resources locally, follow the instructions given below to set up the deployment.
 
-1.  Open a terminal and navigate to the `<KUBERNETES_HOME>/helm/choreo-connect` directory.
+1.  Open a terminal and navigate to the `<KUBERNETES_HOME>` directory.
 2.  Execute the command that is relevant to your Helm version.
 
     !!! Tip
@@ -146,13 +146,13 @@ Once you have set up your Helm resources locally, follow the instructions given 
     -   Using **Helm v2**
 
         ```bash
-        helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
+        helm install --name <RELEASE_NAME> ./helm/choreo-connect --namespace <NAMESPACE>
         ```
 
     -   Using **Helm v3**
 
         ```bash
-        helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
+        helm install <RELEASE_NAME> ./helm/choreo-connect --namespace <NAMESPACE> --create-namespace
         ```
 
 #### Update configurations during deployment

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-on-kubernetes-with-apim-as-control-plane-helm-artifacts.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-on-kubernetes-with-apim-as-control-plane-helm-artifacts.md
@@ -61,7 +61,7 @@ Execute the command that is relevant to your Helm version.
         --set wso2.deployment.am.ingress.gateway.hostname=gw.wso2.com \
         --set wso2.deployment.am.ingress.gateway.enabled=false \
         --set wso2.deployment.am.imagePullPolicy=IfNotPresent \
-        --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.1/resources/controlplane-deployment.toml
+        --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/{{choreo_connect.helm_chart.git_tag}}/resources/controlplane-deployment.toml
     ```
 
 -   Using **Helm v3**
@@ -71,7 +71,7 @@ Execute the command that is relevant to your Helm version.
         --set wso2.deployment.am.ingress.gateway.hostname=gw.wso2.com \
         --set wso2.deployment.am.ingress.gateway.enabled=false \
         --set wso2.deployment.am.imagePullPolicy=IfNotPresent \
-        --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.1/resources/controlplane-deployment.toml
+        --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/{{choreo_connect.helm_chart.git_tag}}/resources/controlplane-deployment.toml
     ```
 
 ## Option 1: Install Chart from WSO2 Helm Chart Repository
@@ -91,14 +91,14 @@ Execute the following command to install the Helm Cart by selecting the helm ver
 -   Using **Helm v2**
 
     ```bash tab='Format'
-    helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> \
+    helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> \
         --set wso2.deployment.mode=APIM_AS_CP \
         --set wso2.apim.controlPlane.hostName=am.wso2.com \
         --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
     ```
 
     ```bash tab='Sample'
-    helm install --name my-release wso2/choreo-connect --version 1.1.0-1 --namespace cc \
+    helm install --name my-release wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace cc \
         --set wso2.deployment.mode=APIM_AS_CP \
         --set wso2.apim.controlPlane.hostName=am.wso2.com \
         --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
@@ -107,14 +107,14 @@ Execute the following command to install the Helm Cart by selecting the helm ver
 -   Using **Helm v3**
 
     ```bash tab='Format'
-    helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace \
+    helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace \
         --set wso2.deployment.mode=APIM_AS_CP \
         --set wso2.apim.controlPlane.hostName=am.wso2.com \
         --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
     ```
 
     ```bash tab='Sample'
-    helm install my-release wso2/choreo-connect --version 1.1.0-1 --namespace cc --create-namespace \
+    helm install my-release wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace cc --create-namespace \
         --set wso2.deployment.mode=APIM_AS_CP \
         --set wso2.apim.controlPlane.hostName=am.wso2.com \
         --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
@@ -129,7 +129,7 @@ Please see the following example.
 -   Using **Helm v2**
 
     ```bash tab='Format'
-    helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> \
+    helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> \
         --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> \
         --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
     ```
@@ -137,7 +137,7 @@ Please see the following example.
 -   Using **Helm v3**
 
     ```bash tab='Format'
-    helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace \
+    helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace \
         --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> \
         --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
     ```
@@ -156,7 +156,7 @@ Check out the Helm Resources for the Choreo Connect Git repository.
 
     ```bash
     git clone https://github.com/wso2/kubernetes-microgateway.git
-    git checkout tags/v1.1.0.1
+    git checkout tags/{{choreo_connect.helm_chart.git_tag}}
     ```
 
 This creates a local copy of [wso2/kubernetes-microgateway](https://github.com/wso2/kubernetes-microgateway), which includes all the Helm Resources for Choreo Connect.
@@ -170,7 +170,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
 1.  Open the `values.yaml` file in the `<KUBERNETES_HOME>/helm/choreo-connect` directory of your local copy.
 
     !!! Info
-        Before you do any changes, go through the [default configurations](https://github.com/wso2/kubernetes-microgateway/tree/v1.1.0.1/helm/choreo-connect) in this file.
+        Before you do any changes, go through the [default configurations](https://github.com/wso2/kubernetes-microgateway/tree/{{choreo_connect.helm_chart.git_tag}}/helm/choreo-connect) in this file.
 
 2.  Use the following guidelines to update the deployment configurations:
 
@@ -205,7 +205,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
                     serviceName: "<controlplane kubernetes service name>"
         ```
 
-    -   You can update [other configurations](https://github.com/wso2/kubernetes-microgateway/tree/v1.1.0.1/helm/choreo-connect/README.md) as required.
+    -   You can update [other configurations](https://github.com/wso2/kubernetes-microgateway/tree/{{choreo_connect.helm_chart.git_tag}}/helm/choreo-connect/README.md) as required.
 
 3.  Save the `values.yaml` file.
 
@@ -222,13 +222,13 @@ Once you have set up your Helm resources locally, follow the instructions given 
     -   Using **Helm v2**
 
         ```bash
-        helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE>
+        helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
         ```
 
     -   Using **Helm v3**
 
         ```bash
-        helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-1 --namespace <NAMESPACE> --create-namespace
+        helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
         ```
 
 #### Update configurations during deployment

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-on-kubernetes-with-apim-as-control-plane-helm-artifacts.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-on-kubernetes-with-apim-as-control-plane-helm-artifacts.md
@@ -213,7 +213,7 @@ Follow the steps given below to configure how your Choreo Connect deployment sho
 
 Once you have set up your Helm resources locally, follow the instructions given below to set up the deployment.
 
-1.  Open a terminal and navigate to the `<KUBERNETES_HOME>/helm/choreo-connect` directory.
+1.  Open a terminal and navigate to the `<KUBERNETES_HOME>` directory.
 2.  Execute the command that is relevant to your Helm version.
 
     !!! Tip
@@ -222,13 +222,13 @@ Once you have set up your Helm resources locally, follow the instructions given 
     -   Using **Helm v2**
 
         ```bash
-        helm install --name <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
+        helm install --name <RELEASE_NAME> ./helm/choreo-connect {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE>
         ```
 
     -   Using **Helm v3**
 
         ```bash
-        helm install <RELEASE_NAME> wso2/choreo-connect --version {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
+        helm install <RELEASE_NAME> ./helm/choreo-connect {{choreo_connect.helm_chart.version}} --namespace <NAMESPACE> --create-namespace
         ```
 
 #### Update configurations during deployment

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/git-integration.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/git-integration.md
@@ -310,7 +310,7 @@ To authenticate the repository with SSH key, the SSH private key file path shoul
     ```
 
     ```dockerfile tab='Example'
-      FROM wso2/choreo-connect-adapter:1.1.0
+      FROM wso2/choreo-connect-adapter:{{choreo_connect.version}}
 
       USER root
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/production-deployment-guideline.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/production-deployment-guideline.md
@@ -296,12 +296,12 @@ For example lets say you want to replace the CA certificates of Choreo Connect R
 Create a Dockerfile as follows.
 
 ```dockerfile tab='Format'
-FROM wso2/choreo-connect-router:1.1.0
+FROM wso2/choreo-connect-router:{{choreo_connect.version}}
 <YOUR_DOCKER_COMMANDS>
 ```
 
 ```dockerfile tab='Sample'
-FROM wso2/choreo-connect-router:1.1.0
+FROM wso2/choreo-connect-router:{{choreo_connect.version}}
 COPY my-ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ```
 
@@ -312,7 +312,7 @@ docker build -t <IMAGE_NAME> -f <DOCKER_FILE_PATH> <CONTEXT>
 ```
 
 ```bash tab='Sample'
-docker build -t myimages/choreo-connect-router:1.1.0 -f Dockerfile .
+docker build -t myimages/choreo-connect-router:{{choreo_connect.version}} -f Dockerfile .
 ```
 
 ## Mode 1: API Manager as Control Plane Configurations
@@ -380,12 +380,12 @@ cp -r petstore/ apictl-projects-dir/petstore
 Create a Dockerfile as follows.
 
 ```dockerfile tab='Format'
-FROM wso2/choreo-connect-adapter:1.1.0
+FROM wso2/choreo-connect-adapter:{{choreo_connect.version}}
 COPY <DIR_WITH_APICTL_PROJECTS> /home/wso2/artifacts/apis
 ```
 
 ```dockerfile tab='Sample'
-FROM wso2/choreo-connect-adapter:1.1.0
+FROM wso2/choreo-connect-adapter:{{choreo_connect.version}}
 COPY apictl-projects-dir /home/wso2/artifacts/apis
 ```
 
@@ -396,7 +396,7 @@ docker build -t <IMAGE_NAME> -f <DOCKER_FILE_PATH> <CONTEXT>
 ```
 
 ```bash tab='Sample'
-docker build -t myimages/choreo-connect-adapter-petstore:1.1.0 -f Dockerfile .
+docker build -t myimages/choreo-connect-adapter-petstore:{{choreo_connect.version}} -f Dockerfile .
 ```
 
 !!! Important
@@ -454,7 +454,7 @@ wso2:
       # Image name for adapter
       imageName: "choreo-connect-adapter-petstore"
       # Image tag for adapter
-      imageTag: "1.1.0"
+      imageTag: "{{choreo_connect.version}}"
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: IfNotPresent
 ```

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/production-deployment-guideline.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/production-deployment-guideline.md
@@ -399,27 +399,14 @@ docker build -t <IMAGE_NAME> -f <DOCKER_FILE_PATH> <CONTEXT>
 docker build -t myimages/choreo-connect-adapter-petstore:{{choreo_connect.version}} -f Dockerfile .
 ```
 
-!!! Important
-    Make sure push all the images to the same docker registry. You can specify the docker registry in `wso2.deployment.dockerRegistry` of the helm release.
-    The docker registry is applied for the all docker images of the Choreo Connect components, i.e. Adapter, Enforcer and Router.
-    
-    Hence for the above sample, push Enforcer and Router images to the registry `myimages`.
-
-    ```bash tab='Enforcer'
-    docker tag wso2/choreo-connect-enforcer myimages/choreo-connect-enforcer
-    docker push myimages/choreo-connect-enforcer
-    ```
-
-    ```bash tab='Router'
-    docker tag wso2/choreo-connect-router myimages/choreo-connect-router
-    docker push myimages/choreo-connect-router
-    ```
-
 #### Step 3: Update Adapter Docker Image Name
 
 Update the following values in the helm release with the Adapter docker image, image pull secrets. You can separate each gateway environments by specifying the value `wso2.deployment.labelName`.
 
 {!includes/deploy/cc-prod-guide-helm-values-yaml-tip.md!}
+
+!!! important
+    Make sure to set `wso2.deployment.adapter.apiArtifactsMountEmptyDir=false`. This field is available from Helm chart version `1.1.0.5`.
 
 ```yaml tab='Format'
 wso2:
@@ -432,12 +419,16 @@ wso2:
     imagePullSecrets: <LIST_OF_PULL_SECRETS>
 
     adapter:
+      # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
+      dockerRegistry: <DOCKER_REGISTRY_FOR_ADAPTER>
       # Image name for adapter
       imageName: "<ADAPTER_IMAGE_NAME>"
       # Image tag for adapter
       imageTag: "<IMAGE_TAG>"
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: <IMAGE_PULL_POLICY>
+      # Mount an empty directory on API artifacts directory
+      apiArtifactsMountEmptyDir: false
 ```
 
 ```yaml tab='Sample'
@@ -446,17 +437,21 @@ wso2:
     # Label (environment) name of the deployment
     labelName: "default"
     # If a custom image must be used, define the docker registry. Default to DockerHub. If subscription specified it will be "docker.wso2.com"
-    dockerRegistry: "myimages"
+    dockerRegistry: ""
     # Image pull secrets to pull images from docker registry. If subscriptions are specified a secret with subscriptions details are created and imagePullSecrets will be default to it.
     imagePullSecrets: []
 
     adapter:
+      # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
+      dockerRegistry: "myimages"
       # Image name for adapter
       imageName: "choreo-connect-adapter-petstore"
       # Image tag for adapter
       imageTag: "{{choreo_connect.version}}"
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: IfNotPresent
+      # Mount an empty directory on API artifacts directory
+      apiArtifactsMountEmptyDir: false
 ```
 
 #### Step 4: Disable the Adapter Rest API

--- a/en/docs/design/api-security/opa-validation/custom-opa-policy-for-choreo-connect.md
+++ b/en/docs/design/api-security/opa-validation/custom-opa-policy-for-choreo-connect.md
@@ -9,7 +9,7 @@ Following contains the steps that you required to follow to create a custom OPA 
         <dependency>
             <groupId>org.wso2.choreo.connect</groupId>
             <artifactId>org.wso2.choreo.connect.enforcer.commons</artifactId>
-            <version>1.1.0</version>
+            <version>{{choreo_connect.version}}</version>
         </dependency>
         ```
 

--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -234,7 +234,7 @@ These features are unsupported and removed from WSO2 API Manager 4.1.0 onwards.
 ## Compatible WSO2 product versions
 
 - WSO2 API Manager 4.1.0 is compatible with WSO2 Identity Server 5.11.0.
-- WSO2 API Manager 4.1.0 is compatible with Choreo Connect 1.1.0.
+- WSO2 API Manager 4.1.0 is compatible with Choreo Connect {{choreo_connect.version}}.
 
 ## Fixed issues
 

--- a/en/docs/includes/deploy/cc-prod-guide-helm-values-yaml-tip.md
+++ b/en/docs/includes/deploy/cc-prod-guide-helm-values-yaml-tip.md
@@ -1,2 +1,2 @@
 !!! Tip
-    You can find the complete [values.yaml file with default values](https://github.com/wso2/kubernetes-microgateway/blob/v1.0.0.1/helm/choreo-connect/values.yaml) and [configuration description](https://github.com/wso2/kubernetes-microgateway/blob/v1.0.0.1/helm/choreo-connect/README.md#configuration) in the kubernetes-microgateway GitHub repository.
+    You can find the complete [values.yaml file with default values](https://github.com/wso2/kubernetes-microgateway/blob/1.1.x/helm/choreo-connect/values.yaml) and [configuration description](https://github.com/wso2/kubernetes-microgateway/blob/1.1.x/helm/choreo-connect/README.md#configuration) in the kubernetes-microgateway GitHub repository.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -2227,12 +2227,12 @@ extra:
           link: https://twitter.com/wso2
         - type: linkedin
           link: https://www.linkedin.com/company/wso2
-    choreo_connect:
+    choreo_connect: # not applied in "includes" section, update "includes" separately
         version: 1.1.0
         envoy_version: v1.20.2 # for GA release
         helm_chart:
-            version: 1.1.0-3
-            git_tag: 1.1.0.3
+            version: 1.1.0-5
+            git_tag: v1.1.0.5
     site_version: 4.1.0
     #base_path: http://localhost:8000
     base_path: https://apim.docs.wso2.com/en/4.1.0


### PR DESCRIPTION
## Purpose
Use a placeholder for the Choreo Connect version, since it is used in many places including docker images and Helm charts versions.

![image](https://user-images.githubusercontent.com/23183042/181573620-9d33fa92-8eea-4587-a747-ad53757a93e1.png)
