### PR TITLE
[4.0.0] Fixing the apictl versioning in QSG

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -228,7 +228,7 @@ API Products, and Applications across WSO2 API-M environments and to perform CI/
 
      1. Navigate to the [API Manager Tooling page](https://wso2.com/api-management/tooling/).
 
-     2. Download the apictl version 4.0.1 (or the latest of the 4.x family) based your operating system from the **API Controller Tooling** section.
+     2. Download the apictl version 4.0.0 (or the latest of the 4.0.x family) based your operating system from the **API Controller Tooling** section.
  
      3. Extract the ZIP to a preferred location.
 


### PR DESCRIPTION
## Purpose
The QSG of API Management contains the wrong apictl version. This PR fixes it.

## Goals
Fixing the apictl versioning in QSG

## Approach
Mentioned using apictl 4.0.0 (or the latest one in 4.0.x family)