### PR TITLE
[4.2.0] Adding documentation on common API Policy version support and import

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -335,7 +335,7 @@ For more information, see [Download and Initialize the apictl](#download-and-ini
             **Flags:**  
             
             -    Optional :     
-                `--format` : pretty-print environments using templates 
+                `--format` : pretty-print environments using Go templates 
 
     -   **Response**
 

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/managing-apis-and-api-products.md
@@ -35,7 +35,7 @@ Follow the instructions below to display a list of APIs or API Products in an en
                 -   Optional :  
                     `--query` or `-q` : Search query pattern  
                     `--limit` or `-l` : Maximum number of APIs to return (Default 25)
-                    `--format` : pretty-print environments using templates
+                    `--format` : pretty-print APIs using Go templates
 
             !!! example
                 ```bash
@@ -101,6 +101,7 @@ Follow the instructions below to display a list of APIs or API Products in an en
                 -   Optional :  
                     `--query` or `-q` : Search query pattern  
                     `--limit` or `-l` : Maximum number of API Products to return
+                    `--format` : pretty-print API Products using Go templates
 
             !!! example
                 ```bash
@@ -157,7 +158,7 @@ Follow the instructions below to display a list of revisions created for an API 
                 -   Optional :  
                     `--provider` or `-r` : Provider of the API  
                     `--query` or `-q` : Search query pattern  
-                    `--format` : pretty-print environments using templates
+                    `--format` : pretty-print API revisions using Go templates
 
             !!! example
                 ```bash
@@ -203,7 +204,7 @@ Follow the instructions below to display a list of revisions created for an API 
                 -   Optional :  
                     `--provider` or `-r` : Provider of the API Product
                     `--query` or `-q` : Search query pattern  
-                    `--format` : pretty-print environments using templates
+                    `--format` : pretty-print API Product revisions using Go templates
 
             !!! example
                 ```bash

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -255,7 +255,7 @@ mentioned gateway environments. If the **deployment environments are not provide
             
             -   Required :  
                 `--file` or `-f` : The file path of the API Product to import.  
-                `--environment` or `-e` : Environment to which the API Product should be exported.  
+                `--environment` or `-e` : Environment to which the API Product should be imported.  
             -   Optional :  
                 `--preserve-provider` : Preserve existing provider of API Product after importing. Default value is `true`.  
                 `--rotate-revision` : If the maximum revision limit reached, delete the oldest revision and create a new revision.  

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
@@ -96,7 +96,7 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
             apictl delete policy api -n <common API Policy name> -v <common API Policy version> -e <environment>
             ```
             ``` bash
-            apictl delete policy api --name <common API Policy name> -v <common API Policy version> --version <common API Policy version> --environment <environment> 
+            apictl delete policy api --name <common API Policy name> --version <common API Policy version> --environment <environment> 
             ```
 
             !!! info

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
@@ -38,11 +38,11 @@ Follow the instructions below to display a list of common API Policies in an env
                 **Flags:**  
                 
                 -   Required :  
-                    `--environment` or `-e` : Environment to be searched  
-                -   Optional :
-                    `--all`: All common API Policies available in the environment
-                    `--limit` or `-l` : Maximum number of common API Policies to return (Default 25)
-                    `--format` : pretty-print common API Policies using Go templates
+                    `--environment` or `-e` : Environment to be searched   
+                -   Optional :   
+                    `--all`: All common API Policies available in the environment   
+                    `--limit` or `-l` : Maximum number of common API Policies to return (Default 25)   
+                    `--format` : pretty-print common API Policies using Go templates   
 
             !!!note
                 When executing the `apictl get policies api` command, using both the `--all` and `--limit` flags at once is not allowed.
@@ -69,7 +69,7 @@ Follow the instructions below to display a list of common API Policies in an env
             4bfdb007-5cf4-461d-8360-d89e3c8765f2   setToHeader                Set To Header               v1                  Mediation           [request]                  [Synapse]                 [HTTP]
             bcc2b759-f78b-4680-bf99-505f921c6e5e   addQueryParam              Add Query Param             v1                  Mediation           [request]                  [Synapse ChoreoConnect]   [HTTP]
             3660df5e-2776-4128-bbf0-34e76436bfdd   CustomLogPolicy            Custom Log Policy           v1                  Mediation           [request]                  [Synapse]                 [HTTP SOAP]
-            3a61542f-4acf-41b7-9b63-c50dc37234d6   CustomLogPolicy            Custom Log Policy           v2                  Mediation           [request fault]         [Synapse ChoreoConnect]   [HTTP SOAP SOAPTOREST]
+            3a61542f-4acf-41b7-9b63-c50dc37234d6   CustomLogPolicy            Custom Log Policy           v2                  Mediation           [request fault]            [Synapse ChoreoConnect]   [HTTP SOAP SOAPTOREST]
             ```
             
             !!! tip 

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
@@ -42,7 +42,7 @@ Follow the instructions below to display a list of common API Policies in an env
                 -   Optional :
                     `--all`: All common API Policies available in the environment
                     `--limit` or `-l` : Maximum number of common API Policies to return (Default 25)
-                    `--format` : pretty-print environments using templates
+                    `--format` : pretty-print common API Policies using templates
 
             !!!note
                 When executing the `apictl get policies api` command, using both the `--all` and `--limit` flags at once is not allowed.
@@ -64,13 +64,16 @@ Follow the instructions below to display a list of common API Policies in an env
         -   **Response**
 
             ```bash
-            ID                                     NAME                       Display NAME               CATEGORY            APPLICABLE FLOWS     SUPPORTED GATEWAYS
-            e758ccd3-39ec-430c-8722-a44253a53ecd   ccCallInterceptorService   Call Interceptor Service   Mediation           [request response]   [ChoreoConnect]
-            55e8e47f-35ee-46b3-b097-5f347079c7c4   setToHeader                Set To Header              Mediation           [request]            [Synapse]
+            ID                                     NAME                       DISPLAY NAME                VERSION             CATEGORY            APPLICABLE FLOWS           SUPPORTED GATEWAYS        SUPPORTED API TYPES
+            0d254577-566d-4277-8104-8e764d10dbca   ccCallInterceptorService   Call Interceptor Service    v1                  Mediation           [request response]         [ChoreoConnect]           [HTTP]
+            4bfdb007-5cf4-461d-8360-d89e3c8765f2   setToHeader                Set To Header               v1                  Mediation           [request]                  [Synapse]                 [HTTP]
+            bcc2b759-f78b-4680-bf99-505f921c6e5e   addQueryParam              Add Query Param             v1                  Mediation           [request]                  [Synapse ChoreoConnect]   [HTTP]
+            3660df5e-2776-4128-bbf0-34e76436bfdd   CustomLogPolicy            Custom Log Policy           v1                  Mediation           [request]                  [Synapse]                 [HTTP SOAP]
+            3a61542f-4acf-41b7-9b63-c50dc37234d6   CustomLogPolicy            Custom Log Policy           v2                  Mediation           [request fault]         [Synapse ChoreoConnect]   [HTTP SOAP SOAPTOREST]
             ```
             
             !!! tip 
-                When using the `apictl get policies api -e dev` command, `--all` optional flag can be used to 
+                When using the `get policies api` command, `--all` optional flag can be used to 
                 get all available common API Policies.
 
             !!!note
@@ -90,10 +93,10 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
 
         -   **Command**
             ``` bash
-            apictl delete policy api -n <common API Policy-name> -e <environment>
+            apictl delete policy api -n <common API Policy name> -v <common API Policy version> -e <environment>
             ```
             ``` bash
-            apictl delete policy api --name <common API Policy-name> --environment <environment> 
+            apictl delete policy api --name <common API Policy name> -v <common API Policy version> --version <common API Policy version> --environment <environment> 
             ```
 
             !!! info
@@ -102,20 +105,18 @@ For more information, see [Download and Initialize the apictl]({{base_path}}/ins
                 -   Required :  
                     `--environment` or `-e` : Environment from which the common API Policy should be deleted  
                     `--name` or `-n` : Name of the common API Policy to be deleted  
-
-            !!!note
-                In apictl v4.1.0, --version flag support is not provided. Instead, internally it considers the default version which is `v1` when finding the policy.
+                    `--version` or `-v` : Version of the common API Policy to be deleted  
 
             !!! example
                 ```bash
-                apictl delete policy api -n addHeader -e dev
+                apictl delete policy api -n addHeader -v v1 -e dev
                 ```
                 ```bash
-                apictl delete policy api --name addHeader --environment production 
+                apictl delete policy api --name addHeader --version v1 --environment production 
                 ```
 
         -   **Response**
 
             ```bash
-            addHeader common API Policy deleted successfully!
+            addHeader common API Policy with the version v1 deleted successfully!
             ```

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/managing-common-api-policies.md
@@ -42,7 +42,7 @@ Follow the instructions below to display a list of common API Policies in an env
                 -   Optional :
                     `--all`: All common API Policies available in the environment
                     `--limit` or `-l` : Maximum number of common API Policies to return (Default 25)
-                    `--format` : pretty-print common API Policies using templates
+                    `--format` : pretty-print common API Policies using Go templates
 
             !!!note
                 When executing the `apictl get policies api` command, using both the `--all` and `--limit` flags at once is not allowed.

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
@@ -28,42 +28,43 @@
     -   **Command**
      
         ```go
-        apictl export policy api -n <Common API Policy name> -e <environment>  
+        apictl export policy api -n <Common API Policy name> -v <common API Policy version> -e <environment>  
         ``` 
         ```go
-        apictl export policy api --name <Common API Policy name> --environment <environment>  
+        apictl export policy api --name <Common API Policy name> --version <common API Policy version> --environment <environment>  
         ```
         ```go
-        apictl export policy api --name <Common API Policy name> --environment <environment> --format <Policy Definition file format>
+        apictl export policy api --name <Common API Policy name> --version <common API Policy version> --environment <environment> --format <Policy Definition file format>
         ```
 
         !!! info
             **Flags:**  
             
             -    Required :  
-                `--name` or `-n` : Name of the API Product to be exported      
+                `--name` or `-n` : Name of the API Product to be exported
+                `--version` or `-v` : Version of the common API Policy to be deleted       
                 `--environment` or `-e` : Environment from which the API Product should be exported  
             -   Optional :  
                 `--format` : File format of exported policy definition file (JSON or YAML). The default value is YAML.   
 
         !!! example
             ```go
-            apictl export policy api -n addHeader -e dev
+            apictl export policy api -n addHeader -v v1 -e dev
             ```          
             ```go
-            apictl export policy api -n addHeader -e dev --format JSON
+            apictl export policy api -n addHeader -e -v1 dev --format JSON
             ``` 
 
     -   **Response**
 
         ``` bash tab="Response Format"
         Successfully exported API Policy!
-        Find the exported API Policies at /Users/benura/.wso2apictl/exported/policies/api/<Environment Name>/<Policy Name>_<Polic Version>.zip
+        Find the exported API Policies at /Users/benura/.wso2apictl/exported/policies/api/<Environment Name>/<Policy Name>_<Policy Version>.zip
         ```
 
         ``` bash tab="Example Response"
         Successfully exported API Policy!
-        Find the exported API Policies at /Users/benura/.wso2apictl/exported/policies/api/<Environment Name>/testHeader_v1.zip
+        Find the exported API Policies at /Users/benura/.wso2apictl/exported/policies/api/dev/addHeader_v1.zip
         ```
 
 The exported ZIP file has the following structure:

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
@@ -126,7 +126,7 @@ You can use the common API Policy archive exported from the previous section (or
         apictl import policy api -f  <path to Common API Policy archived file> -e <environment> 
         ```
         ``` bash
-        apictl import api --file <path to Common API Policy archived file> --environment <environment>
+        apictl import policy api --file <path to Common API Policy archived file> --environment <environment>
         ```
 
         !!! info
@@ -141,13 +141,13 @@ You can use the common API Policy archive exported from the previous section (or
             apictl import policy api -f ~/addHeader_v1.zip -e production 
             ```
             ```bash
-            apictl import api --file ~/addHeader_v1.zip --environment production
+            apictl import policy api --file ~/addHeader_v1.zip --environment production
             ```   
             ```bash
             apictl import policy api -f ~/AddHeader -e production 
             ``` 
             ``` go
-            apictl import api --file ~/AddHeader --environment production 
+            apictl import policy api --file ~/AddHeader --environment production 
             ```
 
         !!! tip

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
@@ -13,7 +13,7 @@
 !!! tip
     A user with `Internal/devops` role or `admin` role are allowed to import/export Common API Policies. To create a custom user who can import/export Common API Policies, refer [Steps to Create a Custom User who can Perform API Controller Operations]({{base_path}}/install-and-setup/setup/api-controller/advanced-topics/creating-custom-users-to-perform-api-controller-operations/#steps-to-create-a-custom-user-who-can-perform-api-controller-operations).
 
-### Export an Common API Policies
+### Export a Common API Policy
 
 1.  Log in to the WSO2 API-M in the exporting environment by following steps in [Login to an Environment]({{base_path}}/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller#login-to-an-environment).  
     
@@ -100,3 +100,61 @@ The structure of an exported Common API Policy ZIP file is explained below:
         </tr>
     </tbody>
 </table>
+
+### Import a Common API Policy
+
+You can use the common API Policy archive exported from the previous section (or you can extract it and use the extracted folder) and import it to the WSO2 API-M instance in the target environment. 
+
+1.  Log in to the WSO2 API-M in the importing environment by following steps in [Login to an Environment]({{base_path}}/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller#login-to-an-environment).
+    
+    !!! tip
+        If you are already logged-in and your logged-in credentials and keys are already available in the `<USER_HOME>/.wso2apictl/keys.json` file, you can skip this step. 
+
+    !!! info
+        If you skip step 1 and if no keys exist for the environment in the `<USER_HOME>/.wso2apictl/keys.json` file, you will be prompt to log in to the environment when running the next command.
+
+2.  Run any of the following apictl commands to import a common API Policy.
+
+    -   **Command**
+        ``` bash
+        apictl import policy api -f <path to Common API Policy directory> -e <environment> 
+        ```
+        ``` bash
+        apictl import policy api --file <path to Common API Policy directory> --environment <environment>
+        ```
+        ``` bash
+        apictl import policy api -f  <path to Common API Policy archived file> -e <environment> 
+        ```
+        ``` bash
+        apictl import api --file <path to Common API Policy archived file> --environment <environment>
+        ```
+
+        !!! info
+            **Flags:**  
+            
+            -   Required :  
+                `--file` or `-f` : The file path of the common API Policy to import.  
+                `--environment` or `-e` : Environment to which the common API Policy should be imported.
+
+        !!! example
+            ```bash
+            apictl import policy api -f ~/addHeader_v1.zip -e production 
+            ```
+            ```bash
+            apictl import api --file ~/addHeader_v1.zip --environment production
+            ```   
+            ```bash
+            apictl import policy api -f ~/AddHeader -e production 
+            ``` 
+            ``` go
+            apictl import api --file ~/AddHeader --environment production 
+            ```
+
+        !!! tip
+            If your file path is `/Users/benura/.wso2apictl/exported/policies/api/dev/addHeader_v1.zip`, then you need to enter `dev/addHeader_v1.zip` as the value for `--file` or `-f` flag.
+       
+     -   **Response**
+        
+        ``` bash
+        Successfully Imported API Policy.
+        ```

--- a/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-common-api-policies/migrating-common-api-policies-to-different-environments.md
@@ -42,7 +42,7 @@
             
             -    Required :  
                 `--name` or `-n` : Name of the API Product to be exported
-                `--version` or `-v` : Version of the common API Policy to be deleted       
+                `--version` or `-v` : Version of the common API Policy to be exported       
                 `--environment` or `-e` : Environment from which the API Product should be exported  
             -   Optional :  
                 `--format` : File format of exported policy definition file (JSON or YAML). The default value is YAML.   
@@ -52,7 +52,7 @@
             apictl export policy api -n addHeader -v v1 -e dev
             ```          
             ```go
-            apictl export policy api -n addHeader -e -v1 dev --format JSON
+            apictl export policy api -n addHeader -v v1 -e dev --format JSON
             ``` 
 
     -   **Response**


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/docs-apim/issues/6453
Fixes: https://github.com/wso2/docs-apim/issues/6457

## Goals
Adding documentation on common API Policy version support and import

## Approach
- Added version-related changes to the documentation for,
  - `apictl get policies api` command output
  -  `apictl export policy api` command flags
  -  `apictl delete policy api` command flags
- Added new documentation for `apictl import policy api`
- Fixed typos and formatting issues