### PR TITLE
Add missing registry indices db script to documentation

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-400.md
@@ -21,7 +21,9 @@ Before you begin:
     
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-400.md
@@ -20,6 +20,49 @@ Before you begin:
 -   **If you are using Oracle**, commit the changes after running the scripts given below.
     
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
@@ -23,7 +23,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
@@ -22,6 +22,49 @@ The following information describes how to upgrade your API Manager server **fro
 Follow the instructions below to upgrade your WSO2 API Manager server **from WSO2 API-M 2.0.0 to 4.0.0**.
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
@@ -23,7 +23,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
@@ -23,6 +23,48 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
@@ -23,7 +23,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
@@ -22,6 +22,49 @@ The following information describes how to upgrade your API Manager server **fro
 Follow the instructions below to upgrade your WSO2 API Manager server **from WSO2 API-M 2.2.0 to 4.0.0**.
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
@@ -35,6 +35,49 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 -   [Step 7 - Restart the WSO2 API-M 4.0.0 server](#step-7-restart-the-wso2-api-m-400-server)
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
@@ -36,7 +36,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
@@ -35,6 +35,49 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 -   [Step 7 - Restart the WSO2 API-M 4.0.0 server](#step-7-restart-the-wso2-api-m-400-server)
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 4.0.0.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
@@ -36,7 +36,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
@@ -35,6 +35,49 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 -   [Step 7 - Restart the WSO2 API-M 4.0.0 server](#step-7-restart-the-wso2-api-m-400-server)
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration if it was enabled
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default from API Manager 3.0.0 onwards.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
@@ -36,7 +36,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
@@ -38,6 +38,49 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 <!-- omit in toc -->
 ### Preparing for Migration
 <!-- omit in toc -->
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration if it was enabled
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default from API Manager 3.0.0 onwards.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
@@ -39,7 +39,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 ### Preparing for Migration
 <!-- omit in toc -->
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
@@ -35,6 +35,49 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 -   [Step 7 - Restart the WSO2 API-M 4.0.0 server](#step-7-restart-the-wso2-api-m-400-server)
 
 ### Preparing for Migration
+
+#### Run the following script on the registry database to add missing registry indices.
+
+??? info "DB Scripts"
+
+       ```tab="DB2"
+       CREATE INDEX REG_TAG_IND_BY_TG1
+       ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)/
+      
+       CREATE INDEX REG_RESC_PROP_BY_3
+       ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)/
+       ```
+
+       ```tab="MSSQL"
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_TAG_IND_BY_REG_TAG_ID')
+       DROP INDEX REG_RESOURCE_TAG.REG_RESOURCE_TAG_IND_BY_REG_TAG_ID
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+      
+       IF EXISTS (SELECT NAME FROM SYSINDEXES WHERE NAME = 'REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID')
+       DROP INDEX REG_RESOURCE_PROPERTY.REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+   
+       ```tab="MySQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID USING HASH ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+       
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+      
+       ```tab="Oracle"
+       CREATE INDEX REG_TAG_IND_BY_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID)
+       /
+      
+       CREATE INDEX REG_RESC_PROP_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID,REG_PROPERTY_ID)
+       /
+       ```
+       
+       ```tab="PostgreSQL"
+       CREATE INDEX REG_RESOURCE_TAG_IND_BY_REG_TAG_ID ON REG_RESOURCE_TAG(REG_TAG_ID, REG_TENANT_ID);
+
+       CREATE INDEX REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID ON REG_RESOURCE_PROPERTY(REG_TENANT_ID, REG_PROPERTY_ID);
+       ```
+
 #### Disabling versioning in the registry configuration if it was enabled
 
 If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default from API Manager 3.0.0 onwards.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
@@ -36,7 +36,9 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 
 ### Preparing for Migration
 
-#### Run the following script on the registry database to add missing registry indices.
+#### Creating registry indices
+
+Run the following script on the registry database to add missing registry indices.
 
 ??? info "DB Scripts"
 


### PR DESCRIPTION
## Purpose
Add script for missing indices in registry db.
fixing : https://github.com/wso2/docs-apim/issues/6315

- REG_RESOURCE_TAG_IND_BY_REG_TAG_ID to REG_RESOURCE_TAG
- REG_RESOURCE_PROPERTY_IND_BY_REG_PROP_ID to REG_RESOURCE_PROPERTY

## Related PRs 
https://github.com/wso2/carbon-kernel/pull/3169