### PR TITLE
Fixed the Jinja-like statement build issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ en/site
 /en/tools/config-catalog-generator-cc/node_modules/
 
 # prefers Python virtual environment for development
-.venv/
+venv/
+env/

--- a/en/docs/observe/micro-integrator/classic-observability-traces/monitoring-with-opentelemetry-mi.md
+++ b/en/docs/observe/micro-integrator/classic-observability-traces/monitoring-with-opentelemetry-mi.md
@@ -353,11 +353,13 @@ public class SysoutTelemetryManager implements OpenTelemetryManager {
 
 If you need more `opentelemetry.properties` than the developed ones, you can edit the `for` loop of `synapse.properties.j2` file in the `<MI_HOME>/repository/resources/conf/templates/conf` folder in the following way.
 
+{% raw %}
 ```
 {%for property in opentelemetry.properties %}
 opentelemetry.properties.{{property.header}} = {{property.key}}
 {% endfor %}
 ```
+{% endraw %}
 
 The `deployment.toml` file entry will be as follows:
 

--- a/en/requirements.txt
+++ b/en/requirements.txt
@@ -1,3 +1,4 @@
+jinja2<3.1.0
 mkdocs==1.0.4
 Pygments==2.7.4
 pymdown-extensions==6.2


### PR DESCRIPTION
## Purpose
Fixed #6146 

## Approach
Add the **"Jinja-like"** statement inside  {% raw %} ....  {% endraw %} tag. Example is given below.
```
{% raw %}
{%for property in opentelemetry.properties %}
opentelemetry.properties.{{property.header}} = {{property.key}}
{% endfor %}
{% endraw %}
```