### PR TITLE
[4.1.0] Add missing registry db indices to REG_RESOURCE_PROPERTY and REG_RESOURCE_TAG

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
@@ -168,7 +168,47 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5. Disable versioning in the registry configuration
+5.  Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+
+    ```tab="DB2"
+    CREATE INDEX REG_TAG_IND_BY_TG1
+    ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+   
+    CREATE INDEX REG_RESC_PROP_BY_3
+    ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+    ```
+
+    ```tab="MSSQL"
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+    DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+   
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+    DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+    ```tab="MySQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+    ```tab="Oracle"
+    CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+    /
+   
+    CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+    /
+    ```
+    
+    ```tab="PostgreSQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+6. Disable versioning in the registry configuration
 
     If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.1.0.
     
@@ -409,7 +449,7 @@ Follow the instructions below to move all the existing API Manager configuration
         !!! note "NOTE"
             Changing these configurations should only be done before the initial API-M Server startup. If changes are done after the initial startup, the registry resource created previously will not be available.
 
-6. If you have enabled any other feature related configurations in API Manager 2.6.0, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
+7. If you have enabled any other feature related configurations in API Manager 2.6.0, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
 
 ### Step 2: Migrate the API Manager Resources
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
@@ -168,7 +168,7 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5.  Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+5.  Run the following script on the registry database to add missing registry indices.
 
 
     ```tab="DB2"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
@@ -164,7 +164,7 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+5.  Run the following script on the registry database to add missing registry indices.
 
 
     ```tab="DB2"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
@@ -164,7 +164,49 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5. Disable versioning in the registry configuration
+5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+
+    ```tab="DB2"
+    CREATE INDEX REG_TAG_IND_BY_TG1
+    ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+   
+    CREATE INDEX REG_RESC_PROP_BY_3
+    ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+    ```
+
+    ```tab="MSSQL"
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+    DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+   
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+    DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+    ```tab="MySQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+    ```tab="Oracle"
+    CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+    /
+   
+    CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+    /
+    ```
+    
+    ```tab="PostgreSQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+
+
+6. Disable versioning in the registry configuration
 
     If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.1.0.
     
@@ -405,7 +447,7 @@ Follow the instructions below to move all the existing API Manager configuration
         !!! note "NOTE"
             Changing these configurations should only be done before the initial API-M Server startup. If changes are done after the initial startup, the registry resource created previously will not be available.
 
-6.  If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
+7. If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
 
 ### Step 2: Migrate the API Manager Resources
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
@@ -163,7 +163,7 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+5.  Run the following script on the registry database to add missing registry indices.
 
 
     ```tab="DB2"

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
@@ -163,7 +163,49 @@ Follow the instructions below to move all the existing API Manager configuration
         gateway_labels = ["Test"]
         ```
 
-5. Disable versioning in the registry configuration
+5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+
+    ```tab="DB2"
+    CREATE INDEX REG_TAG_IND_BY_TG1
+    ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+   
+    CREATE INDEX REG_RESC_PROP_BY_3
+    ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+    ```
+
+    ```tab="MSSQL"
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+    DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+   
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+    DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+    ```tab="MySQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+    ```tab="Oracle"
+    CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+    /
+   
+    CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+    /
+    ```
+    
+    ```tab="PostgreSQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+
+
+6. Disable versioning in the registry configuration
 
     If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.1.0.
 
@@ -404,7 +446,7 @@ Follow the instructions below to move all the existing API Manager configuration
         !!! note "NOTE"
             Changing these configurations should only be done before the initial API-M Server startup. If changes are done after the initial startup, the registry resource created previously will not be available.
 
-6.  If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
+7. If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
 
 ### Step 2: Migrate the API Manager Resources
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
@@ -164,8 +164,8 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
         [apim.sync_runtime_artifacts.gateway]
         gateway_labels = ["Test"]
         ```
-   
-4. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+4. Run the following script on the registry database to add missing registry indices.
 
     ```tab="DB2"
     CREATE INDEX REG_TAG_IND_BY_TG1

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
@@ -124,7 +124,7 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
         validationQuery = "SELECT 1 FROM DUAL"
         ```    
 
-2.   If you have used separate DB for user management, you need to update `<API-M_4.0.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+2. If you have used separate DB for user management, you need to update `<API-M_4.0.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
      
     ```
     [realm_manager]
@@ -165,7 +165,46 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
         gateway_labels = ["Test"]
         ```
    
-4. If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
+4. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+    ```tab="DB2"
+    CREATE INDEX REG_TAG_IND_BY_TG1
+    ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+   
+    CREATE INDEX REG_RESC_PROP_BY_3
+    ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+    ```
+
+    ```tab="MSSQL"
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+    DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+   
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+    DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+    ```tab="MySQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+    ```tab="Oracle"
+    CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+    /
+   
+    CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+    /
+    ```
+    
+    ```tab="PostgreSQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+5. If you have enabled any other feature related configurations at `<API-M_4.1.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
 
 ### Step 2: Migrate the API Manager Resources
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/400-to-410/upgrading-from-400-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/400-to-410/upgrading-from-400-to-410.md
@@ -148,7 +148,47 @@ Follow the instructions below to move all the existing API Manager configuration
 
        ```
 
-5. If you have enabled any other feature related configurations at `<API-M_4.0.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
+5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+
+
+    ```tab="DB2"
+    CREATE INDEX REG_TAG_IND_BY_TG1
+    ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+   
+    CREATE INDEX REG_RESC_PROP_BY_3
+    ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+    ```
+
+    ```tab="MSSQL"
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+    DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+   
+    IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+    DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+    ```tab="MySQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+   
+    ```tab="Oracle"
+    CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+    /
+   
+    CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+    /
+    ```
+    
+    ```tab="PostgreSQL"
+    CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+    CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+    ```
+
+6. If you have enabled any other feature related configurations at `<API-M_4.0.0_HOME>/repository/conf/deployment.toml`, make sure to add them in to `<API-M_4.1.0_HOME>/repository/conf/deployment.toml` file.
 
 !!! note
     If the older API-M setup has been configured for a different admin role other than admin and if the role is not persisted in read-only userstore, make sure not to change the `admin_role` configuration in the deployment.toml this time. You have to configure it after step 4.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/400-to-410/upgrading-from-400-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/400-to-410/upgrading-from-400-to-410.md
@@ -148,7 +148,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
        ```
 
-5. Run the following script on the registry database to add registry index `REG_RESC_PROP_BY_REG_PROP_ID`.
+5.  Run the following script on the registry database to add missing registry indices.
 
 
     ```tab="DB2"


### PR DESCRIPTION
## Purpose
Add script for missing indices in registry db.
fixing : https://github.com/wso2/docs-apim/issues/6315

- REG_RESOURCE_TAG_IND_BY_REG_TAG_ID to REG_RESOURCE_TAG
- REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID to REG_RESOURCE_PROPERTY

## Related PRs 
https://github.com/wso2/carbon-kernel/pull/3169