### PR TITLE
Add note about REST methods in Generate Data Service docs

### DIFF
--- a/en/docs/integrate/develop/creating-artifacts/data-services/creating-data-services.md
+++ b/en/docs/integrate/develop/creating-artifacts/data-services/creating-data-services.md
@@ -357,6 +357,10 @@ datasource and automatically creates the SELECT, INSERT, UPDATE, and DELETE oper
 
 5. 	From the list of tables, select the tables and the REST resource methods that you want in the generated data service.
 
+	!!!	Note
+		1.	The **POST** REST method is enabled only when the database is not in read-only mode.
+		2.	The **PUT** and **DELETE** REST methods are enabled only when a primary key is defined on the table.
+
 	<a href="{{base_path}}/assets/img/integrate/tutorials/data_services/select_tables.png"><img src="{{base_path}}/assets/img/integrate/tutorials/data_services/select_tables.png" width="700"></a>
 
 6. 	You can select a service generation mode from the following two options:


### PR DESCRIPTION
## Purpose
The REST methods in Generate Data Service wizard are enabled depending on the database properties. This PR will add a note about those properties.

Fixes: https://github.com/wso2/api-manager/issues/293

## Approach
![Screenshot from 2022-09-08 10-50-02](https://user-images.githubusercontent.com/18748929/189041350-2e72cd02-3793-433a-8450-b15e4526e45a.png)
