### PR TITLE
Fix the TM separated distributed setup configurations

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -158,7 +158,7 @@ Follow the instructions given below to configure the Gateway node so that it can
       ```
 
     !!! Info
-        Throtteling configurations are used by the gateway to connect with the traffic manager. Gateway will publish gateway invocation related events to the TM using the `apim.throttling.url_group`. Traffic managers will receive these events and throttle decisions will be published to gateway. To receive these throttle decisions, gateway has to create a JMS connection using `throttle_decision_endpoints` and listen.
+        Rate limiting configurations are used by the Gateway to connect with the Traffic Manager. The Gateway will publish Gateway invocation-related events to the TM using the `apim.throttling.url_group`. Traffic Managers will receive these events and rate limiting decisions will be published to the Gateway. To receive these rate limiting decisions, the Gateway has to create a JMS connection using `throttle_decision_endpoints` and listen.
 
 3. Add the following configurations to the deployment.toml file to configure the Gateway environment. Change the `gateway_labels` property based on your Gateway environment.
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -168,7 +168,7 @@ Follow the instructions given below to configure the Gateway node so that it can
     ```
 
     !!! Info
-        Once an API is deployed/undeployed, Control plan will send a deploy/undeploy event to the gateways. Using this configuration, gateway will filter out it's relevant deploy/undeploy events and retrieve the artifacts.
+        Once an API is deployed/undeployed, the Control Plane will send a deploy/undeploy event to the Gateways. Using this configuration, the Gateway will filter out its relevant deploy/undeploy events and retrieve the artifacts.
 
 4. Enable JSON Web Token (JWT) if required. For instructions, see [Generating JSON Web Token]({{base_path}}/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway).
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -128,7 +128,7 @@ Follow the instructions given below to configure the Gateway node so that it can
      ```
 
     !!! Info
-        Event hub configuration is used retrive gateway artifacts. Using `event_listening_endpoints` gateway will create a JMS connection with the event hub which then used to subscribe for API/Application/Subscription and Keymanager operations related events. `service_url` points to the internal API resides in the event hub that is used to pull artifacts and information from the db.
+        Event hub configuration is used to retrive gateway artifacts. Using `event_listening_endpoints`, gateway will create a JMS connection with the event hub which then used to subscribe for API/Application/Subscription and Keymanager operations related events. `service_url` points to the internal API resides in the event hub that is used to pull artifacts and information from the db.
 
     * **Connecting the Gateway to the Traffic Manager node**:
       
@@ -158,7 +158,7 @@ Follow the instructions given below to configure the Gateway node so that it can
       ```
 
     !!! Info
-        Throtteling configurations are used by the gateway to connect with the traffic manager. Gateway will publish gateway invokation related events to the TM using the `apim.throttling.url_group.traffic_manager_urls`. Traffic managers will receive these events are throttle decisions will be published to gateway. To receive these throttle decisions, gateway has to create a jms connection using `throttle_decision_endpoints` and listen.
+        Throtteling configurations are used by the gateway to connect with the traffic manager. Gateway will publish gateway invocation related events to the TM using the `apim.throttling.url_group`. Traffic managers will receive these events and throttle decisions will be published to gateway. To receive these throttle decisions, gateway has to create a JMS connection using `throttle_decision_endpoints` and listen.
 
 3. Add the following configurations to the deployment.toml file to configure the Gateway environment. Change the `gateway_labels` property based on your Gateway environment.
 
@@ -454,7 +454,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
 
     **Add Event Listener Configurations**:
 
-    Below configurations are only added to the control plane if you are using the resident key manager (resides in the Control Plane). Once you add the below configurations, Control plane will listen to token revocation events. If you are using WSO2 IS as keymanager, you need to add these in the IS node.
+    Below configurations are only added to the control plane if you are using the resident key manager (resides in the Control Plane). If you are using WSO2 IS as keymanager, you need to add these in the IS node. Once you add the below configurations, Control plane or Identity Server will listen to token revocation events and invoke the `notification_endpoint` regarding the revoked token. 
 
     ```toml tab="Control Plane with High Availability"
     # Event Listener configurations
@@ -485,9 +485,6 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     password = "${admin.password}"
     'header.X-WSO2-KEY-MANAGER' = "default"
     ```
-
-    !!! Info
-        With these configurations, we are configuring an event listner that will be triggered once an token is revoked. In such revocation event, Control plane or Identity server will inform the `notification_endpoint` regarding this revoked token.
 
 3. If required, encrypt the Auth Keys (access tokens, client secrets, and authorization codes), see [Encrypting OAuth Keys]({{base_path}}/design/api-security/oauth2/encrypting-oauth2-tokens).
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -128,7 +128,7 @@ Follow the instructions given below to configure the Gateway node so that it can
      ```
 
     !!! Info
-        Event hub configuration is used to retrive gateway artifacts. Using `event_listening_endpoints`, gateway will create a JMS connection with the event hub which then used to subscribe for API/Application/Subscription and Keymanager operations related events. `service_url` points to the internal API resides in the event hub that is used to pull artifacts and information from the db.
+        Event hub configuration is used to retrieve Gateway artifacts. Using `event_listening_endpoints`, the Gateway will create a JMS connection with the event hub that is then used to subscribe for API/Application/Subscription and Key Manager operations-related events. The `service_url` points to the internal API that resides in the event hub that is used to pull artifacts and information from the database.
 
     * **Connecting the Gateway to the Traffic Manager node**:
       

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -410,7 +410,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     !!! Info
         This configuration is used for deploying APIs to the Gateway and for connecting the Developer Portal component to the Gateway if the Gateway is shared across tenants. If the Gateway is not used in multiple tenants, you can create a [Gateway Environment using the Admin Portal]({{base_path}}/deploy-and-publish/deploy-on-gateway/deploy-api/exposing-apis-via-custom-hostnames/#using-a-new-gateway-environment-to-expose-apis-via-custom-hostnames).  
 
-        Please note that in the above configurations, `service_url` points to the `9443` port of the gateway node while `http_endpoint` and `https_endpoint` points to the `http` and `https nio ports` (8280 and 8243).
+        Note that in the above configurations, the `service_url` points to the `9443` port of the Gateway node, while `http_endpoint` and `https_endpoint` points to the `http` and `https nio ports` (8280 and 8243).
     
     **Add Event Hub Configurations**:
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -408,7 +408,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     ```
 
     !!! Info
-        This configuration is used for deploying APIs to the Gateway and for connecting the Developer Portal component to the Gateway if the gateway is shared across tenants. If the gateway is not used in multiple tenants, you can create a [Gateway Environment using the admin portal]({{base_path}}/deploy-and-publish/deploy-on-gateway/deploy-api/exposing-apis-via-custom-hostnames/#using-a-new-gateway-environment-to-expose-apis-via-custom-hostnames).  
+        This configuration is used for deploying APIs to the Gateway and for connecting the Developer Portal component to the Gateway if the Gateway is shared across tenants. If the Gateway is not used in multiple tenants, you can create a [Gateway Environment using the Admin Portal]({{base_path}}/deploy-and-publish/deploy-on-gateway/deploy-api/exposing-apis-via-custom-hostnames/#using-a-new-gateway-environment-to-expose-apis-via-custom-hostnames).  
 
         Please note that in the above configurations, `service_url` points to the `9443` port of the gateway node while `http_endpoint` and `https_endpoint` points to the `http` and `https nio ports` (8280 and 8243).
     

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -715,7 +715,7 @@ Configure the Traffic Manager to communicate with the Control Plane.
     !!! Info
         With `event_listening_endpoints`, the Traffic Manager is subscribed to the JMS stream of both event hubs. Once a policy-related event is received, it will pull the execution plans from the `service_url`.
 
-    If the Traffic manager node is configured with High Availability (HA), configure throttling as follows.
+    If the Traffic Manager node is configured with High Availability (HA), configure rate limiting as follows.
 
     ```toml
     [apim.throttling]

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -101,19 +101,6 @@ Follow the instructions given below to configure the Gateway node so that it can
      username = "$ref{super_admin.username}"
      password = "$ref{super_admin.password}"
 
-     # Event Listener configurations
-     [[event_listener]]
-     id = "token_revocation"
-     type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
-     name = "org.wso2.is.notification.ApimOauthEventInterceptor"
-     order = 1
-
-     [event_listener.properties]
-     notification_endpoint = "https://[control-plane-LB-host]/internal/data/v1/notify"
-     username = "${admin.username}"
-     password = "${admin.password}"
-     'header.X-WSO2-KEY-MANAGER' = "default"
-
      # Event Hub configurations
      [apim.event_hub]
      enable = true
@@ -121,14 +108,6 @@ Follow the instructions given below to configure the Gateway node so that it can
      password = "$ref{super_admin.password}"
      service_url = "https://[control-plane-LB-host]/services/"
      event_listening_endpoints = ["tcp://control-plane-1-host:5672", "tcp://control-plane-2-host:5672"]
-
-     [[apim.event_hub.publish.url_group]]
-     urls = ["tcp://control-plane-1-host:9611"]
-     auth_urls = ["ssl://control-plane-1-host:9711"]
-
-     [[apim.event_hub.publish.url_group]]
-     urls = ["tcp://control-plane-2-host:9611"]
-     auth_urls = ["ssl://control-plane-2-host:9711"]
      
      ```
 
@@ -139,19 +118,6 @@ Follow the instructions given below to configure the Gateway node so that it can
      username = "$ref{super_admin.username}"
      password = "$ref{super_admin.password}"
 
-     # Event Listener configurations
-     [[event_listener]]
-     id = "token_revocation"
-     type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
-     name = "org.wso2.is.notification.ApimOauthEventInterceptor"
-     order = 1
-
-     [event_listener.properties]
-     notification_endpoint = "https://[control-plane-host]:${mgt.transport.https.port}/internal/data/v1/notify"
-     username = "${admin.username}"
-     password = "${admin.password}"
-     'header.X-WSO2-KEY-MANAGER' = "default"
-
      # Event Hub configurations
      [apim.event_hub]
      enable = true
@@ -159,12 +125,10 @@ Follow the instructions given below to configure the Gateway node so that it can
      password = "$ref{super_admin.password}"
      service_url = "https://[control-plane-host]:${mgt.transport.https.port}/services/"
      event_listening_endpoints = ["tcp://control-plane-host:5672"]
-
-     [[apim.event_hub.publish.url_group]]
-     urls = ["tcp://control-plane-host:9611"]
-     auth_urls = ["ssl://control-plane-host:9711"]
-
      ```
+
+    !!! Info
+        Event hub configuration is used retrive gateway artifacts. Using `event_listening_endpoints` gateway will create a JMS connection with the event hub which then used to subscribe for API/Application/Subscription and Keymanager operations related events. `service_url` points to the internal API resides in the event hub that is used to pull artifacts and information from the db.
 
     * **Connecting the Gateway to the Traffic Manager node**:
       
@@ -193,12 +157,18 @@ Follow the instructions given below to configure the Gateway node so that it can
       traffic_manager_auth_urls = ["ssl://traffic-manager-host:9711"]
       ```
 
+    !!! Info
+        Throtteling configurations are used by the gateway to connect with the traffic manager. Gateway will publish gateway invokation related events to the TM using the `apim.throttling.url_group.traffic_manager_urls`. Traffic managers will receive these events are throttle decisions will be published to gateway. To receive these throttle decisions, gateway has to create a jms connection using `throttle_decision_endpoints` and listen.
+
 3. Add the following configurations to the deployment.toml file to configure the Gateway environment. Change the `gateway_labels` property based on your Gateway environment.
 
     ```toml
     [apim.sync_runtime_artifacts.gateway]
     gateway_labels =["Default"]
     ```
+
+    !!! Info
+        Once an API is deployed/undeployed, Control plan will send a deploy/undeploy event to the gateways. Using this configuration, gateway will filter out it's relevant deploy/undeploy events and retrieve the artifacts.
 
 4. Enable JSON Web Token (JWT) if required. For instructions, see [Generating JSON Web Token]({{base_path}}/deploy-and-publish/deploy-on-gateway/api-gateway/passing-enduser-attributes-to-the-backend-via-api-gateway).
 
@@ -262,8 +232,81 @@ Follow the instructions given below to configure the Gateway node so that it can
         ```
 
 #### Sample configuration for the Gateway
+```toml tab="HA Cluster"
+[server]
+hostname = "gw.wso2.com"
+node_ip = "127.0.0.1"
+server_role = "gateway-worker"
 
-```toml
+[user_store]
+type = "database_unique_id"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[database.shared_db]
+type = "mysql"
+url = "jdbc:mysql://mysql:3306/WSO2SHARED_DB?autoReconnect=true&amp;useSSL=false&amp;allowPublicKeyRetrieval=true"
+username = "wso2carbon"
+password = "wso2carbon"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[keystore.tls]
+file_name =  "wso2carbon.jks"
+type =  "JKS"
+password =  "wso2carbon"
+alias =  "wso2carbon"
+key_password =  "wso2carbon"
+
+[truststore]
+file_name = "client-truststore.jks"
+type = "JKS"
+password = "wso2carbon"
+
+[transport.https.properties]
+proxyPort = 443
+
+# key manager implementation
+[apim.key_manager]
+service_url = "https://api.am.wso2.com/services/"
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+type = "default"
+
+[apim.sync_runtime_artifacts.gateway]
+gateway_labels =["Default"]
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://api.am.wso2.com/services/"
+event_listening_endpoints = ["tcp://apim-cp-1:5672", "tcp://apim-cp-2:5672"]
+
+# Traffic Manager configurations
+[apim.throttling]
+service_url = "https://tm.am.wso2.com/services/"
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+enable_unlimited_tier = true
+enable_header_based_throttling = true
+enable_jwt_claim_based_throttling = true
+enable_query_param_based_throttling = true
+throttle_decision_endpoints = ["tcp://traffic-manager-1:5672", "tcp://traffic-manager-2:5672"]
+
+[[apim.throttling.url_group]]
+traffic_manager_urls=["tcp://traffic-manager-1:9611"]
+traffic_manager_auth_urls=["ssl://traffic-manager-1:9711"]
+
+[[apim.throttling.url_group]]
+traffic_manager_urls=["tcp://traffic-manager-2:9611"]
+traffic_manager_auth_urls=["ssl://traffic-manager-2:9711"]
+```
+
+```toml tab="Single Node"
 [server]
 hostname = "gw.wso2.com"
 node_ip = "127.0.0.1"
@@ -311,19 +354,6 @@ throttle_decision_endpoints = ["tcp://tm.wso2.com:5672"]
 traffic_manager_urls=["tcp://tm.wso2.com:9611"]
 traffic_manager_auth_urls=["ssl://tm.wso2.com:9711"]
 
-# Event Listener configurations
-[[event_listener]]
-id = "token_revocation"
-type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
-name = "org.wso2.is.notification.ApimOauthEventInterceptor"
-order = 1
-
-[event_listener.properties]
-notification_endpoint = "https://cp.wso2.com:9443/internal/data/v1/notify"
-username = "${admin.username}"
-password = "${admin.password}"
-'header.X-WSO2-KEY-MANAGER' = "default"
-
 # Event Hub configurations
 [apim.event_hub]
 enable = true
@@ -331,16 +361,6 @@ username = "$ref{super_admin.username}"
 password = "$ref{super_admin.password}"
 service_url = "https://cp.wso2.com:9443/services/"
 event_listening_endpoints = ["tcp://cp.wso2.com:5672"]
-
-[[apim.event_hub.publish.url_group]]
-urls = ["tcp://cp.wso2.com:9611"]
-auth_urls = ["ssl://cp.wso2.com:9711"]
-
-[apim.cors]
-allow_origins = "*"
-allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
-allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
-allow_credentials = false
 
 [apim.sync_runtime_artifacts.gateway]
 gateway_labels =["Default"]
@@ -357,11 +377,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
 
     **Connecting the Control Plane to the Gateway node**:
 
-    !!! Info
-        This configuration is used for publishing APIs to the Gateway and for connecting the Developer Portal component to the Gateway.
-
     ```toml tab="Gateway with High Availability"
-
     [[apim.gateway.environment]]
     name = "Default"
     type = "hybrid"
@@ -391,64 +407,14 @@ Follow the steps given below to configure the Control Plane nodes to communicate
 
     ```
 
-    **Connecting the Control Plane to the Traffic Manager node**:
-
     !!! Info
-        This configuration enables the publishing of throttling policies, custom templates, block conditions, and API events to the Traffic Manager node.
+        This configuration is used for deploying APIs to the Gateway and for connecting the Developer Portal component to the Gateway if the gateway is shared across tenants. If the gateway is not used in multiple tenants, you can create a [Gateway Environment using the admin portal]({{base_path}}/deploy-and-publish/deploy-on-gateway/deploy-api/exposing-apis-via-custom-hostnames/#using-a-new-gateway-environment-to-expose-apis-via-custom-hostnames).  
 
-    ```toml tab="Traffic Manager with HA"
-
-    [apim.throttling]
-    username = "$ref{super_admin.username}"
-    password = "$ref{super_admin.password}"
-    enable_data_publishing = true
-    service_url = "https://[traffic-manager-LB-host]/services/"
-    event_duplicate_url = ["tcp://control-plane-2-host:5672"]
-
-    [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://traffic-manager-1-host:9611"]
-    traffic_manager_auth_urls = ["ssl://traffic-manager-1-host:9711"]
-
-    [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://traffic-manager-2-host:9611"]
-    traffic_manager_auth_urls = ["ssl://traffic-manager-2-host:9711"]
-
-    ```
-
-    ```toml tab="Single Traffic Manager"
-
-    [apim.throttling]
-    username = "$ref{super_admin.username}"
-    password = "$ref{super_admin.password}"
-    enable_data_publishing = true
-    service_url = "https://[traffic-manager-host]:${mgt.transport.https.port}/services/"
-
-    [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://traffic-manager-host:9611"]
-    traffic_manager_auth_urls = ["ssl://traffic-manager-host:9711"]
-
-    ```
-
-    !!! Note
-        Configure the `event_duplicate_url` if the Control Plane is configured for High Availability (HA).
-
-    **Add Event Listener and Event Hub Configurations**:
+        Please note that in the above configurations, `service_url` points to the `9443` port of the gateway node while `http_endpoint` and `https_endpoint` points to the `http` and `https nio ports` (8280 and 8243).
+    
+    **Add Event Hub Configurations**:
 
     ```toml tab="Control Plane with High Availability"
-
-    # Event Listener configurations
-    [[event_listener]]
-    id = "token_revocation"
-    type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
-    name = "org.wso2.is.notification.ApimOauthEventInterceptor"
-    order = 1
-
-    [event_listener.properties]
-    notification_endpoint = "https://[control-plane-LB-host]/internal/data/v1/notify"
-    username = "${admin.username}"
-    password = "${admin.password}"
-    'header.X-WSO2-KEY-MANAGER' = "default"
-
     # Event Hub configurations
     [apim.event_hub]
     enable = true
@@ -456,6 +422,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     password= "$ref{super_admin.password}"
     service_url = "https://localhost:${mgt.transport.https.port}/services/"
     event_listening_endpoints = ["tcp://localhost:5672"]
+    event_duplicate_url = ["tcp://apim-cp-2:5672"]
 
     [[apim.event_hub.publish.url_group]]
     urls = ["tcp://control-plane-1-host:9611"]
@@ -468,20 +435,6 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     ```
 
     ```toml tab="Single Control Plane"
-
-    # Event Listener configurations
-    [[event_listener]]
-    id = "token_revocation"
-    type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
-    name = "org.wso2.is.notification.ApimOauthEventInterceptor"
-    order = 1
-
-    [event_listener.properties]
-    notification_endpoint = "https://[control-plane-host]:${mgt.transport.https.port}/internal/data/v1/notify"
-    username = "${admin.username}"
-    password = "${admin.password}"
-    'header.X-WSO2-KEY-MANAGER' = "default"
-
     # Event Hub configurations
     [apim.event_hub]
     enable = true
@@ -495,6 +448,46 @@ Follow the steps given below to configure the Control Plane nodes to communicate
     auth_urls = ["ssl://control-plane-host:9711"]
 
     ```
+
+    !!! Info
+        As there are two event hubs in a HA setup, each event hub has to publish events to both event streams. This will be done through the event streams created with `apim.event_hub.publish.url_group`. The token revocation events that are received to an event hub will be duplicated to the other event hub using `event_duplicate_url`.
+
+    **Add Event Listener Configurations**:
+
+    Below configurations are only added to the control plane if you are using the resident key manager (resides in the Control Plane). Once you add the below configurations, Control plane will listen to token revocation events. If you are using WSO2 IS as keymanager, you need to add these in the IS node.
+
+    ```toml tab="Control Plane with High Availability"
+    # Event Listener configurations
+    [[event_listener]]
+    id = "token_revocation"
+    type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+    name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+    order = 1
+
+    [event_listener.properties]
+    notification_endpoint = "https://[control-plane-LB-host]/internal/data/v1/notify"
+    username = "${admin.username}"
+    password = "${admin.password}"
+    'header.X-WSO2-KEY-MANAGER' = "default"
+    ```
+
+    ```toml tab="Single Control Plane"
+    # Event Listener configurations
+    [[event_listener]]
+    id = "token_revocation"
+    type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+    name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+    order = 1
+
+    [event_listener.properties]
+    notification_endpoint = "https://[control-plane-host]:${mgt.transport.https.port}/internal/data/v1/notify"
+    username = "${admin.username}"
+    password = "${admin.password}"
+    'header.X-WSO2-KEY-MANAGER' = "default"
+    ```
+
+    !!! Info
+        With these configurations, we are configuring an event listner that will be triggered once an token is revoked. In such revocation event, Control plane or Identity server will inform the `notification_endpoint` regarding this revoked token.
 
 3. If required, encrypt the Auth Keys (access tokens, client secrets, and authorization codes), see [Encrypting OAuth Keys]({{base_path}}/design/api-security/oauth2/encrypting-oauth2-tokens).
 
@@ -515,7 +508,103 @@ Follow the steps given below to configure the Control Plane nodes to communicate
 
 #### Sample configuration for the Control Plane
 
-```toml
+```toml tab="HA Cluster"
+[server]
+hostname = "api.am.wso2.com"
+node_ip = "127.0.0.1"
+server_role="control-plane"
+base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+
+[user_store]
+type = "database_unique_id"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[database.apim_db]
+type = "mysql"
+url = "jdbc:mysql://mysql:3306/WSO2AM_DB?autoReconnect=true&amp;useSSL=false&amp;allowPublicKeyRetrieval=true"
+username = "wso2carbon"
+password = "wso2carbon"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.shared_db]
+type = "mysql"
+url = "jdbc:mysql://mysql:3306/WSO2SHARED_DB?autoReconnect=true&amp;useSSL=false&amp;allowPublicKeyRetrieval=true"
+username = "wso2carbon"
+password = "wso2carbon"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[keystore.tls]
+file_name =  "wso2carbon.jks"
+type =  "JKS"
+password =  "wso2carbon"
+alias =  "wso2carbon"
+key_password =  "wso2carbon"
+
+[truststore]
+file_name = "client-truststore.jks"
+type = "JKS"
+password = "wso2carbon"
+
+[[apim.gateway.environment]]
+name = "Default"
+type = "hybrid"
+display_in_api_console = true
+description = "This is a hybrid gateway that handles both production and sandbox token traffic."
+show_as_token_endpoint_url = true
+service_url = "https://[api-gateway-LB-host]/services/"
+ws_endpoint = "ws://[api-gateway-LB-host]:9099"
+wss_endpoint = "wss://[api-gateway-LB-host]:8099"
+http_endpoint = "http://[api-gateway-LB-host]"
+https_endpoint = "https://[api-gateway-LB-host]"
+
+[apim.devportal]
+url = "https://api.am.wso2.com/devportal"
+
+[transport.https.properties]
+proxyPort = 443
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://api.am.wso2.com/services/"
+event_listening_endpoints = ["tcp://localhost:5672"]
+event_duplicate_url = ["tcp://apim-cp-2:5672"]
+
+[[apim.event_hub.publish.url_group]]
+urls = ["tcp://apim-cp-1:9611"]
+auth_urls = ["ssl://apim-cp-1:9711"]
+
+[[apim.event_hub.publish.url_group]]
+urls = ["tcp://apim-cp-2:9611"]
+auth_urls = ["ssl://apim-cp-2:9711"]
+
+# key manager implementation
+[apim.key_manager]
+service_url = "https://api.am.wso2.com/services/"
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+type = "default"
+
+[[event_listener]]
+id = "token_revocation"
+type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+order = 1
+
+[event_listener.properties]
+notification_endpoint = "https://api.am.wso2.com/internal/data/v1/notify"
+username = "${admin.username}"
+password = "${admin.password}"
+'header.X-WSO2-KEY-MANAGER' = "default"
+```
+
+```toml tab="Single Node"
 [server]
 hostname = "cp.wso2.com"
 node_ip = "127.0.0.1"
@@ -568,18 +657,6 @@ wss_endpoint = "wss://gw.wso2.com:8099"
 http_endpoint = "http://gw.wso2.com:8280"
 https_endpoint = "https://gw.wso2.com:8243"
 
-# Traffic Manager configurations
-[apim.throttling]
-username= "$ref{super_admin.username}"
-password= "$ref{super_admin.password}"
-enable_data_publishing = true
-service_url = "https://tm.wso2.com:9443/services/"
-throttle_decision_endpoints = ["tcp://tm.wso2.com:5672"]
-
-[[apim.throttling.url_group]]
-traffic_manager_urls=["tcp://tm.wso2.com:9611"]
-traffic_manager_auth_urls=["ssl://tm.wso2.com:9711"]
-
 # Event Listener configurations
 [[event_listener]]
 id = "token_revocation"
@@ -604,13 +681,6 @@ event_listening_endpoints = ["tcp://cp.wso2.com:5672"]
 [[apim.event_hub.publish.url_group]]
 urls = ["tcp://cp.wso2.com:9611"]
 auth_urls = ["ssl://cp.wso2.com:9711"]
-
-[apim.cors]
-allow_origins = "*"
-allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
-allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
-allow_credentials = false
-
 ```
 
 ### Configure the Traffic Manager Nodes
@@ -626,7 +696,6 @@ Configure the Traffic Manager to communicate with the Control Plane.
     **Connecting the Traffic Manager to the Control Plane node**:
 
     ```toml tab="Control Plane with High Availability"
- 
     # Event Hub configurations
     [apim.event_hub]
     enable = true
@@ -634,19 +703,9 @@ Configure the Traffic Manager to communicate with the Control Plane.
     password = "$ref{super_admin.password}"
     service_url = "https://[control-plane-LB-host]/services/"
     event_listening_endpoints = ["tcp://control-plane-1-host:5672", "tcp://control-plane-2-host:5672"]
-
-    [[apim.event_hub.publish.url_group]]
-    urls = ["tcp://control-plane-1-host:9611"]
-    auth_urls = ["ssl://control-plane-1-host:9711"]
-
-    [[apim.event_hub.publish.url_group]]
-    urls = ["tcp://control-plane-2-host:9611"]
-    auth_urls = ["ssl://control-plane-2-host:9711"] 
-
     ```
  
     ```toml tab="Single Control Plane"
- 
     # Event Hub configurations
     [apim.event_hub]
     enable = true
@@ -654,34 +713,21 @@ Configure the Traffic Manager to communicate with the Control Plane.
     password = "$ref{super_admin.password}"
     service_url = "https://[control-plane-host]/services/"
     event_listening_endpoints = ["tcp://control-plane-host:5672"]
-
-    [[apim.event_hub.publish.url_group]]
-    urls = ["tcp://control-plane-host:9611"]
-    auth_urls = ["ssl://control-plane-host:9711"]
-
     ```
+
+    !!! Info
+        With `event_listening_endpoints`, traffic manager is subscribed to the JMS stream of both event hubs. Once a policy related event is received, it will pull the execution plans from the `service_url`.
 
     If the Traffic manager node is configured with High Availability (HA), configure throttling as follows.
 
     ```toml
-
     [apim.throttling]
     event_duplicate_url = ["tcp://traffic-manager-2-host:5672"]
-    service_url = "https://[traffic-manager-LB-host]/services/"
     throttle_decision_endpoints = ["tcp://localhost:5672"]
-
-    [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://traffic-manager-1-host:9611"]
-    traffic_manager_auth_urls = ["ssl://traffic-manager-1-host:9711"]
-
-    [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://traffic-manager-2-host:9611"]
-    traffic_manager_auth_urls = ["ssl://traffic-manager-2-host:9711"]
-
     ```
 
-    !!! Note
-        The `event_duplicate_url` should be added in order to publish events to the other node.
+    !!! Info
+        The `event_duplicate_url` will publish throttle decisions to the other TM node to maintain consistency.
 
 3. Follow the steps given below to configure High Availability (HA) for the Traffic Manager.
 
@@ -700,7 +746,57 @@ Configure the Traffic Manager to communicate with the Control Plane.
 
 #### Sample configuration for the Traffic Manager
 
-```toml
+```toml tab="HA Cluster"
+[server]
+hostname = "tm.am.wso2.com"
+node_ip = "127.0.0.1"
+server_role = "traffic-manager"
+
+[transport.https.properties]
+proxyPort = 443
+
+[user_store]
+type = "database_unique_id"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[database.shared_db]
+type = "mysql"
+url = "jdbc:mysql://mysql:3306/WSO2AM_SHARED_DB?autoReconnect=true&amp;useSSL=false&amp;allowPublicKeyRetrieval=true"
+username = "wso2carbon"
+password = "wso2carbon"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[keystore.tls]
+file_name =  "wso2carbon.jks"
+type =  "JKS"
+password =  "wso2carbon"
+alias =  "wso2carbon"
+key_password =  "wso2carbon"
+
+[truststore]
+file_name = "client-truststore.jks"
+type = "JKS"
+password = "wso2carbon"
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://api.am.wso2.com/services/"
+event_listening_endpoints = ["tcp://apim-cp-1:5672", "tcp://apim-cp-2:5672"]
+
+# Traffic Manager configurations
+[apim.throttling]
+event_duplicate_url = ["tcp://traffic-manager-2:5672"]
+throttle_decision_endpoints = ["tcp://localhost:5672"]
+```
+
+```toml tab="Single Node"
 [server]
 hostname = "tm.wso2.com"
 node_ip = "127.0.0.1"
@@ -714,12 +810,6 @@ type = "database_unique_id"
 username = "admin"
 password = "admin"
 create_admin_account = true
-
-[database.apim_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2AM_DB;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE"
-username = "wso2carbon"
-password = "wso2carbon"
 
 [database.shared_db]
 type = "h2"
@@ -746,10 +836,6 @@ username = "$ref{super_admin.username}"
 password = "$ref{super_admin.password}"
 service_url = "https://cp.wso2.com:9443/services/"
 event_listening_endpoints = ["tcp://cp.wso2.com:5672"]
-
-[[apim.event_hub.publish.url_group]]
-urls = ["tcp://cp.wso2.com:9611"]
-auth_urls = ["ssl://cp.wso2.com:9711"]
 
 ```
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -713,7 +713,7 @@ Configure the Traffic Manager to communicate with the Control Plane.
     ```
 
     !!! Info
-        With `event_listening_endpoints`, traffic manager is subscribed to the JMS stream of both event hubs. Once a policy related event is received, it will pull the execution plans from the `service_url`.
+        With `event_listening_endpoints`, the Traffic Manager is subscribed to the JMS stream of both event hubs. Once a policy-related event is received, it will pull the execution plans from the `service_url`.
 
     If the Traffic manager node is configured with High Availability (HA), configure throttling as follows.
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -724,7 +724,7 @@ Configure the Traffic Manager to communicate with the Control Plane.
     ```
 
     !!! Info
-        The `event_duplicate_url` will publish throttle decisions to the other TM node to maintain consistency.
+        The `event_duplicate_url` will publish rate limiting decisions to the other Traffic Manager node to maintain consistency.
 
 3. Follow the steps given below to configure High Availability (HA) for the Traffic Manager.
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated.md
@@ -454,7 +454,7 @@ Follow the steps given below to configure the Control Plane nodes to communicate
 
     **Add Event Listener Configurations**:
 
-    Below configurations are only added to the control plane if you are using the resident key manager (resides in the Control Plane). If you are using WSO2 IS as keymanager, you need to add these in the IS node. Once you add the below configurations, Control plane or Identity Server will listen to token revocation events and invoke the `notification_endpoint` regarding the revoked token. 
+    The below configurations are only added to the Control Plane if you are using the Resident Key Manager (resides in the Control Plane). If you are using WSO2 IS as Key Manager, you need to add these in the IS node. Once you add the below configurations, the Control Plane or Identity Server will listen to token revocation events and invoke the `notification_endpoint` regarding the revoked token. 
 
     ```toml tab="Control Plane with High Availability"
     # Event Listener configurations


### PR DESCRIPTION
## Purpose
This PR fixes the issues with the distributed setup config page for TM separated deployment. 
Previous doc contained several unwanted configurations and I have added the bare minimum configurations and further explained the usecase of each config.

![screencapture-localhost-8000-install-and-setup-setup-distributed-deployment-deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated-2022-09-21-18_17_49](https://user-images.githubusercontent.com/47380453/191507839-7009fe56-f09a-4bf9-bd97-74293509c6b1.png)

