### PR TITLE
Improved the 3.2.0 migration docs

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-stores/introduction-to-userstores.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-stores/introduction-to-userstores.md
@@ -6,4 +6,4 @@ The user stores of can be configured to operate in either one of the following m
 
 **User store operates in read/write mode** - In Read/Write mode, the API Manager reads/writes into the user store.
 
-**User store operates in read only mode** - In Read Only mode, the API Manager does not modify any data in the user store. Instead we maintain roles and permissions in a seperate database and read users/roles from the configured read only user store.
+**User store operates in read only mode** - In Read Only mode, the API Manager does not modify any data in the user store. Instead we maintain roles and permissions in a separate database and read users/roles from the configured read only user store.

--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -353,7 +353,7 @@ hostname = "test.wso2.com"
 </div>
 </div>
 <strong>Solr based indexing</strong>
-<p>API Manager has a Solr based indexing mechanism and it is not recommended to share the Solr directory <code>&lt;PRODUCT_HOME&gt;/solr/data/</code> between the Developer Portal and Publisher servers. You need to have seperate Solr directories for each of the servers.</p>
+<p>API Manager has a Solr based indexing mechanism and it is not recommended to share the Solr directory <code>&lt;PRODUCT_HOME&gt;/solr/data/</code> between the Developer Portal and Publisher servers. You need to have separate Solr directories for each of the servers.</p>
 </div></td>
 </tr>
 <tr class="even">

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -239,10 +239,10 @@ been removed from Hotspot JVM.</p>
 </td>
 </tr>
 <tr class="odd">
-<td><p>Use a seperate admin user account to login into the system</p>
+<td><p>Use a separate admin user account to login into the system</p>
 <p><br />
 </p></td>
-<td><p>WSO2 recommends that you use two seperate admin user accounts in production, one account for logging into the system and the other one as the system user in configurations (for internal service communications).</p>
+<td><p>WSO2 recommends that you use two separate admin user accounts in production, one account for logging into the system and the other one as the system user in configurations (for internal service communications).</p>
 <p>For more information regarding admin user accounts, see <a href="{{base_path}}/reference/config-catalog/#super-admin-configurations">Super admin configurations</a>.</p>
 </td>
 </tr>

--- a/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
+++ b/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
@@ -56,7 +56,7 @@ By default, the primary keystore configured as above is used for internal data e
 
 ## Configuring the Secondary Keystore for TLS connections
 
-In order to configure a seperate keystore as the secondary keystore, add below configurations to `deployment.toml`.
+In order to configure a separate keystore as the secondary keystore, add below configurations to `deployment.toml`.
 
 ```toml
 [keystore.tls]
@@ -69,7 +69,7 @@ key_password =  "passwd12#"
 
 ## Configuring the Internal Keystore
 
-Configuring a seperate internal keystore facilitates you to keep the certificate used for those encryptions unchanged while the certificate used for signing are changed. For that, add below configurations to `deployment.toml`. 
+Configuring a separate internal keystore facilitates you to keep the certificate used for those encryptions unchanged while the certificate used for signing are changed. For that, add below configurations to `deployment.toml`. 
 
 ```toml
 [keystore.internal]
@@ -82,7 +82,7 @@ key_password =  "passwd12#"
 
 !!! warning
     Using a totally new keystore for internal data encryption in an existing deployment will make already encrypted data unusable. In such cases, an appropriate data migration effort is needed.
-    Hence, if you have already been using the same keystore for both primary and internal keystores for sometime and later decided to use a seperate internal keystore, use the current keystore for internal keystore and use the new keystore for primary keystore instead. This avoids unnecessary data migration.
+    Hence, if you have already been using the same keystore for both primary and internal keystores for sometime and later decided to use a separate internal keystore, use the current keystore for internal keystore and use the new keystore for primary keystore instead. This avoids unnecessary data migration.
 
 
     ```toml

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-1100-to-320.md
@@ -401,13 +401,13 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! warning
         When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0.
 
-        -   /api/_RevokeAPI_.xml
-        -   /sequences/_cors_request_handler_.xml
-        -   /sequences/_resource_mismatch_handler_.xml
-        -   /sequences/main.xml
-        -   /sequences/_throttle_out_handler.xml
-        -   /sequences/fault.xml
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/_resource_mismatch_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/sequences/_throttle_out_handler_.xml`
+        -   `/sequences/fault.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`
                 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
@@ -424,7 +424,7 @@ Follow the instructions below to move all the existing API Manager configuration
         Taking the `log4j.properties` file from your old WSO2 API-M Server and adding it to the WSO2 API-M 3.2.0 Server will no longer work. Refer to [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the `log4j2.properties` file.
 
     !!! note
-        Log4j2 has hot deployment support therefore the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -3777,7 +3777,7 @@ Follow the instructions below to move all the existing API Manager configuration
         But, if you are not using WSO2 IS as a Key Manager, you have to follow the steps mentioned below in order to upgrade the identity components that have been shared with WSO2 API-M.
 
     ??? note "If you are using DB2"
-        Move indexes to the the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
+        Move indexes to the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
 
         SQLADM or DBADM authority is required in order to invoke the `ADMIN_MOVE_TABLE` stored procedure. You must also have the appropriate object creation authorities, including authorities to issue the SELECT statement on the source table and to issue the INSERT statement on the target table. 
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-320.md
@@ -6,7 +6,8 @@ The following information describes how to upgrade your API Manager server **fro
     Before you follow this section, see [Upgrading Process]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-process) for more information.
 
 !!! Attention
-    If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-5100) instead of the following steps.    
+    	
+If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-5100) instead of below steps.  
 
 Follow the instructions below to upgrade your WSO2 API Manager server **from WSO2 API-M 2.0.0 to 3.2.0**.
 
@@ -17,6 +18,8 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
     ```
 !!! note "If you are using Oracle"
     Please commit the changes after running the scripts given below.
+
+Follow the instructions below to upgrade your WSO2 API Manager server from WSO2 API-M 2.0.0 to 3.2.0.
     
 ### Preparing for Migration
 #### Disabling versioning in the registry configuration
@@ -26,8 +29,7 @@ If there are frequently updating registry properties, having the versioning enab
 Therefore, if registry versioning was enabled in WSO2 API-M 2.0.0 setup, it is **required** run the below scripts against **the database that is used by the registry**.
 
 !!! note
-    Alternatively, you can turn on the registry versioning in API Manager 3.2.0 and continue. However, this is
-    highly **NOT RECOMMENDED** and these configurations should only be changed once.
+    Alternatively, it is possible to turn on registry versioning in API Manager 3.2.0 and continue. However, this is highly **NOT RECOMMENDED** and these configurations should only be changed once.
 
 !!! info "Verifying registry versioning turned on in your current API-M and running the scripts"
     1. Open the `registry.xml` file in the `<OLD_API-M_HOME>/repository/conf` directory.
@@ -45,7 +47,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.0.0 setup, it is *
     !!! warning
         If the above configurations are already set as `false` you should not run the following scripts.
 
-    From API-M 3.0.0 onwards, by default, these configurations are set to `false` and now as these configurations are getting changed from the old setup to the new setup, you need to remove the versioning details from the database in order for the registry resources to work properly. As a result in order to remove the registry versioning details, you need to select the relevant DB type and run the script against the DB that the registry resides in. 
+    From API-M 3.0.0 onwards, by default, these configurations are set to `false` and now as these configurations are getting changed from the old setup to the new setup, you need to remove the versioning details from the database in order for the registry resources to work properly. As a result, in order to remove the registry versioning details, you need to select the relevant DB type and run the script against the DB that the registry resides in. 
 
     ??? info "DB Scripts"
         ```tab="DB2"
@@ -297,7 +299,7 @@ Follow the instructions below to move all the existing API Manager configuration
     -   API Manager databases
 
     !!! note
-        In API-M 3.2.0, a combined **SHARED_DB** has been introduced to keep both the use-related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the previous version, you need to configure `WSO2REG_DB` and `WSO2UM_DB` databases separately in API-M 3.2.0 to avoid any issues.
+        In API-M 3.2.0, a combined **SHARED_DB** has been introduced to keep both the user-related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the previous version, you need to configure `WSO2REG_DB` and `WSO2UM_DB` databases separately in API-M 3.2.0 to avoid any issues.
 
     **SHARED_DB** should point to the previous API-M version's `WSO2REG_DB`. The following example shows you how you can define the configurations related to a MySQL database.
 
@@ -326,7 +328,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as follows:
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -337,7 +339,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
     !!! attention "If you are using another DB type"
-        If you are using another DB type other than **MySQL**, or **Oracle**, when defining the DB related configurations in the `deployment.toml` file, you need to add the `driver` and `validationQuery` parameters additionally as mentioned below.
+        If you are using another DB type other than **MySQL** or **Oracle**, when defining the DB related configurations in the `deployment.toml` file, you need to add the `driver` and `validationQuery` parameters additionally as mentioned below.
 
         ```tab="MSSQL"
         [database.apim_db]
@@ -393,6 +395,7 @@ Follow the instructions below to move all the existing API Manager configuration
         In API-M 3.2.0, you do not need to configure the registry configurations as you did in the `<OLD_API-M_HOME>/repository/conf/registry.xml` file and the user database configurations as you did in in the `<OLD_API-M_HOME>/repository/conf/user-mgt.xml` file, as those configurations have been handled internally.
 
 6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
+
     -   Move your Synapse super tenant configurations.
          
          Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
@@ -401,15 +404,15 @@ Follow the instructions below to move all the existing API Manager configuration
          
          Copy the contents in the `<OLD_API-M_HOME>/repository/tenants` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/tenants` directory with the copied contents.
 
-    !!! warning
+    !!! Warning
         When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0.
 
-        -   /api/_RevokeAPI_.xml
-        -   /sequences/_cors_request_handler_.xml
-        -   /sequences/main.xml
-        -   /sequences/_throttle_out_handler.xml
-        -   /sequences/fault.xml
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/sequences/_throttle_out_handler_.xml`
+        -   `/sequences/fault.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`
                 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
@@ -431,7 +434,7 @@ Follow the instructions below to move all the existing API Manager configuration
         Taking the `log4j.properties` file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the log4j2.properties file.
 
     !!! note
-        Log4j2 has hot deployment support therefore the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -2427,7 +2430,7 @@ Follow the instructions below to move all the existing API Manager configuration
         );
         ```
 
-5.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks`, and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
+5.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! Attention
         In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in the previous version, you need to add the following configuration to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure the internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.0.0 and the primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
@@ -2568,7 +2571,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     5.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
-    6. Update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
+    6. Update the`<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
          ```
          [user_store]

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-320.md
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-530-to-5100) instead of below steps.    
 
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```    
@@ -249,7 +249,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.1.0 setup, it is *
         ```
     
 !!! warning "Not recommended"
-    If you decide to proceed with registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
+    If you decide to proceed with the registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
     
     ```
     [registry.static_configuration]
@@ -265,12 +265,14 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.1.0 setup, it is *
     - [Step 1 - Migrate the API Manager configurations](#step-1---migrate-the-api-manager-configurations)
     - [Step 2 - Upgrade API Manager to 3.2.0](#step-2---upgrade-api-manager-to-320)
     - [Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics](#step-3---optionally-migrate-the-configurations-for-wso2-api-m-analytics)
+      - [Step 3.1 - Configure WSO2 API-M Analytics 3.2.0](#step-31---configure-wso2-api-m-analytics-320)
+      - [Step 3.2 - Configure WSO2 API-M 3.2.0 for Analytics and Migrate data into new Analytics Database](#step-32---configure-wso2-api-m-320-for-analytics-and-migrate-data-into-new-analytics-database)
     - [Step 4 - Restart the WSO2 API-M 3.2.0 server](#step-4---restart-the-wso2-api-m-320-server)
 
 ### Step 1 - Migrate the API Manager configurations
 
 !!! warning
-    Do not copy entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration modal has been changed and now all the configurations are being done via a single file (deployment.toml). Instead, redo the configuration changes in the new configuration file.
+    Do not copy the entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration model has been changed and now all the configurations are done via a single file (`deployment.toml`). Instead, redo the configuration changes in the new configuration file.
 
 !!! note
     
@@ -283,9 +285,9 @@ Follow the instructions below to move all the existing API Manager configuration
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -298,7 +300,7 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! note
         In API-M 3.2.0, a combined SHARED_DB has been introduced to keep both the user related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the previous version, you need to configure WSO2REG_DB and WSO2UM_DB databases separately in API-M 3.2.0 to avoid any issues.
 
-    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
+    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. The following example shows you how you can define the configurations related to a MySQL database.
 
     ```
     [database.apim_db]
@@ -314,7 +316,7 @@ Follow the instructions below to move all the existing API Manager configuration
     password = "password"
     ```
 
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally, add a new entry as below to the `deployment.toml` if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -325,7 +327,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -378,7 +380,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.  Update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.  Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -390,29 +392,29 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! info
         In API-M 3.2.0, you do not need to configure the registry configurations as you did in the `<OLD_API-M_HOME>/repository/conf/registry.xml` file and the user database configurations as you did in in the `<OLD_API-M_HOME>/repository/conf/user-mgt.xml` file, as those configurations have been handled internally.
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/tenants` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/tenants` directory with the copied contents.
 
     !!! warning
-        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modification in API-M 3.2.0 version.
+        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0.
 
-        -   /api/\_RevokeAPI_.xml
-        -   /sequences/\_cors_request_handler_.xml
-        -   /sequences/main.xml
-        -   proxy-services/WorkflowCallbackService.xml
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7.  Move all your Execution plans from `<API-M_2.1.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7.  Move all your Execution plans from the `<API-M_2.1.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8.  If you manually added any custom OSGI bundles to the `<API-M_2.1.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8.  If you manually added any custom OSGI bundles to the `<API-M_2.1.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9.  If you manually added any JAR files to the `<API-M_2.1.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
@@ -422,7 +424,7 @@ Follow the instructions below to move all the existing API Manager configuration
         Taking the log4j.properties file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the log4j2.properties file.
 
     !!! note
-        Log4j2 has hot deployment support, and **Managing Logs** section has been removed from the Management Console. You can now use the log4j2.properties file to modify logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -512,11 +514,11 @@ Follow the instructions below to move all the existing API Manager configuration
 4.  Upgrade the WSO2 API Manager database from version 2.1.0 to version 3.2.0 by executing the relevant database script, from the scripts that are provided below, on the `WSO2AM_DB` database.
 
     !!! Attention
-        If there is a error similar to this when running the db script for ***mssql***
+        If there is an error similar to this when running the db script for ***MSSQL***
         ``` java
             SQL Error [5074] [S0001]: The object '<SOME_ID>' is dependent on column 'ACCESS_TOKEN'.
         ```
-        Use the ID mentioned in the error to run the sql statement below. This will drop a default constraint created by the database
+        Use the ID mentioned in the error to run the SQL statement below. This will drop a default constraint created by the database
         ```java
             ALTER TABLE AM_SUBSCRIPTION_KEY_MAPPING
             DROP CONSTRAINT <SOME_ID>;
@@ -2346,7 +2348,7 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! Attention
-        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.1.0 and primary keystore can be pointed to a keystore with a ceritificate, which has strong RSA key. 
+        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.1.0 and primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
 
         ``` java
         [keystore.primary]
@@ -2365,7 +2367,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -2380,7 +2382,7 @@ Follow the instructions below to move all the existing API Manager configuration
 6.  Upgrade the Identity component in WSO2 API Manager from version 5.3.0 to 5.10.0.
 
     ??? note "If you are using DB2"
-        Move indexes to the the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support newly added table indexes.
+        Move indexes to the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
 
         SQLADM or DBADM authority is required in order to invoke the `ADMIN_MOVE_TABLE` stored procedure. You must also have the appropriate object creation authorities, including authorities to issue the SELECT statement on the source table and to issue the INSERT statement on the target table.    
 
@@ -2422,7 +2424,7 @@ Follow the instructions below to move all the existing API Manager configuration
             <TABLE_SCHEMA_OF_IDN_OAUTH2_ACCESS_TOKEN_TABLE> and <TABLE_SCHEMA_OF_IDN_OAUTH2_AUTHORIZATION_CODE_TABLE> : Replace these schema’s with each respective schema for the table.
             ```
 
-        If you recieve an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
+        If you get an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
         spaces](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.admin.gui.doc/doc/c0023713.html) in the IBM documentation.          
         ``` java
         CREATE TABLESPACE SYSTOOLSPACE IN IBMCATGROUP
@@ -2461,7 +2463,7 @@ Follow the instructions below to move all the existing API Manager configuration
                     location: "step2"
                     schema: "identity"
                 -
-                    name: "TenantPortalMigrator" 
+                    name: "TenantPortalMigrator"
                     order: 11
                 ```
 
@@ -2475,7 +2477,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     5.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
-    6. Update <API-M_3.2.0_HOME>/repository/conf/deployment.toml file as follows, to point to the previous user store.
+    6. Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
         ```
         [user_store]
@@ -2485,7 +2487,7 @@ Follow the instructions below to move all the existing API Manager configuration
     7.  Start WSO2 API Manager 3.2.0 as follows to carry out the complete Identity component migration.
         
         !!! note 
-            If you are migrating your user stores to the new user store managers with the unique ID capabilities, Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step
+            If you are migrating your user stores to the new user store managers with the unique ID capabilities, follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
         
         ```tab="Linux / Mac OS"
         sh wso2server.sh -Dmigrate -Dcomponent=identity
@@ -2496,10 +2498,10 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finish completely and server get started.
+            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
         !!! note
-            Please note that if you want to use the latest user store, please update the <API-M_3.2.0_HOME>/repository/conf/deployment.toml as follows after the identity migration,
+            Please note that if you want to use the latest user store, please update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows after the identity migration,
 
             ```
             [user_store]
@@ -2530,7 +2532,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         -   Remove the `migration-resources` directory, which is in the `<API-M_3.2.0_HOME>` directory.
 
-        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
+        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
 
             ```
             -Dmigrate -Dcomponent=identity
@@ -2581,7 +2583,7 @@ Follow the instructions below to move all the existing API Manager configuration
     2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
@@ -2608,8 +2610,302 @@ Follow the instructions below to move all the existing API Manager configuration
 !!! warning
     This step is **only required** if you have WSO2 API-M-Analytics configured in your current deployment.
 
-!!! info
-    As you are upgrading from WSO2 API-M Analytics 2.1.0, in order migrate the configurations required to run WSO2 API-M Analytics for WSO2 API-M 3.2.0 carryout the same instructions as mentioned in [Upgrading from 2.5.0 to 3.2.0 - Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320/#step-3-optionally-migrate-the-configurations-for-wso2-api-m-analytics) section.
+Follow the steps below to migrate APIM Analytics 2.2.0 to APIM Analytics 3.2.0
+
+#### Step 3.1 - Configure WSO2 API-M Analytics 3.2.0
+
+!!! note
+    -   In API-M 3.2.0, the default Developer Portal and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
+
+1.  Download [WSO2 API Manager Analytics 3.2.0](http://wso2.com/api-management/).
+
+2.  Create a **new** database for the new statistics database and configure it in the `<APIM_ANALYTICS_3.2.0_HOME>/conf/dashboard/deployment.yaml` and `<API-M_ANALYTICS_3.2.0_HOME>/conf/worker/deployment.yaml` as follows:
+
+    The following is an example on how to configure the MySQL database configurations.
+
+    ``` java
+    #Data source for APIM Analytics
+    - name: APIM_ANALYTICS_DB
+        description: "The datasource used for APIM statistics aggregated data."
+        jndiConfig:
+        name: jdbc/APIM_ANALYTICS_DB
+        definition:
+        type: RDBMS
+        configuration:
+            jdbcUrl: 'jdbc:mysql://localhost:3306/analytics_db'
+            username: username
+            password: password
+            driverClassName: com.mysql.jdbc.Driver
+            minIdle: 5
+            maxPoolSize: 50
+            idleTimeout: 60000
+            connectionTestQuery: SELECT 1
+            validationTimeout: 30000
+            isAutoCommit: false
+    ```
+
+3.  Share the AM_DB with dashboard profile by adding following configuration to `<API-M_ANALYTICS_3.2.0_HOME>/conf/dashboard/deployment.yaml`. 
+
+    ``` java
+    #Main datasource used in API Manager
+    - name: AM_DB
+        description: Main datasource used by API Manager
+        jndiConfig:
+        name: jdbc/AM_DB
+        definition:
+        type: RDBMS
+        configuration:
+            jdbcUrl: "jdbc:mysql://localhost:3306/am_db"
+            username: root
+            password: root
+            driverClassName: com.mysql.jdbc.Driver
+            maxPoolSize: 10
+            idleTimeout: 60000
+            connectionTestQuery: SELECT 1
+            validationTimeout: 30000
+            isAutoCommit: false
+    ```
+
+4.  Copy the relevant JDBC driver OSGI bundle to the `<APIM_ANALYTICS_3.2.0_HOME>/lib` folder.
+
+    !!! info "To convert the JAR files to OSGi bundles, follow the steps given below."
+        1. Download the non-OSGi jar for the required third party product, and save it in a preferred directory in your machine.
+        2. Go to the `<API-M_ANALYTICS_HOME>/bin` directory. Run the command given below, to generate the converted file in the `<API-M_ANALYTICS_HOME>/lib` directory.
+
+        ```
+        ./jartobundle.sh <PATH_TO_NON-OSGi_JAR> ../lib
+        ```
+
+5.  Copy the keystores (i.e., `client-truststore.jks` , `wso2cabon.jks` and any other custom JKS) used in the previous version from `<OLD_API-M_ANALYTICS_HOME>/repository/resources/security` and replace the existing keystores in the `<NEW_API-M_ANALYTICS_HOME>/resources/security` directory.
+
+6.  Start the Worker and Dashboard profiles as below by navigating to `<API-M_ANALYTICS_3.2.0_HOME>/bin` location.
+
+    ```tab="Worker"
+    sh worker.sh
+    ```
+
+    ```tab="Dashboard"
+    sh dashboard.sh
+    ```
+
+
+#### Step 3.2 - Configure WSO2 API-M 3.2.0 for Analytics and Migrate data into new Analytics Database
+
+Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M Analytics migration in order to migrate the statistics related data.
+
+1.  Configure following statistics related datasources for WSO2 API Manager Analytics in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    !!! warning
+        The following 3 datasources should be configured in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml`
+         file **only until the stats migration is complete**. After the statistics migration is completed remove the `WSO2AM_STATS_DB` and `APIM_ANALYTICS_DB` datasource configurations, which were added for the old and new statistics databases, into the latter mentioned file.
+
+    The following is an example of how the configurations should be defined when using MySQL.
+
+    -   The first datasource points to the **migrated 3.2.0 AM_DB datasource.**
+
+        ``` java
+        [database.apim_db]
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/am_db"
+        username = "username"
+        password = "password"
+        ```
+
+    -   The second datasource points to the **WSO2 Data Analytics (WSO2 DAS) based previous datasource WSO2AM_STATS_DB for statistics** .
+
+        ``` java
+        [[datasource]]
+        id = "WSO2AM_STATS_DB"
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/stats_db"
+        driver = "com.mysql.jdbc.Driver"
+        validationQuery = "SELECT 1"
+        username = "username"
+        password = "password"
+        pool_options.defaultAutoCommit = true
+        ```
+
+    -   The third datasource points to the **WSO2 Stream Processor (WSO2 SP) based new datasource APIM\_ANALYTICS\_DB for statistics.**
+
+        ``` java
+        [[datasource]]
+        id = "APIM_ANALYTICS_DB"
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/analytics_db"
+        driver = "com.mysql.jdbc.Driver"
+        validationQuery = "SELECT 1"
+        username = "username"
+        password = "password"
+        pool_options.defaultAutoCommit = true
+        ```
+
+    !!! note
+        When performing Analytics migration in WSO2 API-M Analytics 3.2.0, you need to set the **defaultAutoCommit** value to **true** in the `APIM_ANALYTICS_DB` and `WSO2AM_STATS_DB` datasource configurations.
+
+    !!! info
+        Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MSSQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
+
+        !!! example
+
+            ```sql tab="MySQL"
+            ALTER DATABASE <DB-NAME> COLLATE latin1_general_cs ;
+            ```
+
+            ```sql tab="MSSQL"
+            ALTER DATABASE <DB-NAME> COLLATE SQL_Latin1_General_CP1_CS_AS ;
+            ```
+
+    ??? attention "If you are using another DB type"
+        If you are using another DB type other than **MySQL** or **Oracle**, when defining the DB related configurations in the `deployment.toml` file for API Manager database, you need to add the `driver` and `validationQuery` parameters optionally. For example MSSQL database configuration is as follows for the API Manager database.
+ 
+        ```
+        [database.apim_db]
+        type = "mssql"
+        url = "jdbc:sqlserver://localhost:1433;databaseName=mig_am_db;SendStringParametersAsUnicode=false"
+        username = "username"
+        password = "password"
+        driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        validationQuery = "SELECT 1"
+        ```
+
+2.  Download and copy the [org.wso2.carbon.apimgt.migrate.client-3.2.0-2.jar]({{base_path}}/assets/attachments/install-and-setup/org.wso2.carbon.apimgt.migrate.client-3.2.0-2.jar) to the `<API-M_3.2.0_HOME>/repository/components/dropins` folder.
+
+3.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
+
+4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    ``` java
+    [apim.analytics]
+    enable = false
+    ```
+
+5.  After setting the above configurations in place, start up the WSO2 API-M 3.2.0 server with the following command,
+ **if you had enabled Geo Location Based Statistics** in the old version setup.
+
+    ``` tab="Linux / Mac OS"
+    sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0
+    ```
+
+    ``` tab="Windows"
+    wso2server.bat -DmigrateStats=true -DmigrateFromVersion=2.2.0
+    ```
+    
+    If you had not enabled Geo Location Based Statistics in the old version setup, you have to start up the WSO2 
+    API-M 3.2.0 server with the following command to do the table-wise migration. (This will migrate all the tables except the `GeoLocationAgg` table.)
+
+    ``` tab="Linux / Mac OS"
+    sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp,ApiVersionPerAppAgg,ApiLastAccessSummary,ApiFaultyInvocationAgg,ApiUserBrowserAgg,ApiExeTimeDay,ApiExeTimeHour,ApiExeTimeMinute,ApiThrottledOutAgg,APIM_ReqCountAgg,ApiUserPerAppAgg
+    ```
+
+    ``` tab="Windows"
+    wso2server.bat -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp,ApiVersionPerAppAgg,ApiLastAccessSummary,ApiFaultyInvocationAgg,ApiUserBrowserAgg,ApiExeTimeDay,ApiExeTimeHour,ApiExeTimeMinute,ApiThrottledOutAgg,APIM_ReqCountAgg,ApiUserPerAppAgg
+    ```
+
+    !!! info "Table-wise Migration"
+        The migration client provides the support for table-wise migration. The following are the table names that need to be migrated.
+
+        ``` java
+        ApiPerDestinationAgg
+        ApiResPathPerApp
+        ApiVersionPerAppAgg
+        ApiLastAccessSummary
+        ApiFaultyInvocationAgg
+        ApiUserBrowserAgg
+        GeoLocationAgg
+        ApiExeTimeDay
+        ApiExeTimeHour
+        ApiExeTimeMinute
+        ApiThrottledOutAgg
+        APIM_ReqCountAgg
+        ApiUserPerAppAgg
+        ```
+
+        You need to use the `statTable` migration property for table wise migration.
+
+        For example, if you need to migrate only the `ApiPerDestinationAgg` and `ApiResPathPerApp` tables use the following command:
+
+        !!! attention
+            When you need to migrate multiple tables, the comma separated table names should be without spaces before or after the comma as shown below.
+
+
+        ``` java
+        sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp
+        ```
+
+    !!! info
+        If the default 3 datasource names/name, which you specified above, changed from the details that you specified in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file. Use the following command to pass the values to the migration client.
+
+        ??? info "Click here to see a code snippet of the definition of the datasource name"
+
+            ``` java
+            <jndiConfig>
+                <name>jdbc/WSO2AM_DB</name>
+            </jndiConfig>
+            ```
+
+        ``` tab="Format"
+        sh wso2server.sh -DdataSource=<AM_DATASOURCE_NAME>,<OLD_STAT_DATASOURCE_NAME>,<NEW_STAT_DATASOURCE_NAME>
+        ```
+
+        ``` tab="Example"
+        sh wso2server.sh -DdataSource=jdbc/WSO2AM_DB,jdbc/WSO2AM_STATS_DB,jdbc/APIM_ANALYTICS_DB
+        ```
+
+    !!! warning
+        The following warning message could occur during migration if the relevant consumer key does not exist in the `AM_APPLICATION_KEY_MAPPING` table due to Application deletion.
+
+        ``` java
+        ConsumerKey <consumerKey> does not contain in the AM_APPLICATION_KEY_MAPPING table.
+        ```
+
+        In such scenarios, you will face a migration data loss due to API or Application deletion.
+
+
+6.  Stop the WSO2 API-M server.
+
+7.  Execute the relevant database script, from the scripts that are provided below, on the `APIM_ANALYTICS_DB` database.
+
+    ??? info "DB Scripts"
+        ```tab="DB2"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ALTER COLUMN APIVERSION VARCHAR(254) NOT NULL;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APIVERSION,APICREATOR,APICREATORTENANTDOMAIN);
+        ```
+    
+        ```tab="MSSQL"
+        DECLARE @con_com as VARCHAR(8000);
+        SET @con_com = (SELECT name from sys.objects where parent_object_id=object_id('APILASTACCESSSUMMARY') AND type='PK');
+        EXEC('ALTER TABLE APILASTACCESSSUMMARY DROP CONSTRAINT ' + @con_com);
+        ALTER TABLE APILASTACCESSSUMMARY ALTER COLUMN APIVERSION VARCHAR(254) NOT NULL;
+        ALTER TABLE APILASTACCESSSUMMARYADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+    
+        ```tab="MySQL"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+        
+        ```tab="Oracle"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        COMMIT;
+        ```
+            
+        ```tab="PostgreSQL"
+        ALTER TABLE APILASTACCESSSUMMARY DROP CONSTRAINT APILASTACCESSSUMMARY_pkey;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+    
+8.  Remove the migration JAR copied under **Step 3.2 - 2**.  
+  
+9.  Remove both the old and new `WSO2AM_STATS_DB` and `APIM_ANALYTICS_DB` datasources from the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file, which you defined in **Step 3.2 - 1**.
+
+10.  Enable analytics in WSO2 API-M by setting the following configuration to true in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    ``` java
+    [apim.analytics]
+    enable = true
+    ```
 
 ### Step 4 - Restart the WSO2 API-M 3.2.0 server
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-320.md
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-550-to-5100) instead of below steps.    
 
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```
@@ -249,14 +249,14 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.2.0 setup, it is *
         ```
     
 !!! warning "Not recommended"
-    If you decide to proceed with registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
+    If you decide to proceed with the registry resource versioning enabled, add the following configuration to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
     
     ```
     [registry.static_configuration]
     enable=true
     ```
     
-    !!! note "NOTE"
+    !!! note "Note"
         Changing these configuration should only be done before the initial API-M Server startup. If changes are done after the initial startup, the registry resource created previously will not be available.
 
 - [Upgrading API Manager from 2.2.0 to 3.2.0](#upgrading-api-manager-from-220-to-320)
@@ -265,12 +265,14 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.2.0 setup, it is *
     - [Step 1 - Migrate the API Manager configurations](#step-1---migrate-the-api-manager-configurations)
     - [Step 2 - Upgrade API Manager to 3.2.0](#step-2---upgrade-api-manager-to-320)
     - [Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics](#step-3---optionally-migrate-the-configurations-for-wso2-api-m-analytics)
+      - [Step 3.1 - Configure WSO2 API-M Analytics 3.2.0](#step-31---configure-wso2-api-m-analytics-320)
+      - [Step 3.2 - Configure WSO2 API-M 3.2.0 for Analytics and Migrate data into new Analytics Database](#step-32---configure-wso2-api-m-320-for-analytics-and-migrate-data-into-new-analytics-database)
     - [Step 4 - Restart the WSO2 API-M 3.2.0 server](#step-4---restart-the-wso2-api-m-320-server)
 
 ### Step 1 - Migrate the API Manager configurations
 
 !!! warning
-    Do not copy entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration modal has been changed and now all the configurations are being done via a single file (deployment.toml). Instead, redo the configuration changes in the new configuration file.
+    Do not copy the entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration model has been changed and now all the configurations are done via a single file (`deployment.toml`). Instead, redo the configuration changes in the new configuration file.
 
 !!! note
     
@@ -283,9 +285,9 @@ Follow the instructions below to move all the existing API Manager configuration
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -296,9 +298,9 @@ Follow the instructions below to move all the existing API Manager configuration
     -   API Manager databases
 
     !!! note
-        In API-M 3.2.0, a combined SHARED_DB has been introduced to keep both the user related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the previous version, you need to configure WSO2REG_DB and WSO2UM_DB databases separately in API-M 3.2.0 to avoid any issues.
+        In API-M 3.2.0, a combined SHARED_DB has been introduced to keep both the user related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the previous version, you need to configure `WSO2REG_DB` and `WSO2UM_DB` databases separately in API-M 3.2.0 to avoid any issues.
 
-    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
+    `SHARED_DB` should be pointed to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
 
     ```
     [database.apim_db]
@@ -314,7 +316,7 @@ Follow the instructions below to move all the existing API Manager configuration
     password = "password"
     ```
 
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally add a new entry as below to the `deployment.toml` if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -325,7 +327,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -378,7 +380,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.  Update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.  Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -390,39 +392,39 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! info
         In API-M 3.2.0, you do not need to configure the registry configurations as you did in the `<OLD_API-M_HOME>/repository/conf/registry.xml` file and the user database configurations as you did in in the `<OLD_API-M_HOME>/repository/conf/user-mgt.xml` file, as those configurations have been handled internally.
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/tenants` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/tenants` directory with the copied contents.
 
     !!! warning
-        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modificatiosn in API-M 3.2.0 version.
+        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0 version.
 
-        -   /api/\_RevokeAPI_.xml
-        -   /sequences/\_cors_request_handler_.xml
-        -   /sequences/main.xml
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`
         
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7.  Move all your Execution plans from `<API-M_2.2.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7.  Move all your Execution plans from the `<API-M_2.2.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8.  If you manually added any custom OSGI bundles to the `<API-M_2.2.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8.  If you manually added any custom OSGI bundles to the `<API-M_2.2.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9.  If you manually added any JAR files to the `<API-M_2.2.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
-10. WSO2 API Manager 3.2.0 has been upgraded to log4j2 (from log4j). You will notice that there is a log4j2.properties file in the `<API-M_3.2.0_HOME>/repository/conf/` directory instead of the log4j.properties file. Follow [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to migrate your existing log4j.properties file to log4j2.properties file.
+10. WSO2 API Manager 3.2.0 has been upgraded to log4j2 (from log4j). You will notice that there is a log4j2.properties file in the `<API-M_3.2.0_HOME>/repository/conf/` directory instead of the log4j.properties file. Follow [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to migrate your existing `log4j.properties` file to `log4j2.properties` file.
 
     !!! warning
         Taking the log4j.properties file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the log4j2.properties file.
 
     !!! note
-        Log4j2 has hot deployment support, and **Managing Logs** section has been removed from the Management Console. You can now use the log4j2.properties file to modify logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -465,11 +467,11 @@ Follow the instructions below to move all the existing API Manager configuration
                 A message about PowerShell appears, and the shell changes to PowserShell (PS).
 
             2.  Run the PowerShell script by passing the location of the gateway artifacts that you need to migrate.
-            ```
-            .\apim220_to_apim320_gateway_artifact_migrator.ps1 <API-definitions-path>
-            ```
+                ```
+                .\apim220_to_apim320_gateway_artifact_migrator.ps1 <API-definitions-path>
+                ```
 
-            `<API-definition-path>` - This is the location where the WSO2 API-M 3.2.0 API definitions, which were copied from the API-M 2.2.0 deployment, reside.
+                `<API-definition-path>` - This is the location where the WSO2 API-M 3.2.0 API definitions, which were copied from the API-M 2.2.0 deployment, reside.
 
             -   Super Tenant - `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default`
 
@@ -485,11 +487,11 @@ Follow the instructions below to move all the existing API Manager configuration
                 A message about PowerShell appears, and the shell changes to PowserShell (PS).
 
             2.  Run the PowerShell script by passing the location of the gateway artifacts that you need to migrate.
-            ```
-            .\apim220_to_apim320_gateway_artifact_migrator_for_tenants.ps1 <API-definitions-path>
-            ```
+                ```
+                .\apim220_to_apim320_gateway_artifact_migrator_for_tenants.ps1 <API-definitions-path>
+                ```
 
-            `<API-definition-path>` - This is the location where the WSO2 API-M 3.2.0 API definitions, which were copied from the API-M 2.2.0 deployment, reside.
+                `<API-definition-path>` - This is the location where the WSO2 API-M 3.2.0 API definitions, which were copied from the API-M 2.2.0 deployment, reside.
 
             -   Tenant - `<API-M_3.2.0_HOME>/repository/tenants`
 
@@ -2142,7 +2144,7 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! Attention
-        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.2.0 and primary keystore can be pointed to a keystore with a ceritificate, which has strong RSA key. 
+        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.2.0 and primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
 
         ``` java
         [keystore.primary]
@@ -2161,7 +2163,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -2176,7 +2178,7 @@ Follow the instructions below to move all the existing API Manager configuration
 6.  Upgrade the Identity component in WSO2 API Manager from version 5.5.0 to 5.10.0.
 
     ??? note "If you are using DB2"
-        Move indexes to the the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support newly added table indexes.
+        Move indexes to the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
 
         SQLADM or DBADM authority is required in order to invoke the `ADMIN_MOVE_TABLE` stored procedure. You must also have the appropriate object creation authorities, including authorities to issue the SELECT statement on the source table and to issue the INSERT statement on the target table.    
 
@@ -2218,7 +2220,7 @@ Follow the instructions below to move all the existing API Manager configuration
             <TABLE_SCHEMA_OF_IDN_OAUTH2_ACCESS_TOKEN_TABLE> and <TABLE_SCHEMA_OF_IDN_OAUTH2_AUTHORIZATION_CODE_TABLE> : Replace these schema’s with each respective schema for the table.
             ```
 
-        If you recieve an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
+        If you get an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
         spaces](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.admin.gui.doc/doc/c0023713.html) in the IBM documentation.          
         ``` java
         CREATE TABLESPACE SYSTOOLSPACE IN IBMCATGROUP
@@ -2245,7 +2247,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Make sure you have enabled migration by setting the `migrationEnable` element to `true` as shown above. You have to remove the following 3 steps from migration-config.yaml which is included under version: "5.10.0"
+            Make sure you have enabled migration by setting the `migrationEnable` element to `true` as shown above. You have to remove the following 3 steps from the `migration-config.yaml` file which is included under version: "5.10.0"
                 ```
                 -
                     name: "MigrationValidator"
@@ -2263,7 +2265,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     4.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
-    5. Update <API-M_3.2.0_HOME>/repository/conf/deployment.toml file as follows, to point to the previous user store.
+    5. Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
         ```
         [user_store]
@@ -2273,7 +2275,7 @@ Follow the instructions below to move all the existing API Manager configuration
     6.  Start WSO2 API Manager 3.2.0 as follows to carry out the complete Identity component migration.
         
         !!! note
-            If you are migrating your user stores to the new user store managers with the unique ID capabilities, Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step
+            If you are migrating your user stores to the new user store managers with the unique ID capabilities, follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
         
         ```tab="Linux / Mac OS"
         sh wso2server.sh -Dmigrate -Dcomponent=identity
@@ -2284,10 +2286,10 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finish completely and server get started.
+            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
         !!! note
-            Please note that if you want to use the latest user store, please update the <API-M_3.2.0_HOME>/repository/conf/deployment.toml as follows after the identity migration,
+            Please note that if you want to use the latest user store, please update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows after the identity migration,
 
             ```
             [user_store]
@@ -2318,7 +2320,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         -   Remove the `migration-resources` directory, which is in the `<API-M_3.2.0_HOME>` directory.
 
-        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
+        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
 
             ```
             -Dmigrate -Dcomponent=identity
@@ -2360,7 +2362,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
 8.  Re-index the artifacts in the registry.
 
-    1.  Run the [reg-index.sql]({{base_path}}/assets/attachments/install-and-setup/reg-index.sql) script against the `SHARED_DB` database.
+    1.  Run the [reg-index.sql]({{base_path}}/assets/attachments/install-and-setup/reg-index.sql) script against the configured `SHARED_DB` database.
 
         !!! note
             Please note that depending on the number of records in the REG_LOG table, this script will take a considerable amount of time to finish. Do not stop the execution of script until it is completed.
@@ -2368,7 +2370,7 @@ Follow the instructions below to move all the existing API Manager configuration
     2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
@@ -2395,8 +2397,302 @@ Follow the instructions below to move all the existing API Manager configuration
 !!! warning
     This step is **only required** if you have WSO2 API-M-Analytics configured in your current deployment.
 
-!!! info
-    As you are upgrading from WSO2 API-M Analytics 2.2.0, in order migrate the configurations required to run WSO2 API-M Analytics for WSO2 API-M 3.2.0 carryout the same instructions as mentioned in [Upgrading from 2.5.0 to 3.2.0 - Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320/#step-3-optionally-migrate-the-configurations-for-wso2-api-m-analytics) section.
+Follow the steps below to migrate APIM Analytics 2.2.0 to APIM Analytics 3.2.0
+
+#### Step 3.1 - Configure WSO2 API-M Analytics 3.2.0
+
+!!! note
+    -   In API-M 3.2.0, the default Developer Portal and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
+
+1.  Download [WSO2 API Manager Analytics 3.2.0](http://wso2.com/api-management/).
+
+2.  Create a **new** database for the new statistics database and configure it in the `<APIM_ANALYTICS_3.2.0_HOME>/conf/dashboard/deployment.yaml` and `<API-M_ANALYTICS_3.2.0_HOME>/conf/worker/deployment.yaml` as follows:
+
+    The following is an example on how to configure the MySQL database configurations.
+
+    ``` java
+    #Data source for APIM Analytics
+    - name: APIM_ANALYTICS_DB
+        description: "The datasource used for APIM statistics aggregated data."
+        jndiConfig:
+        name: jdbc/APIM_ANALYTICS_DB
+        definition:
+        type: RDBMS
+        configuration:
+            jdbcUrl: 'jdbc:mysql://localhost:3306/analytics_db'
+            username: username
+            password: password
+            driverClassName: com.mysql.jdbc.Driver
+            minIdle: 5
+            maxPoolSize: 50
+            idleTimeout: 60000
+            connectionTestQuery: SELECT 1
+            validationTimeout: 30000
+            isAutoCommit: false
+    ```
+
+3.  Share the AM_DB with dashboard profile by adding following configuration to `<API-M_ANALYTICS_3.2.0_HOME>/conf/dashboard/deployment.yaml`. 
+
+    ``` java
+    #Main datasource used in API Manager
+    - name: AM_DB
+        description: Main datasource used by API Manager
+        jndiConfig:
+        name: jdbc/AM_DB
+        definition:
+        type: RDBMS
+        configuration:
+            jdbcUrl: "jdbc:mysql://localhost:3306/am_db"
+            username: root
+            password: root
+            driverClassName: com.mysql.jdbc.Driver
+            maxPoolSize: 10
+            idleTimeout: 60000
+            connectionTestQuery: SELECT 1
+            validationTimeout: 30000
+            isAutoCommit: false
+    ```
+
+4.  Copy the relevant JDBC driver OSGI bundle to the `<APIM_ANALYTICS_3.2.0_HOME>/lib` folder.
+
+    !!! info "To convert the JAR files to OSGi bundles, follow the steps given below."
+        1. Download the non-OSGi jar for the required third party product, and save it in a preferred directory in your machine.
+        2. Go to the `<API-M_ANALYTICS_HOME>/bin` directory. Run the command given below, to generate the converted file in the `<API-M_ANALYTICS_HOME>/lib` directory.
+
+        ```
+        ./jartobundle.sh <PATH_TO_NON-OSGi_JAR> ../lib
+        ```
+
+5.  Copy the keystores (i.e., `client-truststore.jks` , `wso2cabon.jks` and any other custom JKS) used in the previous version from `<OLD_API-M_ANALYTICS_HOME>/repository/resources/security` and replace the existing keystores in the `<NEW_API-M_ANALYTICS_HOME>/resources/security` directory.
+
+6.  Start the Worker and Dashboard profiles as below by navigating to `<API-M_ANALYTICS_3.2.0_HOME>/bin` location.
+
+    ```tab="Worker"
+    sh worker.sh
+    ```
+
+    ```tab="Dashboard"
+    sh dashboard.sh
+    ```
+
+
+#### Step 3.2 - Configure WSO2 API-M 3.2.0 for Analytics and Migrate data into new Analytics Database
+
+Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M Analytics migration in order to migrate the statistics related data.
+
+1.  Configure following statistics related datasources for WSO2 API Manager Analytics in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    !!! warning
+        The following 3 datasources should be configured in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml`
+         file **only until the stats migration is complete**. After the statistics migration is completed remove the `WSO2AM_STATS_DB` and `APIM_ANALYTICS_DB` datasource configurations, which were added for the old and new statistics databases, into the latter mentioned file.
+
+    The following is an example of how the configurations should be defined when using MySQL.
+
+    -   The first datasource points to the **migrated 3.2.0 AM_DB datasource.**
+
+        ``` java
+        [database.apim_db]
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/am_db"
+        username = "username"
+        password = "password"
+        ```
+
+    -   The second datasource points to the **WSO2 Data Analytics (WSO2 DAS) based previous datasource WSO2AM_STATS_DB for statistics** .
+
+        ``` java
+        [[datasource]]
+        id = "WSO2AM_STATS_DB"
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/stats_db"
+        driver = "com.mysql.jdbc.Driver"
+        validationQuery = "SELECT 1"
+        username = "username"
+        password = "password"
+        pool_options.defaultAutoCommit = true
+        ```
+
+    -   The third datasource points to the **WSO2 Stream Processor (WSO2 SP) based new datasource APIM\_ANALYTICS\_DB for statistics.**
+
+        ``` java
+        [[datasource]]
+        id = "APIM_ANALYTICS_DB"
+        type = "mysql"
+        url = "jdbc:mysql://localhost:3306/analytics_db"
+        driver = "com.mysql.jdbc.Driver"
+        validationQuery = "SELECT 1"
+        username = "username"
+        password = "password"
+        pool_options.defaultAutoCommit = true
+        ```
+
+    !!! note
+        When performing Analytics migration in WSO2 API-M Analytics 3.2.0, you need to set the **defaultAutoCommit** value to **true** in the `APIM_ANALYTICS_DB` and `WSO2AM_STATS_DB` datasource configurations.
+
+    !!! info
+        Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MSSQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
+
+        !!! example
+
+            ```sql tab="MySQL"
+            ALTER DATABASE <DB-NAME> COLLATE latin1_general_cs ;
+            ```
+
+            ```sql tab="MSSQL"
+            ALTER DATABASE <DB-NAME> COLLATE SQL_Latin1_General_CP1_CS_AS ;
+            ```
+
+    ??? attention "If you are using another DB type"
+        If you are using another DB type other than **MySQL** or **Oracle**, when defining the DB related configurations in the `deployment.toml` file for API Manager database, you need to add the `driver` and `validationQuery` parameters optionally. For example MSSQL database configuration is as follows for the API Manager database.
+ 
+        ```
+        [database.apim_db]
+        type = "mssql"
+        url = "jdbc:sqlserver://localhost:1433;databaseName=mig_am_db;SendStringParametersAsUnicode=false"
+        username = "username"
+        password = "password"
+        driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        validationQuery = "SELECT 1"
+        ```
+
+2.  Download and copy the [org.wso2.carbon.apimgt.migrate.client-3.2.0-2.jar]({{base_path}}/assets/attachments/install-and-setup/org.wso2.carbon.apimgt.migrate.client-3.2.0-2.jar) to the `<API-M_3.2.0_HOME>/repository/components/dropins` folder.
+
+3.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
+
+4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    ``` java
+    [apim.analytics]
+    enable = false
+    ```
+
+5.  After setting the above configurations in place, start up the WSO2 API-M 3.2.0 server with the following command,
+ **if you had enabled Geo Location Based Statistics** in the old version setup.
+
+    ``` tab="Linux / Mac OS"
+    sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0
+    ```
+
+    ``` tab="Windows"
+    wso2server.bat -DmigrateStats=true -DmigrateFromVersion=2.2.0
+    ```
+    
+    If you had not enabled Geo Location Based Statistics in the old version setup, you have to start up the WSO2 
+    API-M 3.2.0 server with the following command to do the table-wise migration. (This will migrate all the tables except the `GeoLocationAgg` table.)
+
+    ``` tab="Linux / Mac OS"
+    sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp,ApiVersionPerAppAgg,ApiLastAccessSummary,ApiFaultyInvocationAgg,ApiUserBrowserAgg,ApiExeTimeDay,ApiExeTimeHour,ApiExeTimeMinute,ApiThrottledOutAgg,APIM_ReqCountAgg,ApiUserPerAppAgg
+    ```
+
+    ``` tab="Windows"
+    wso2server.bat -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp,ApiVersionPerAppAgg,ApiLastAccessSummary,ApiFaultyInvocationAgg,ApiUserBrowserAgg,ApiExeTimeDay,ApiExeTimeHour,ApiExeTimeMinute,ApiThrottledOutAgg,APIM_ReqCountAgg,ApiUserPerAppAgg
+    ```
+
+    !!! info "Table-wise Migration"
+        The migration client provides the support for table-wise migration. The following are the table names that need to be migrated.
+
+        ``` java
+        ApiPerDestinationAgg
+        ApiResPathPerApp
+        ApiVersionPerAppAgg
+        ApiLastAccessSummary
+        ApiFaultyInvocationAgg
+        ApiUserBrowserAgg
+        GeoLocationAgg
+        ApiExeTimeDay
+        ApiExeTimeHour
+        ApiExeTimeMinute
+        ApiThrottledOutAgg
+        APIM_ReqCountAgg
+        ApiUserPerAppAgg
+        ```
+
+        You need to use the `statTable` migration property for table wise migration.
+
+        For example, if you need to migrate only the `ApiPerDestinationAgg` and `ApiResPathPerApp` tables use the following command:
+
+        !!! attention
+            When you need to migrate multiple tables, the comma separated table names should be without spaces before or after the comma as shown below.
+
+
+        ``` java
+        sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.2.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp
+        ```
+
+    !!! info
+        If the default 3 datasource names/name, which you specified above, changed from the details that you specified in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file. Use the following command to pass the values to the migration client.
+
+        ??? info "Click here to see a code snippet of the definition of the datasource name"
+
+            ``` java
+            <jndiConfig>
+                <name>jdbc/WSO2AM_DB</name>
+            </jndiConfig>
+            ```
+
+        ``` tab="Format"
+        sh wso2server.sh -DdataSource=<AM_DATASOURCE_NAME>,<OLD_STAT_DATASOURCE_NAME>,<NEW_STAT_DATASOURCE_NAME>
+        ```
+
+        ``` tab="Example"
+        sh wso2server.sh -DdataSource=jdbc/WSO2AM_DB,jdbc/WSO2AM_STATS_DB,jdbc/APIM_ANALYTICS_DB
+        ```
+
+    !!! warning
+        The following warning message could occur during migration if the relevant consumer key does not exist in the `AM_APPLICATION_KEY_MAPPING` table due to Application deletion.
+
+        ``` java
+        ConsumerKey <consumerKey> does not contain in the AM_APPLICATION_KEY_MAPPING table.
+        ```
+
+        In such scenarios, you will face a migration data loss due to API or Application deletion.
+
+
+6.  Stop the WSO2 API-M server.
+
+7.  Execute the relevant database script, from the scripts that are provided below, on the `APIM_ANALYTICS_DB` database.
+
+    ??? info "DB Scripts"
+        ```tab="DB2"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ALTER COLUMN APIVERSION VARCHAR(254) NOT NULL;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APIVERSION,APICREATOR,APICREATORTENANTDOMAIN);
+        ```
+    
+        ```tab="MSSQL"
+        DECLARE @con_com as VARCHAR(8000);
+        SET @con_com = (SELECT name from sys.objects where parent_object_id=object_id('APILASTACCESSSUMMARY') AND type='PK');
+        EXEC('ALTER TABLE APILASTACCESSSUMMARY DROP CONSTRAINT ' + @con_com);
+        ALTER TABLE APILASTACCESSSUMMARY ALTER COLUMN APIVERSION VARCHAR(254) NOT NULL;
+        ALTER TABLE APILASTACCESSSUMMARYADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+    
+        ```tab="MySQL"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+        
+        ```tab="Oracle"
+        ALTER TABLE APILASTACCESSSUMMARY DROP PRIMARY KEY;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        COMMIT;
+        ```
+            
+        ```tab="PostgreSQL"
+        ALTER TABLE APILASTACCESSSUMMARY DROP CONSTRAINT APILASTACCESSSUMMARY_pkey;
+        ALTER TABLE APILASTACCESSSUMMARY ADD PRIMARY KEY (APINAME,APICREATOR,APIVERSION,APICREATORTENANTDOMAIN);
+        ```
+    
+8.  Remove the migration JAR copied under **Step 3.2 - 2**.  
+  
+9.  Remove both the old and new `WSO2AM_STATS_DB` and `APIM_ANALYTICS_DB` datasources from the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file, which you defined in **Step 3.2 - 1**.
+
+10.  Enable analytics in WSO2 API-M by setting the following configuration to true in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+
+    ``` java
+    [apim.analytics]
+    enable = true
+    ```
 
 ### Step 4 - Restart the WSO2 API-M 3.2.0 server
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-320.md
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-560-to-5100) instead of below steps.
 
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```
@@ -21,7 +21,7 @@ Follow the instructions below to upgrade your WSO2 API Manager server **from WSO
 ### Preparing for Migration
 #### Disabling versioning in the registry configuration
 
-If there are frequently updating registry properties, having the versioning enabled for registry resources can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.2.0.
+If there are frequently updating registry properties, having the versioning enabled for registry resources in the registry can lead to unnecessary growth in the registry related tables in the database. To avoid this, versioning has been disabled by default in API Manager 3.2.0.
 
 Therefore, if registry versioning was enabled in WSO2 API-M 2.5.0 setup, it is **required** run the below scripts against **the database that is used by the registry**. Follow the below steps to achieve this.
 
@@ -249,7 +249,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.5.0 setup, it is *
         ```
 
 !!! warning "Not Recommeded"
-    If you decided to proceed with registry resource versioning enabled, add the following configuration to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file. 
+    If you decide to proceed with the registry resource versioning enabled, add the following configuration to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager.
     
     ```
     [registry.static_configuration]
@@ -272,7 +272,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.5.0 setup, it is *
 ### Step 1 - Migrate the API Manager configurations
 
 !!! warning
-    Do not copy entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration modal has been changed and now all the configurations are being done via a single file (deployment.toml). Instead, redo the configuration changes in the new configuration file.
+    Do not copy the entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration model has been changed and now all the configurations are done via a single file (`deployment.toml`). Instead, redo the configuration changes in the new configuration file.
 
 !!! note
     
@@ -285,9 +285,9 @@ Follow the instructions below to move all the existing API Manager configuration
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -300,7 +300,7 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! note
         In API-M 3.2.0, a combined **SHARED_DB** has been introduced to keep both the user related data (`WSO2UM_DB`) and the registry data (`WSO2REG_DB`). If you have used separate DBs for user management and registry in the older version, you need to configure WSO2REG_DB and WSO2UM_DB databases separately in API-M 3.2.0 to avoid any issues.
 
-    **SHARED_DB** should be pointed to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
+    **SHARED_DB** should be pointed to the previous API-M version's `WSO2REG_DB`. The following example shows you how you can define the configurations related to a MySQL database.
 
     ```
     [database.apim_db]
@@ -315,7 +315,7 @@ Follow the instructions below to move all the existing API Manager configuration
     username = "username"
     password = "password"
     ```
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally add a new entry as below to the `deployment.toml` if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -326,7 +326,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -379,7 +379,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.  Update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.  Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -391,7 +391,7 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! info
         In API-M 3.2.0, you do not need to configure the registry configurations as you did in the `<OLD_API-M_HOME>/repository/conf/registry.xml` file and the user database configurations as you did in in the `<OLD_API-M_HOME>/repository/conf/user-mgt.xml` file, as those configurations have been handled internally.
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
@@ -400,20 +400,20 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! warning
         When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0 version.
 
-        -   /api/\_RevokeAPI_.xml
-        -   /sequences/\_cors_request_handler_.xml
-        -   /sequences/main.xml
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`
 
     !!! attention          
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7. Move all your Execution plans from `<API-M_2.5.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7. Move all your Execution plans from the `<API-M_2.5.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8. If you manually added any custom OSGI bundles to the `<API-M_2.5.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8. If you manually added any custom OSGI bundles to the `<API-M_2.5.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9. If you manually added any JAR files to the `<API-M_2.5.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
@@ -423,7 +423,7 @@ Follow the instructions below to move all the existing API Manager configuration
         Taking the log4j.properties file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the log4j2.properties file.
 
     !!! note
-        Log4j2 has hot deployment support, and **Managing Logs** section has been removed from the Management Console. You can now use the log4j2.properties file to modify logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -1982,7 +1982,7 @@ Follow the instructions below to move all the existing API Manager configuration
 4.  Copy the keystores (i.e., `client-truststore.jks` , `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! Attention
-        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.5.0 and primary keystore can be pointed to a keystore with a ceritificate, which has strong RSA key. 
+        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.5.0 and the primary keystore can be pointed to a keystore with a certificate, which has strong a RSA key. 
 
         ``` java
         [keystore.primary]
@@ -2001,7 +2001,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -2016,8 +2016,8 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Upgrade the Identity component in WSO2 API Manager from version 5.6.0 to 5.10.0.
 
     ??? note "If you are using DB2"
-        Move indexes to the the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN`  and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need
-        to be moved to the existing TS32K tablespace in order to support newly added table indexes.
+        Move indexes to the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN`  and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need
+        to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
 
         SQLADM or DBADM authority is required in order to invoke the `ADMIN_MOVE_TABLE` stored procedure. You must also have the appropriate object creation authorities, including authorities to issue the SELECT statement on the source table and to issue the INSERT statement on the target table.
         
@@ -2060,7 +2060,7 @@ Follow the instructions below to move all the existing API Manager configuration
             <TABLE_SCHEMA_OF_IDN_OAUTH2_ACCESS_TOKEN_TABLE> and <TABLE_SCHEMA_OF_IDN_OAUTH2_AUTHORIZATION_CODE_TABLE> : Replace these schema’s with each respective schema for the table.
             ```
 
-        If you recieve an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE tablespaces](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.admin.gui.doc/doc/c0023713.html) in the IBM documentation.           
+        If you get an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE tablespaces](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.admin.gui.doc/doc/c0023713.html) in the IBM documentation.           
 
         ``` java
         CREATE TABLESPACE SYSTOOLSPACE IN IBMCATGROUP
@@ -2104,13 +2104,14 @@ Follow the instructions below to move all the existing API Manager configuration
 
     4.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
     
-    5. Update <API-M_3.2.0_HOME>/repository/conf/deployment.toml file as follows, to point to the previous user store.
+    5. Update the`<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
         ```
         [user_store]
         type = "database"
         ```
-    6. It is recommended to migrate your user stores to the new user store managers with the unique ID capabilities. This provides a significat improvement in performance. Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
+    
+    6. It is recommended to migrate your user stores to the new user store managers with the unique ID capabilities. This provides a significant improvement in performance. Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
     
     7.  Start WSO2 API Manager 3.2.0 as follows to carry out the complete Identity component migration.
     
@@ -2123,10 +2124,10 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finish completely and server get started.
+            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
         
         !!! note
-            Please note that if you want to use the latest user store, please update the <API-M_3.2.0_HOME>/repository/conf/deployment.toml as follows after the identity migration,
+            Please note that if you want to use the latest user store, please update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows after the identity migration,
 
             ```
             [user_store]
@@ -2137,6 +2138,7 @@ Follow the instructions below to move all the existing API Manager configuration
             When running the above step if you encounter the following error message, please follow the steps in this section. Please note that this error could occur only if the identity tables contain a huge volume of data.
 
             Sample exception stack trace is given below.
+
             ```
             ERROR {org.wso2.carbon.registry.core.dataaccess.TransactionManager} -  Failed to start new registry transaction. {org.wso2.carbon.registry.core.dataaccess.TransactionManager} org.apache.tomcat.jdbc.pool.PoolExhaustedException: [pool-30-thread-11] Timeout: Pool empty. Unable to fetch a connection in 60 seconds, none available[size:50; busy:50; idle:0; lastwait:60000
             ```
@@ -2149,7 +2151,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
             2.  Re-run the command above.
 
-            **Make sure to revert the change done in Step 1 , after the migration is complete.**
+            **Make sure to revert the change done in Step 1, after the migration is complete.**
 
     8.  After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -2157,7 +2159,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         -   Remove the `migration-resources` directory, which is in the `<API-M_3.2.0_HOME>` directory.
 
-        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
+        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
 
             ```
             -Dmigrate -Dcomponent=identity
@@ -2208,7 +2210,7 @@ Follow the instructions below to move all the existing API Manager configuration
     2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
@@ -2240,13 +2242,13 @@ Follow the steps below to migrate APIM Analytics 2.5.0 to APIM Analytics 3.2.0
 #### Step 3.1 - Configure WSO2 API-M Analytics 3.2.0
 
 !!! note
-    -   In API-M 3.2.0, the default Store and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
+    -   In API-M 3.2.0, the default Developer Portal and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
 
 1.  Download [WSO2 API Manager Analytics 3.2.0](http://wso2.com/api-management/).
 
 2.  Create a **new** database for the new statistics database and configure it in the `<APIM_ANALYTICS_3.2.0_HOME>/conf/dashboard/deployment.yaml` and `<API-M_ANALYTICS_3.2.0_HOME>/conf/worker/deployment.yaml` as follows:
 
-    In this example shows to configure MySQL database configurations.
+    The following is an example on how to configure the MySQL database configurations.
 
     ``` java
     #Data source for APIM Analytics
@@ -2293,7 +2295,7 @@ Follow the steps below to migrate APIM Analytics 2.5.0 to APIM Analytics 3.2.0
 
 4.  Copy the relevant JDBC driver OSGI bundle to the `<APIM_ANALYTICS_3.2.0_HOME>/lib` folder.
 
-    !!! info "To convert the jar files to OSGi bundles, follow the steps given below."
+    !!! info "To convert the JAR files to OSGi bundles, follow the steps given below."
         1. Download the non-OSGi jar for the required third party product, and save it in a preferred directory in your machine.
         2. Go to the `<API-M_ANALYTICS_HOME>/bin` directory. Run the command given below, to generate the converted file in the `<API-M_ANALYTICS_HOME>/lib` directory.
 
@@ -2321,10 +2323,10 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
 1.  Configure following statistics related datasources for WSO2 API Manager Analytics in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
     !!! warning
-        The following 3 datasources should be configured in the `<API-M_3.2.0_HOME>/repository/conf/ deployment.toml`
+        The following 3 datasources should be configured in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml`
          file **only until the stats migration is complete**. After the statistics migration is completed remove the `WSO2AM_STATS_DB` and `APIM_ANALYTICS_DB` datasource configurations, which were added for the old and new statistics databases, into the latter mentioned file.
 
-    The following in an example of how the configurations should be defined when using MySQL.
+    The following is an example of how the configurations should be defined when using MySQL.
 
     -   The first datasource points to the **migrated 3.2.0 AM_DB datasource.**
 
@@ -2368,7 +2370,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
         When performing Analytics migration in WSO2 API-M Analytics 3.2.0, you need to set the **defaultAutoCommit** value to **true** in the `APIM_ANALYTICS_DB` and `WSO2AM_STATS_DB` datasource configurations.
 
     !!! info
-        Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MS SQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
+        Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MSSQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
 
         !!! example
 
@@ -2376,7 +2378,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
             ALTER DATABASE <DB-NAME> COLLATE latin1_general_cs ;
             ```
 
-            ```sql tab="MS SQL"
+            ```sql tab="MSSQL"
             ALTER DATABASE <DB-NAME> COLLATE SQL_Latin1_General_CP1_CS_AS ;
             ```
 
@@ -2397,7 +2399,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
 
 3.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
 
-4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/ deployment.toml` file.
+4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
     ``` java
     [apim.analytics]
@@ -2416,7 +2418,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
     ```
     
     If you had not enabled Geo Location Based Statistics in the old version setup, you have to start up the WSO2 
-    API-M 3.2.0 server with the following command to do the table-wise migration. (this will migrate all the tables except GeoLocationAgg table)
+    API-M 3.2.0 server with the following command to do the table-wise migration. (This will migrate all the tables except the `GeoLocationAgg` table.)
 
     ``` tab="Linux / Mac OS"
     sh wso2server.sh -DmigrateStats=true -DmigrateFromVersion=2.5.0 -DstatTable=ApiPerDestinationAgg,ApiResPathPerApp,ApiVersionPerAppAgg,ApiLastAccessSummary,ApiFaultyInvocationAgg,ApiUserBrowserAgg,ApiExeTimeDay,ApiExeTimeHour,ApiExeTimeMinute,ApiThrottledOutAgg,APIM_ReqCountAgg,ApiUserPerAppAgg
@@ -2427,7 +2429,7 @@ Follow the instructions below to configure WSO2 API Manager for the WSO2 API-M A
     ```
 
     !!! info "Table-wise Migration"
-        The migration client provides the support for table-wise migration. The following are the table names that needs to be migrated.
+        The migration client provides the support for table-wise migration. The following are the table names that need to be migrated.
 
         ``` java
         ApiPerDestinationAgg

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-320.md
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-5100) instead of below steps.
 
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```
@@ -250,7 +250,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.6.0 setup, it is *
         ```
     
 !!! warning "Not recommended"
-    If you decide to proceed with registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
+    If you decide to proceed with the registry resource versioning enabled, add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
     
     ```
     [registry.static_configuration]
@@ -274,7 +274,7 @@ Therefore, if registry versioning was enabled in WSO2 API-M 2.6.0 setup, it is *
 ### Step 1 - Migrate the API Manager configurations
 
 !!! warning
-    Do not copy entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration modal has been changed and now all the configurations are being done via a single file (deployment.toml). Instead, redo the configuration changes in the new configuration file.
+    Do not copy the entire configuration files from the current version of WSO2 API Manager to the new one, as the configuration model has been changed and now all the configurations are done via a single file (`deployment.toml`). Instead, redo the configuration changes in the new configuration file.
 
 !!! note
     
@@ -287,9 +287,9 @@ Follow the instructions below to move all the existing API Manager configuration
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -318,7 +318,7 @@ Follow the instructions below to move all the existing API Manager configuration
     password = "password"
     ```
 
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally add a new entry as below to the `deployment.toml` if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -329,7 +329,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -382,7 +382,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.  Update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.  Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -394,39 +394,39 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! info
         In API-M 3.2.0, you do not need to configure the registry configurations as you did in the `<OLD_API-M_HOME>/repository/conf/registry.xml` file and the user database configurations as you did in in the `<OLD_API-M_HOME>/repository/conf/user-mgt.xml` file, as those configurations have been handled internally.
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/tenants` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/tenants` directory with the copied contents.
 
     !!! warning
-        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modificatiosn in API-M 3.2.0 version.
+        When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0 version.
 
-        -   /api/\_RevokeAPI_.xml
-        -   /sequences/\_cors_request_handler_.xml
-        -   /sequences/main.xml
-        -   /proxy-services/WorkflowCallbackService.xml        
+        -   `/api/_RevokeAPI_.xml`
+        -   `/sequences/_cors_request_handler_.xml`
+        -   `/sequences/main.xml`
+        -   `/proxy-services/WorkflowCallbackService.xml`        
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7.  Move all your Execution plans from `<API-M_2.6.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7.  Move all your Execution plans from the `<API-M_2.6.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8.  If you manually added any custom OSGI bundles to the `<API-M_2.6.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8.  If you manually added any custom OSGI bundles to the `<API-M_2.6.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9.  If you manually added any JAR files to the `<API-M_2.6.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
-10. WSO2 API Manager 3.2.0 has been upgraded to log4j2 (from log4j). You will notice that there is a log4j2.properties file in the `<API-M_3.2.0_HOME>/repository/conf/` directory instead of the log4j.properties file. Follow [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to migrate your existing log4j.properties file to log4j2.properties file.
+10. WSO2 API Manager 3.2.0 has been upgraded to log4j2 (from log4j). You will notice that there is a log4j2.properties file in the `<API-M_3.2.0_HOME>/repository/conf/` directory instead of the log4j.properties file. Follow [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to migrate your existing `log4j.properties` file to the `log4j2.properties` file.
 
     !!! warning
-        Taking the log4j.properties file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the log4j2.properties file.
+        Taking the log4j.properties file from your old WSO2 API-M Server and adding it to WSO2 API-M Server 3.2.0 will no longer work. Refer [Upgrading to Log4j2]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-to-log4j2) to see how to add a log appender or a logger to the `log4j2.properties` file.
 
     !!! note
-        Log4j2 has hot deployment support, and **Managing Logs** section has been removed from the Management Console. You can now use the log4j2.properties file to modify logging configurations without restarting the server.
+        Log4j2 has hot deployment support; therefore, the **Managing Logs** section has been removed from the Management Console. You can now use the `log4j2.properties` file to modify the required logging configurations without restarting the server.
 
 ### Step 2 - Upgrade API Manager to 3.2.0
 
@@ -2346,7 +2346,7 @@ Follow the instructions below to move all the existing API Manager configuration
 4.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! Attention
-        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate tha   t has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.6.0 and primary keystore can be pointed to a keystore with a ceritificate, which has strong RSA key. 
+        In API Manager 3.2.0, it is required to use a certificate with the RSA key size greater than 2048. If you have used a certificate that has a weak RSA key (key size less than 2048) in previous version, you need to add the following configuration to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file to configure internal and primary keystores. You should point the internal keystore to the keystore copied from API Manager 2.6.0 and the primary keystore can be pointed to a keystore with a certificate, which has a strong RSA key. 
 
         ``` java
         [keystore.primary]
@@ -2365,7 +2365,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -2380,7 +2380,7 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Upgrade the Identity component in WSO2 API Manager from version 5.7.0 to 5.10.0.
 
     ??? note "If you are using DB2"
-        Move indexes to the the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support newly added table indexes.
+        Move indexes to the TS32K Tablespace. The index tablespace in the `IDN_OAUTH2_ACCESS_TOKEN` and `IDN_OAUTH2_AUTHORIZATION_CODE` tables need to be moved to the existing TS32K tablespace in order to support the newly added table indexes.
 
         SQLADM or DBADM authority is required in order to invoke the `ADMIN_MOVE_TABLE` stored procedure. You must also have the appropriate object creation authorities, including authorities to issue the SELECT statement on the source table and to issue the INSERT statement on the target table.    
 
@@ -2422,7 +2422,7 @@ Follow the instructions below to move all the existing API Manager configuration
             <TABLE_SCHEMA_OF_IDN_OAUTH2_ACCESS_TOKEN_TABLE> and <TABLE_SCHEMA_OF_IDN_OAUTH2_AUTHORIZATION_CODE_TABLE> : Replace these schema’s with each respective schema for the table.
             ```
 
-        If you recieve an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
+        If you receive an error due to missing `SYSTOOLSPACE` or `SYSTOOLSTMPSPACE` tablespaces, create those tablespaces manually using the following script prior to executing the stored procedure given above. For more information, see [SYSTOOLSPACE and SYSTOOLSTMPSPACE table
         spaces](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.admin.gui.doc/doc/c0023713.html) in the IBM documentation.          
         ``` java
         CREATE TABLESPACE SYSTOOLSPACE IN IBMCATGROUP
@@ -2469,7 +2469,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     4.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
-    5. Update <API-M_3.2.0_HOME>/repository/conf/deployment.toml file as follows, to point to the previous user store.
+    5. Update the`<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
         ```
         [user_store]
@@ -2479,7 +2479,7 @@ Follow the instructions below to move all the existing API Manager configuration
     6.  Start WSO2 API Manager 3.2.0 as follows to carry out the complete Identity component migration.
         
         !!! note
-            If you are migrating your user stores to the new user store managers with the unique ID capabilities, Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step
+            If you are migrating your user stores to the new user store managers with the unique ID capabilities, follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
                     
         ```tab="Linux / Mac OS"
         sh wso2server.sh -Dmigrate -Dcomponent=identity
@@ -2490,10 +2490,10 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finish completely and server get started.
+            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
         
         !!! note
-            Please note that if you want to use the latest user store, please update the <API-M_3.2.0_HOME>/repository/conf/deployment.toml as follows after the identity migration,
+            Please note that if you want to use the latest user store, please update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows after the identity migration,
 
             ```
             [user_store]
@@ -2524,7 +2524,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         -   Remove the `migration-resources` directory, which is in the `<API-M_3.2.0_HOME>` directory.
 
-        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
+        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
 
             ```
             -Dmigrate -Dcomponent=identity
@@ -2549,7 +2549,7 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         Note:  If cross tenant API subscriptions exist, the migration will be aborted. 
-        To ignore this, Please set the flag ``ignoreCrossTenantSubscriptions`` to true as below.
+        To ignore this, set the flag `ignoreCrossTenantSubscriptions` to `true` as below.
     
         ``` tab="Linux / Mac OS"
         sh wso2server.sh -DignoreCrossTenantSubscriptions=true -DmigrateFromVersion=2.6.0
@@ -2574,12 +2574,12 @@ Follow the instructions below to move all the existing API Manager configuration
     2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
 
-    3.  Add the following configuration in `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+    3.  Add the following configuration into the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
         
         ```
         [indexing]
@@ -2640,14 +2640,14 @@ The schema for table APIMALLALERT is changed in analytics version 3.2. So it is 
 prior to the migration so that it will be recreated at the server startup using the new script. 
 If you think that you require the already available data in the above table you can take a backup of it. But the above 
 table is just used to maintain a summary of all types of alerts in a single place. As 
-these alerts are persisted individually as well in tables specific for the type of the alert, you will not loose any
+these alerts are persisted individually as well in tables specific for the type of the alert, you will not lose any
 data related to alerts by dropping this table.
 
 ??? info "DB Scripts"
      DROP TABLE APIMALLALERT;
 
 !!! note
-    Type and name of a column of few tables were changed through WUM in analytics version 2.6. It is important to 
+    The type and name of columns of a few tables were changed through WUM in analytics version 2.6. It is important to 
     add the above change into your database prior to migration. So execute the below queries which checks whether 
     the above change is already available in your DB and if not, it will add the relevant change. Ensure to replace 
     "Enter Analytics DB name here" with the correct DB name in the scripts.
@@ -2764,7 +2764,7 @@ data related to alerts by dropping this table.
     select alter_geolocation_table_if_coloumn_not_exist(<Enter Analytics DB name here>);
     ```
     
-    ```tab="db2"
+    ```tab="DB2"
     CREATE OR REPLACE PROCEDURE alter_geolocation_table_if_coloumn_not_exist ()
          MODIFIES SQL DATA
          LANGUAGE SQL
@@ -2797,7 +2797,7 @@ data related to alerts by dropping this table.
 
 !!! note
     -   In API-M 2.6.0, when working with API-M Analytics, only the worker profile has been used by default and dashboard profile is used only when there are custom dashboards.
-    -   Now with API-M 3.1.0 onwards, both the worker and dashboard profiles are being used. The default Store and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
+    -   Now with API-M 3.1.0 onwards, both the worker and dashboard profiles are being used. The default Developer Portal and Publisher dashboards are now being moved to the Analytics dashboard server side and they have been removed from the API-M side.
     -   The same set of DBs will be used in the Analytics side and additionally you need to share the WSO2AM_DB with the dashboard server node.
 
 !!! info
@@ -2890,6 +2890,7 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
         ```
         ./jartobundle.sh <PATH_TO_NON-OSGi_JAR> ../lib
         ```
+
 5.  Copy the keystores (i.e., `client-truststore.jks` , `wso2cabon.jks` and any other custom JKS) used in the previous version from `<OLD_API-M_ANALYTICS_HOME>/repository/resources/security` and replace the existing keystores in the `<NEW_API-M_ANALYTICS_HOME>/resources/security` directory.
 
 6.  Start the Worker and Dashboard profiles as below by navigating to `<API-M_ANALYTICS_3.2.0_HOME>/bin` location.
@@ -2909,10 +2910,10 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
 
 Enable analytics in WSO2 API-M by setting the following configuration to true in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
-    ``` java
-    [apim.analytics]
-    enable = true
-    ```
+``` java
+[apim.analytics]
+enable = true
+```
 
 ### Step 4 - Restart the WSO2 API-M 3.2.0 server
 
@@ -2942,6 +2943,6 @@ This concludes the upgrade process.
     The migration client that you use in this guide automatically migrates your tenants, workflows, external user stores, etc. to the upgraded environment. Therefore, there is no need to migrate them manually.
 
 !!! note
-    If you are using a migrated API and wants to consume it via an application which supports JWT authentication (default type in API-M 3.2.0), you need to republish the API. Without republishing the API, JWT authentication doesn't work as it looks for a local entry which will get populated while publishing.
+    If you are using a migrated API and want to consume it via an application which supports JWT authentication (default type in API-M 3.2.0), you need to republish the API. Without republishing the API, JWT authentication doesn't work as it looks for a local entry which will get populated while publishing.
 
     You can consume the migrated API via an OAuth2 application without an issue.

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-320.md
@@ -1,6 +1,6 @@
 # Upgrading API Manager from 3.0.0 to 3.2.0
   
-The following information describes how to upgrade your API Manager server **from APIM 3.0.0 to 3.2.0**.
+The following information describes how to upgrade your API Manager server **from API-M 3.0.0 to 3.2.0**.
 
 !!! note
     Before you follow this section, see [Upgrading Process]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-process) for more information.
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first you have to follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-5100) instead of below steps.
   
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```
@@ -250,7 +250,7 @@ But, if registry versioning was enabled by you in WSO2 API-M 3.0.0 setup, it is 
         ```
     
 !!! warning "Not recommended"
-    If you decide to proceed with registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
+    If you decide to proceed with the registry resource versioning enabled, add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
     
     ```
     [registry.static_configuration]
@@ -287,9 +287,9 @@ Follow the instructions below to move all the existing API Manager configuration
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -302,7 +302,7 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! note
         If you have used separate DBs for user management and registry in the previous version, you need to configure WSO2REG_DB and WSO2UM_DB databases separately in API-M 3.2.0 to avoid any issues.
 
-    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
+    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. The following example shows you how you can define the configurations related to a MySQL database.
 
     ```
     [database.apim_db]
@@ -318,7 +318,7 @@ Follow the instructions below to move all the existing API Manager configuration
     password = "password"
     ```
 
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally add a new entry as below to the `deployment.toml` if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -329,7 +329,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -382,7 +382,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.   If you have used separate DB for user management, you need to update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.   If you have used separate DB for user management, you need to Update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -392,7 +392,7 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
 
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
@@ -401,17 +401,17 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! warning
         When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0 version.
 
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/proxy-services/WorkflowCallbackService.xml`
         
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7.  Move all your Execution plans from `<API-M_3.0.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7.  Move all your Execution plans from the `<API-M_3.0.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8.  If you manually added any custom OSGI bundles to the `<API-M_3.0.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8.  If you manually added any custom OSGI bundles to the `<API-M_3.0.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9.  If you manually added any JAR files to the `<API-M_3.0.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
@@ -1277,7 +1277,7 @@ Follow the instructions below to move all the existing API Manager configuration
 4.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -1323,9 +1323,10 @@ Follow the instructions below to move all the existing API Manager configuration
                     name: "TenantPortalMigrator"
                     order: 11
                 ```
+    
     4.  Copy the `org.wso2.carbon.is.migration-x.x.x.jar` from the `<IS_MIGRATION_TOOL_HOME>/dropins` directory to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
-    5. Update <API-M_3.2.0_HOME>/repository/conf/deployment.toml file as follows, to point to the previous user store.
+    5. Update the`<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the previous user store.
     
         ```
         [user_store]
@@ -1335,7 +1336,7 @@ Follow the instructions below to move all the existing API Manager configuration
     6.  Start WSO2 API Manager 3.2.0 as follows to carry out the complete Identity component migration.
         
         !!! note        
-            If you are migrating your user stores to the new user store managers with the unique ID capabilities, Follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step
+            If you are migrating your user stores to the new user store managers with the unique ID capabilities, follow the guidelines given in the [Migrating User Store Managers](https://is.docs.wso2.com/en/5.10.0/setup/migrating-userstore-managers/) before moving to the next step.
                     
         ```tab="Linux / Mac OS"
         sh wso2server.sh -Dmigrate -Dcomponent=identity
@@ -1346,10 +1347,10 @@ Follow the instructions below to move all the existing API Manager configuration
         ```
 
         !!! note
-            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finish completely and server get started.
+            Please note that depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do not stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
         !!! note
-            Please note that if you want to use the latest user store, please update the <API-M_3.2.0_HOME>/repository/conf/deployment.toml as follows after the identity migration,
+            Please note that if you want to use the latest user store, please update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows after the identity migration,
 
             ```
             [user_store]
@@ -1372,7 +1373,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
             2.  Re-run the command above.
 
-            **Make sure to revert the change done in Step 1 , after the migration is complete.**
+            **Make sure to revert the change done in Step 1, after the migration is complete.**
 
     7.  After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -1380,7 +1381,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
         -   Remove the `migration-resources` directory, which is in the `<API-M_3.2.0_HOME>` directory.
 
-        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
+        -   If you ran WSO2 API-M as a Windows Service when doing the identity component migration, then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the wso2server.bat file.
 
             ```
             -Dmigrate -Dcomponent=identity
@@ -1425,17 +1426,17 @@ Follow the instructions below to move all the existing API Manager configuration
     1.  Run the [reg-index.sql]({{base_path}}/assets/attachments/install-and-setup/reg-index.sql) script against the `SHARED_DB` database.
 
         !!! note
-            Please note that depending on the number of records in the REG_LOG table, this script will take a considerable amount of time to finish. Do not stop the execution of script until it is completed.
+            Please note that depending on the number of records in the REG_LOG table, this script will take a considerable amount of time to finish. Do not stop the execution of the script until it is completed.
 
-    2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
+    2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) in to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
 
-    3.  Add the following configuration in to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+    3.  Add the following configuration into the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
         
         ```
         [indexing]
@@ -1497,7 +1498,7 @@ Upgrade the WSO2 API Manager Analytics database from version 3.0.0 to version 3.
 #### Step 3.2 - Configure WSO2 API-M Analytics 3.2.0
 
 !!! info
-    Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MS SQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
+    Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to the database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MS SQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
 
     !!! example
 
@@ -1604,10 +1605,10 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
 
 Enable analytics in WSO2 API-M by setting the following configuration to true in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
-    ``` java
-    [apim.analytics]
-    enable = true
-    ```
+``` java
+[apim.analytics]
+enable = true
+```
 
 ### Step 4 - Restart the WSO2 API-M 3.2.0 server
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-320.md
@@ -9,7 +9,7 @@ The following information describes how to upgrade your API Manager server **fro
     If you are using WSO2 Identity Server (WSO2 IS) as a Key Manager, first follow the instructions in [Upgrading WSO2 IS as the Key Manager to 5.10.0]({{base_path}}/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5100).    
 
 !!! note "If you are using PostgreSQL"
-    The DB user needs to have superuser role to run the migration client and the relevant scripts
+    The DB user needs to have the `superuser` role to run the migration client and the relevant scripts
     ```
     ALTER USER <user> WITH SUPERUSER;
     ```
@@ -250,7 +250,7 @@ But, if registry versioning was enabled by you in WSO2 API-M 3.1.0 setup, it is 
         ```
     
 !!! warning "Not recommended"
-    If you decide to proceed with registry resource versioning enabled, Add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
+    If you decide to proceed with the registry resource versioning enabled, add the following configuration to the `<NEW_API-M_HOME>/repository/conf/deployment.toml` file of new WSO2 API Manager. 
     
     ```
     [registry.static_configuration]
@@ -260,10 +260,16 @@ But, if registry versioning was enabled by you in WSO2 API-M 3.1.0 setup, it is 
     !!! note "NOTE"
         Changing these configuration should only be done before the initial API-M Server startup. If changes are done after the initial startup, the registry resource created previously will not be available.
 
--   [Step 1 - Migrate the API Manager configurations](#step-1-migrate-the-api-manager-configurations)
--   [Step 2 - Upgrade API Manager to 3.2.0](#step-2-upgrade-api-manager-to-320)
--   [Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics](#step-3-optionally-migrate-the-configurations-for-wso2-api-m-analytics)
--   [Step 4 - Restart the WSO2 API-M 3.2.0 server](#step-4-restart-the-wso2-api-m-320-server)
+- [Upgrading API Manager from 3.1.0 to 3.2.0](#upgrading-api-manager-from-310-to-320)
+    - [Preparing for Migration](#preparing-for-migration)
+      - [Disabling versioning in the registry configuration if it was enabled](#disabling-versioning-in-the-registry-configuration-if-it-was-enabled)
+    - [Step 1 - Migrate the API Manager configurations](#step-1---migrate-the-api-manager-configurations)
+    - [Step 2 - Upgrade API Manager to 3.2.0](#step-2---upgrade-api-manager-to-320)
+    - [Step 3 - Optionally, migrate the configurations for WSO2 API-M Analytics](#step-3---optionally-migrate-the-configurations-for-wso2-api-m-analytics)
+      - [Step 3.1 - Migrating the Analytics Database](#step-31---migrating-the-analytics-database)
+      - [Step 3.2 - Configure WSO2 API-M Analytics 3.2.0](#step-32---configure-wso2-api-m-analytics-320)
+      - [Step 3.3 - Configure WSO2 API-M 3.2.0 for Analytics](#step-33---configure-wso2-api-m-320-for-analytics)
+    - [Step 4 - Restart the WSO2 API-M 3.2.0 server](#step-4---restart-the-wso2-api-m-320-server)
 
 ### Step 1 - Migrate the API Manager configurations
 
@@ -277,13 +283,13 @@ Follow the instructions below to move all the existing API Manager configuration
     - For more information on the configurations in the new configuration model, see the [Configuration Catalog]({{base_path}}/reference/config-catalog).
     - For more information on the mapping between WSO2 API Manager's old configuration files and the new `deployment.toml` file, see [Understanding the New Configuration Model]({{base_path}}/reference/understanding-the-new-configuration-model).
 
-1.  Back up all databases in your API Manager instances along with the Synapse configurations of all the tenants and the super tenant.
+1.  Backup all databases in your API Manager instances along with the Synapse configurations of all the tenants and the super tenant.
 
     -   The Synapse configurations of the super tenant are in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory.
 
-    -   The Synapse configurations of tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
+    -   The Synapse configurations of the tenants are in the `<OLD_API-M_HOME>/repository/tenants` directory.
 
-    -   If you use a **clustered/distributed API Manager setup** , back up the available configurations in the **API Gateway** node.
+    -   If you use a **clustered/distributed API Manager setup**, back up the available configurations in the **API Gateway** node.
 
 2.  Download [WSO2 API Manager 3.2.0](http://wso2.com/api-management/).
 
@@ -296,7 +302,7 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! note
         If you have used separate DBs for user management and registry in the previous version, you need to configure WSO2REG_DB and WSO2UM_DB databases separately in API-M 3.2.0 to avoid any issues.
 
-    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. This example shows to configure MySQL database configurations.
+    SHARED_DB should point to the previous API-M version's `WSO2REG_DB`. The following example shows you how you can define the configurations related to a MySQL database.
 
     ```
     [database.apim_db]
@@ -312,7 +318,7 @@ Follow the instructions below to move all the existing API Manager configuration
     password = "password"
     ```
 
-    Optionally add a new entry as below to the `deployment.toml` if you have configured a seperate user management database in the previous API-M version.
+    Optionally, add a new entry as shown below into the `deployment.toml` file if you have configured a separate user management database in the previous API-M version.
 
     ```
     [database.user]
@@ -323,7 +329,7 @@ Follow the instructions below to move all the existing API Manager configuration
     ```
 
     !!! note
-        If you have configured WSO2CONFIG_DB in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` as below.
+        If you have configured the `WSO2CONFIG_DB` in the previous API-M version, add a new entry to the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows:
 
         ```
         [database.config]
@@ -376,7 +382,7 @@ Follow the instructions below to move all the existing API Manager configuration
         validationQuery = "SELECT 1 FROM SYSIBM.SYSDUMMY1"
         ```
 
-4.   If you have used separate DB for user management, you need to update `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
+4.   If you have used separate DB for user management, you need to update the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file as follows, to point to the correct database for user management purposes.
 
     ```
     [realm_manager]
@@ -386,7 +392,7 @@ Follow the instructions below to move all the existing API Manager configuration
 5.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
 
 
-6.  Move all your Synapse configurations to API-M 3.2.0 pack.
+6.  Move all your Synapse configurations to the API-M 3.2.0 pack.
     -   Move your Synapse super tenant configurations.
         Copy the contents in the `<OLD_API-M_HOME>/repository/deployment/server/synapse-configs/default` directory and replace the contents in the `<API-M_3.2.0_HOME>/repository/deployment/server/synapse-configs/default` directory with the copied contents.
     -   Move all your tenant Synapse configurations.
@@ -395,17 +401,17 @@ Follow the instructions below to move all the existing API Manager configuration
     !!! warning
         When moving the Synapse configurations, **do not replace** the following set of files as they contain some modifications in API-M 3.2.0 version.
 
-        -   /proxy-services/WorkflowCallbackService.xml
+        -   `/proxy-services/WorkflowCallbackService.xml`
 
     !!! attention 
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Gateway** node.
 
-7.  Move all your Execution plans from `<API-M_3.1.0_HOME>/repository/deployment/server/executionplans` directory to `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
+7.  Move all your Execution plans from the `<API-M_3.1.0_HOME>/repository/deployment/server/executionplans` directory to the `<API-M_3.2.0_HOME>/repository/deployment/server/executionplans` directory.
 
     !!! note
         If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Traffic Manager** node.
 
-8.  If you manually added any custom OSGI bundles to the `<API-M_3.1.0_HOME>/repository/components/dropins` directory, copy those to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
+8.  If you manually added any custom OSGI bundles to the `<API-M_3.1.0_HOME>/repository/components/dropins` directory, copy them to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory. 
 
 9.  If you manually added any JAR files to the `<API-M_3.1.0_HOME>/repository/components/lib` directory, copy those and paste them in the `<API-M_3.2.0_HOME>/repository/components/lib` directory.
 
@@ -1122,7 +1128,7 @@ Follow the instructions below to move all the existing API Manager configuration
 4.  Copy the keystores (i.e., `client-truststore.jks`, `wso2cabon.jks` and any other custom JKS) used in the previous version and replace the existing keystores in the `<API-M_3.2.0_HOME>/repository/resources/security` directory.
 
     !!! note "If you have enabled Secure Vault"
-        If you have enabled secure vault in the previous API-M version, you need to add the property values again according to the new config modal and run the script as below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
+        If you have enabled Secure Vault in the previous API-M version, you need to add the property values again according to the new config model and run the script as shown below. Please refer [Encrypting Passwords in Configuration files]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords) for more details.
 
         ```tab="Linux"
         ./ciphertool.sh -Dconfigure
@@ -1162,17 +1168,17 @@ Follow the instructions below to move all the existing API Manager configuration
     1.  Run the [reg-index.sql]({{base_path}}/assets/attachments/install-and-setup/reg-index.sql) script against the `SHARED_DB` database.
 
         !!! note
-            Please note that depending on the number of records in the REG_LOG table, this script will take a considerable amount of time to finish. Do not stop the execution of script until it is completed.
+            Please note that depending on the number of records in the REG_LOG table, this script will take a considerable amount of time to finish. Do not stop the execution of the script until it is completed.
 
-    2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
+    2.  Add the [tenantloader-1.0.jar]({{base_path}}/assets/attachments/install-and-setup/tenantloader-1.0.jar) to the `<API-M_3.2.0_HOME>/repository/components/dropins` directory.
 
         !!! attention
-            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Store and Publisher** nodes.
+            If you are working with a **clustered/distributed API Manager setup**, follow this step on the **Developer Portal and Publisher** nodes.
 
         !!! note
             You need to do this step, if you have **multiple tenants** only.
 
-    3.  Add the following configuration in to `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
+    3.  Add the following configuration into the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
         
         ```
         [indexing]
@@ -1181,7 +1187,7 @@ Follow the instructions below to move all the existing API Manager configuration
         Note that you need to increase the value of `re_indexing` by one each time you need to re-index.
         
         !!! info 
-             If you use a clustered/distributed API Manager setup, do the above change in deployment.toml of Publisher and Devportal nodes
+             If you use a clustered/distributed API Manager setup, do the above change in the `deployment.toml` file of the Publisher and the Developer Portal nodes.
              
     4.  If the `<API-M_3.2.0_HOME>/solr` directory exists, take a backup and thereafter delete it.
 
@@ -1202,7 +1208,7 @@ The schema for table APIMALLALERT is changed in analytics version 3.2. So it is 
 prior to the migration so that it will be recreated at the server startup using the new script. 
 If you think that you require the already available data in the above table you can take a backup of it. But the above 
 table is just used to maintain a summary of all types of alerts in a single place. As 
-these alerts are persisted individually as well in tables specific for the type of the alert, you will not loose any
+these alerts are persisted individually as well in tables specific for the type of the alert, you will not lose any
 data related to alerts by dropping this table.
 
 ??? info "DB Scripts"
@@ -1223,16 +1229,16 @@ data related to alerts by dropping this table.
 
     2. Import the custom dashboard.
          
-         Copy the generated JSON file to the `<API-M_ANALYTICS_HOME>/wso2/dashboard/resources/dashboard` directory.
+         Copy the generated JSON file into the `<API-M_ANALYTICS_HOME>/wso2/dashboard/resources/dashboard` directory.
      
-The GraphQL operations stored in analytics database are persisted in a sorted way from 3.2 onwards due to a performance 
+The GraphQL operations stored in the analytics database are persisted in a sorted way from 3.2 onwards due to a performance 
 improvement. If you use GraphQL APIs please follow the instruction below to sort the already existing data on above
 columns
 
 1.  Configure the datasource used for WSO2 API Manager Analytics in the 
 `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file of WSO2 API Manager.
 
-    The following in an example of how the configurations should be defined when using MySQL.
+    The following is an example of how the configurations should be defined when using MySQL.
 
    
     -   The datasource points to the analytics datasource configured in the version 3.1
@@ -1254,7 +1260,7 @@ columns
         value to **true** in the `APIM_ANALYTICS_DB` 
 
     ??? attention "If you are using another DB type"
-        If you are using another DB type other than *MySQL** or **Oracle**, when defining the DB related configurations in the `deployment.toml` file for API Manager database, you need to add the `driver` and `validationQuery` parameters optionally. For example MSSQL database configuration is as follows for the API Manager database.
+        If you are using another DB type other than **MySQL** or **Oracle**, when defining the DB related configurations in the `deployment.toml` file for API Manager database, you need to add the `driver` and `validationQuery` parameters optionally. For example MSSQL database configuration is as follows for the API Manager database.
  
         ```
         [database.apim_db]
@@ -1270,7 +1276,7 @@ columns
 
 3.  Copy the relevant JDBC driver to the `<API-M_3.2.0_HOME>/repository/components/lib` folder.
 
-4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/ deployment.toml` file.
+4.  Make sure that WSO2 API-M Analytics is disabled in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
     ``` java
     [apim.analytics]
@@ -1302,7 +1308,7 @@ columns
 #### Step 3.2 - Configure WSO2 API-M Analytics 3.2.0
 
 !!! info
-    Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MS SQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
+    Sometimes due to case insensitivity of primary keys in aggregation tables, primary key violation errors are thrown when you try to insert a new record with the same value as an existing record. To overcome this, you need to add encoding and collation to the database when the Analytics DB is created (i.e., before the tables are created). For more information on collation, see [MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-names.html) or [MS SQL](https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15) based on the database that you are using. Sample commands are provided below.
 
     !!! example
 
@@ -1384,7 +1390,7 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
 
 4.  Copy the relevant JDBC driver OSGI bundle to the `<APIM_ANALYTICS_3.2.0_HOME>/lib` folder.
 
-    !!! info "To convert the jar files to OSGi bundles, follow the steps given below."
+    !!! info "To convert the JAR files to OSGi bundles, follow the steps given below."
         1. Download the non-OSGi jar for the required third party product, and save it in a preferred directory in your machine.
         2. Go to the `<API-M_ANALYTICS_HOME>/bin` directory. Run the command given below, to generate the converted file in the `<API-M_ANALYTICS_HOME>/lib` directory.
 
@@ -1392,7 +1398,7 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
         ./jartobundle.sh <PATH_TO_NON-OSGi_JAR> ../lib
         ```
 
-5.  Start the Worker and Dashboard profiles as below by navigating to `<API-M_ANALYTICS_3.2.0_HOME>/bin` location.
+5.  Start the Worker and Dashboard profiles as below by navigating to the `<API-M_ANALYTICS_3.2.0_HOME>/bin` directory.
     
     ```tab="Worker"
     sh worker.sh
@@ -1403,16 +1409,16 @@ Follow the instructions below to configure WSO2 API Manager Analytics for the WS
     ```
 
 !!! note
-    If you have developed any custom dashboards in API-M 3.0.0 Analytics using Stream Processor, you will be able to use the same in API-M Anaytics 3.1.0 as well. If you require any guidance regarding this, you can contact [WSO2 Support](https://support.wso2.com/jira/secure/Dashboard.jspa).
+    If you have developed any custom dashboards in API-M 3.1.0 Analytics using Stream Processor, you will be able to use the same in API-M Analytics 3.2.0 as well. If you require any guidance regarding this, you can contact [WSO2 Support](https://support.wso2.com/jira/secure/Dashboard.jspa).
 
 #### Step 3.3 - Configure WSO2 API-M 3.2.0 for Analytics
 
 Enable analytics in WSO2 API-M by setting the following configuration to true in the `<API-M_3.2.0_HOME>/repository/conf/deployment.toml` file.
 
-    ``` java
-    [apim.analytics]
-    enable = true
-    ```
+``` java
+[apim.analytics]
+enable = true
+```
 
 ### Step 4 - Restart the WSO2 API-M 3.2.0 server
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-process.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-process.md
@@ -30,7 +30,7 @@ version.
       
         !!! info "Migrating the customizations that are not available in the latest version"
             - Initially, update the dependency version of the 
-            dependant WSO2 components and re-build the customized component.
+            dependent WSO2 components and re-build the customized component.
             - As a practice, WSO2 does not make API changes in minor releases of the dependency JARs. However, if 
             there are API changes, please update the custom code and re-build.
                         
@@ -50,11 +50,11 @@ version.
 test your functional and non-functional requirements.
 
 
-7.  Before start the upgrading process, Please make sure that you have read the whole documentation specific to the version upgarde and have a clear understanding of the upgrading process.
+1.  Before you start the upgrading process, make sure that you have read the whole documentation specific to the version upgrade and have a clear understanding of the upgrading process.
 
-8. If you have expired certificates in client-trustore, follow [Renewing a CA-Signed Certificate in a Keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/renewing-a-ca-signed-certificate-in-a-keystore/#renewing-a-ca-signed-certificate-in-a-keystore)
+2. If you have expired certificates in client-trustore, follow [Renewing a CA-Signed Certificate in a Keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/renewing-a-ca-signed-certificate-in-a-keystore/#renewing-a-ca-signed-certificate-in-a-keystore).
 
-9.  Start the migration from the lowest environment (e.g., dev) and continue up to the highest before the production 
+3.  Start the migration from the lowest environment (e.g., dev) and continue up to the highest before the production 
 (e.g., pre-prod). Run the test cases in the migrated environments to confirm that your functional and non-functional requirements are met in the migrated environment.
 
 10. Before you carry out the production migration, run a pilot migration on your pre-prod environment. 

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5100.md
@@ -129,7 +129,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         password = "wso2carbon"
         ```
 
-    -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+    -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
         ```
         [realm_manager]
         data_source = "WSO2USER_DB"

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-5100.md
@@ -140,7 +140,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -148,7 +148,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.3.0"
             migratorConfigs:
@@ -179,7 +179,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -187,7 +187,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-530-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-530-to-5100.md
@@ -140,7 +140,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -148,7 +148,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.10.0"
             migratorConfigs:
@@ -165,7 +165,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -173,7 +173,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-550-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-550-to-5100.md
@@ -140,7 +140,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -148,7 +148,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.10.0"
             migratorConfigs:
@@ -165,7 +165,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -173,7 +173,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-560-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-560-to-5100.md
@@ -140,7 +140,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -148,7 +148,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.10.0"
             migratorConfigs:
@@ -165,7 +165,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -173,7 +173,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-5100.md
@@ -68,7 +68,7 @@ See the steps in the [Configuring WSO2 Identity Server as a Key Manager document
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -76,7 +76,7 @@ See the steps in the [Configuring WSO2 Identity Server as a Key Manager document
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.10.0"
             migratorConfigs:
@@ -93,7 +93,7 @@ See the steps in the [Configuring WSO2 Identity Server as a Key Manager document
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -101,7 +101,7 @@ See the steps in the [Configuring WSO2 Identity Server as a Key Manager document
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-5100.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-5100.md
@@ -140,7 +140,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
             password = "wso2carbon"
             ```
 
-        -   If you have used a seperate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
+        -   If you have used a separate user management database as the primary userstore in previous IS as KM setup, add the following to the `<IS_HOME>/repository/conf/deployment.toml` in IS 5.10.0.
             ```
             [realm_manager]
             data_source = "WSO2USER_DB"
@@ -148,7 +148,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
         -   You **DO NOT NEED** to copy the API-M Key Manager specific configurations from `<OLD_IS_KM_HOME>/repository/conf/api-manager.xml` of previous IS as KM version to IS 5.10.0.
 
     !!! Important
-        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from `migration-config.yaml` in the migration-resources directory.
+        Before executing the IS migration client according to [Step 11 of IS 5.10 migration guide](https://is.docs.wso2.com/en/5.10.0/setup/migrating-to-5100/), keep in mind to remove the following entries from the `migration-config.yaml` file, which is in the `migration-resources` directory.
         ```        
         - version: "5.10.0"
             migratorConfigs:
@@ -165,7 +165,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     !!! warning
     
-        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finish completely and server get started.
+        Depending on the number of records in the identity tables, this identity component migration will take a considerable amount of time to finish. Do **NOT** stop the server during the migration process and please wait until the migration process finishes completely and the server starts.
 
 3. After you have successfully completed the migration, stop the server and remove the following files and folders.
 
@@ -173,7 +173,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
     -   Remove the migration-resources directory, which is in the `<IS_HOME>` directory.
 
-    -   If you ran WSO2 IS as a Windows Service when doing the IS migration , then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
+    -   If you ran WSO2 IS as a Windows Service when doing the IS migration,  then you need to remove the following parameters in the command line arguments section (CMD_LINE_ARGS) of the `wso2server.bat` file.
         ```
         -Dmigrate -Dcomponent=identity        
         ```

--- a/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
+++ b/en/docs/learn/api-controller/advanced-topics/configuring-different-endpoint-types.md
@@ -41,7 +41,7 @@ API Manager supports four (4) main types of endpoints as follows.
         - `amznAccessKey`: Access Key for endpoint
         - `amznSecretKey`: Access Secret for endpoint
 
-Let us discuss configuring each of the above endpoint type with examples, seperately, in the following sections.
+Let us discuss configuring each of the above endpoint type with examples, separately, in the following sections.
 
 ### HTTP/REST Endpoints
 

--- a/en/docs/learn/api-gateway/message-mediation/removing-specific-request-headers-from-response.md
+++ b/en/docs/learn/api-gateway/message-mediation/removing-specific-request-headers-from-response.md
@@ -19,7 +19,7 @@ add the above mediation policy per API or globally.
 
 To handle error responses, follow the instructions below. 
 
-1.  To address the scenario where the API does not exist, open the `<API-M_HOME>/repository/deployment/server/synapse-configs/default/sequences/main.xml` file.
+1.  To address the scenario where the API does not exist, open the `<API-M_HOME>/repository/deployment/server/synapse-configs/default`/sequences/main.xml`` file.
 3.  Add the name of the header to be removed as a property, just before the beginning of `send` mediator, as shown below.
     
     !!! example
@@ -57,7 +57,7 @@ To handle error responses, follow the instructions below.
 !!! note
     The above method removes only the specified headers from the response. If you need to remove all the headers, follow the instructions below.
 
-    1.  Open the `<API-M_HOME>/repository/deployment/server/synapse-configs/default/sequences/main.xml` file.
+    1.  Open the `<API-M_HOME>/repository/deployment/server/synapse-configs/default`/sequences/main.xml`` file.
 
     2.  Add the `TRANSPORT_HEADERS` property, after the beginning of the `<out>` sequence opening tag, as shown in the example below.
 

--- a/en/docs/learn/design-api/endpoints/certificates.md
+++ b/en/docs/learn/design-api/endpoints/certificates.md
@@ -58,7 +58,7 @@ Follow the steps below to add a certificate to an endpoint:
     password = "wso2carbon"
     ```
 
-- If you are using a seperate keystore and truststore pair (per custom ssl profile) for each endpoint domain, add the configuration for each **custom ssl profile** in  `<API-M_HOME>/repository/conf/deployment.toml` as follows.
+- If you are using a separate keystore and truststore pair (per custom ssl profile) for each endpoint domain, add the configuration for each **custom ssl profile** in  `<API-M_HOME>/repository/conf/deployment.toml` as follows.
 
     ``` tab="Format"
     [[keystore.ssl_profile.custom]]


### PR DESCRIPTION
## Purpose
- Fixed typos and grammar issues.
- Copied the "Step 3.1 - Configure WSO2 API-M Analytics 3.2.0" section from the Upgrading from 3.2.0 to 2.5.0 docs to older versions, because they were requesting the users to refer to the 2.5.0 docs. 
- Fixed some common spelling mistakes and grammar mistakes that were identified.