### PR TITLE
[4.1.0] Add jinja2 version 3.0.3 as requirement for python3

### DIFF
--- a/en/requirements.txt
+++ b/en/requirements.txt
@@ -10,3 +10,4 @@ markdown-include==0.5.1
 markdown==3.1
 mkdocs-redirects==1.0.0
 mkdocs-exclude==1.0.2
+jinja2==3.0.3


### PR DESCRIPTION
## Purpose
$subject

Do not work with python 3 if this version of jinja2 is not specified.
Python2 ARM installation is not there for Apple M1 machines.