### PR TITLE
[3.0.0] Add jinja2 version 3.0.3 as a requirement for python3

### DIFF
--- a/en/requirements.txt
+++ b/en/requirements.txt
@@ -10,3 +10,4 @@ markdown-include==0.5.1
 markdown==3.1
 mkdocs-redirects==1.0.0
 mkdocs-exclude==1.0.2
+jinja2==3.0.3


### PR DESCRIPTION
## Purpose
port https://github.com/wso2/docs-apim/pull/6403