### PR TITLE
Modifying the definition --export-directory flag of apictl

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -511,7 +511,7 @@ Run the following apictl command to change the default location of the export di
         **Flags:** 
 
         - Required :   
-            `--export-directory`: Path to directory where APIs, API Products and Applications should be saved.   
+            `--export-directory`: Path to directory where APIs, API Products, and Applications should be saved.   
             Default : `/home/.wso2apictl/exported`
             
             

--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -511,7 +511,7 @@ Run the following apictl command to change the default location of the export di
         **Flags:** 
 
         - Required :   
-            `--export-directory`: Path to directory where APIs should be saved.   
+            `--export-directory`: Path to directory where APIs, API Products and Applications should be saved.   
             Default : `/home/.wso2apictl/exported`
             
             


### PR DESCRIPTION
## Purpose
The --export-directory of WSO2 API Controller (apictl) stands for the location to export not only APIs but also to store API Products and Applications. This PR fixes the unclarity of the definition in the documentation.

## Goals
Modifying the definition --export-directory flag of apictl

## Approach
Updated the definition of `apictl set --export-directory` flag to mention about API Products and Applications as well.