### PR TITLE
Add the doc changes for enabling correlation logs during runtime

### DIFF
--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -87,10 +87,6 @@ For more instructions, see [WSO2 Devops API v0]({{base_path}}/reference/product-
      "properties":[]}]
     }
     ```
-
-
-
-
    
 2. Get correlation log configurations.
     

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -832,7 +832,7 @@ For example, let's consider that you need to log all the methods for the gateway
 
 Denying of threads is needed because some threads keep on printing unnecessary JDBC logs continuously. Therefore, by denying these unwanted threads from printing logs, it helps to reduce the cluttering of the logs.
 
-In order to enable denying of threads, 
+In order to enable denying of threads:
 
 - Add the following configuration as a system property to the API Manager startup script.
 

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -42,7 +42,7 @@ Enabling observability at the server startup is simple in API Manager. All you n
 Devops REST API can be used to enable / disable correlation logs during the runtime and retrieve the correlation logs configurations. 
 For more instructions, see [WSO2 Devops API v0]({{base_path}}/reference/product-apis/devops-apis/devops-v0/devops-v0/#/paths/~1config~1correlation~1/get).
 
-1. Enable / disable correlation log configurations 
+1. Enable / disable correlation log configurations.
    
     Correlation logs can be configured at a component level granularity using the devops API. 
 

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -13,7 +13,7 @@ Furthermore, when observability is enabled in WSO2 API-M, a random Correlation I
 
 ## Enabling Correlation Logs
 
-Correlation logs are disabled by default and it can be enabled at the server startup using the system parameter OR during the runtime using the Devops REST API. 
+Correlation logs are disabled by default and it can be enabled at the server startup using the system parameter OR during the runtime using the DevOps REST API. 
 
 ### Enable Correlation Logs at the Server Startup
 

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -92,7 +92,7 @@ For more instructions, see [WSO2 Devops API v0]({{base_path}}/reference/product-
 
 
    
-2. Get correlation log configurations 
+2. Get correlation log configurations.
     
     ```bash tab="Sample Request"
     curl -X GET 'https://localhost:9443/api/am/devops/v0/config/correlation/' -H 'Authorization: Basic YWRtaW46YWRtaW4=' -k

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -834,7 +834,7 @@ Denying of threads is needed because some threads keep on printing unnecessary J
 
 In order to enable denying of threads, 
 
-- Add the following configuration as a system property to the APIM startup script.
+- Add the following configuration as a system property to the API Manager startup script.
 
     ``` tab="Format"
     -Dorg.wso2.CorrelationLogInterceptor.BlacklistedThreads=<threadName1>,<threadName2> 

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -103,7 +103,7 @@ For more instructions, see [WSO2 Devops API v0]({{base_path}}/reference/product-
     ```
 
 !!! note
-    When correlation logs are enabled using the system property, the devops API will not be able to disable the correlation logs. 
+    When correlation logs are enabled using the system property, the DevOps API will not be able to disable the correlation logs. 
 
 ### Method Call Logs
 

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -851,7 +851,7 @@ In order to enable denying of threads,
 
     OR
 
-- Use the devops API to update the denied threads for the jdbc component
+- Use the DevOps API to update the denied threads for the JDBC component.
 
     ```bash tab="Sample Request"
     curl -X PUT 'https://localhost:9443/api/am/devops/v0/config/correlation' \

--- a/en/docs/observe/api-manager/monitoring-correlation-logs.md
+++ b/en/docs/observe/api-manager/monitoring-correlation-logs.md
@@ -901,7 +901,7 @@ In order to enable denying of threads,
     ```
 
     !!! note
-        If the correlation logs are enabled using the system property, devops API will not be able to change the denied threads of the jdbc component. 
+        If the correlation logs are enabled using the system property, DevOps API will not be able to change the denied threads of the JDBC component. 
 
 
 If the above configuration is not added, by default, the `MessageDeliveryTaskThreadPool` thread will be denied as it is found to print a considerable amount of messages for API-M instances. However, if the above configuration is added, the default value will be overridden. 

--- a/en/docs/reference/product-apis/devops-apis/devops-v0/devops-v0.yaml
+++ b/en/docs/reference/product-apis/devops-apis/devops-v0/devops-v0.yaml
@@ -14,7 +14,7 @@
 ################################################################################
 openapi: 3.0.1
 info:
-  version: v0
+  version: v0.1
   title: WSO2 API Manager - DevOps
   description: |
     This document specifies a **RESTful API** for WSO2 **API Manager** - DevOps.
@@ -120,6 +120,71 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  "/config/correlation/":
+    get:
+      summary: |
+        GET status of correlation log components
+
+      responses:
+        "200":
+          description: Status of Correlation Log Components
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CorrelationComponentsList"
+        "404":
+          description: |
+            Not Found.
+            Request component not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error while retrieving info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    put:
+      summary: |
+        Enable / Disable correlation logs
+      description: >
+        This operation enables you to enable / disable correlation logs 
+        of the product. This operation can be done at the product level 
+        or at each component level by providing the componentName query
+        parameter.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CorrelationComponentsList"
+        description: |
+          The enable / disable correlation log status is provided as a payload.
+      responses:
+        "200":
+          description: Successfully Set the status of the correlation logs.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CorrelationComponentsList"
+        "404":
+          description: |
+            Not Found.
+            Request components not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error while configuring the correlation log status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+                
 servers:
   - url: https://apis.wso2.com/api/am/devops/v0
 components:
@@ -149,6 +214,40 @@ components:
         apiId:
           type: string
           example: 12d6e73c-778d-45ac-b57d-117c6c5092a4
+
+    CorrelationComponentsList:
+      title: correlation-components
+      properties:
+        components:
+          type: array
+          items:
+            $ref: "#/components/schemas/CorrelationComponent"
+    CorrelationComponent:
+      title: Correlation Component INFO object
+      properties:
+        name:
+          type: string
+          example: http
+        enabled:
+          type: string
+          example: true
+        properties:
+          type: array
+          items:
+            $ref: "#/components/schemas/CorrelationComponentProperty"
+
+    CorrelationComponentProperty:
+      title: Properties for correlation components
+      properties:
+        name:
+          type: string
+          example: "deniedThreads"
+        value:
+          type: array
+          items:
+            type: string
+            example: "MessageDeliveryTaskThreadPool"
+
     Error:
       title: Error object returned with 4XX HTTP Status
       required:


### PR DESCRIPTION
Document changes needed in the enabling correlation logs section
is added and the changes done in the devops API description is
added to the docs as well.

> Fix: wso2/api-manager#275
> Fix: wso2/api-manager#533