### PR TITLE
Add note to copy secondary user stores for tenants after migration

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
@@ -1289,6 +1289,10 @@ You have to run the following migration client to update the API Manager artifac
 
     -   Remove the `migration-resources` directory, which is in the `<API-M_4.1.0_HOME>` directory.
 
+    !!! note
+
+        Make sure you have copied the tenant's userstores if you have configured them in WSO2 API Manager 2.6.0.
+
 ### Step 5: Re-Index the API Manager artifacts
 
 1. To re-index the API artifacts in the registry, Add the following configuration into the `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
@@ -633,6 +633,10 @@ You have to run the following migration client to update the API Manager artifac
 
     -   Remove the `migration-resources` directory, which is in the `<API-M_4.1.0_HOME>` directory.
 
+    !!! note
+
+        Make sure you have copied the tenant's userstores if you have configured them in WSO2 API Manager 3.0.0.
+
 ### Step 5: Re-Index the API Manager artifacts
 
 1. To re-index the API artifacts in the registry, Add the following configuration into the `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
@@ -632,6 +632,10 @@ You have to run the following migration client to update the API Manager artifac
 
     -   Remove the `migration-resources` directory, which is in the `<API-M_4.1.0_HOME>` directory.
 
+    !!! note
+
+        Make sure you have copied the tenant's userstores if you have configured them in WSO2 API Manager 3.1.0.
+
 ### Step 5: Re-Index the API Manager artifacts
 
 1. To re-index the API artifacts in the registry, Add the following configuration into the `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
@@ -394,6 +394,10 @@ You have to run the following migration client to update the API Manager artifac
 
     -   Remove the `migration-resources` directory, which is in the `<API-M_4.1.0_HOME>` directory.
 
+    !!! note
+
+        Make sure you have copied the tenant's userstores if you have configured them in WSO2 API Manager 3.2.0.
+
 ### Step 5: Re-Index the API Manager artifacts
 
 1. To re-index the API artifacts in the registry, Add the following configuration into the `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.


### PR DESCRIPTION
## Purpose
Secondary user stores for tenants are populated after migration.
https://github.com/wso2/docs-apim/issues/6239

## Goals
remind users to copy secondary user stores.

## Approach
Note added.