### PR TITLE
[4.0.0] Point migration docs to the latest stable IS migration client for IS 5.x.x

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400.md
@@ -3445,7 +3445,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     1.  Download the identity component migration resources and unzip it in a local directory.
         
-         Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+         Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     2.  Copy the `migration-resources` folder from the extracted folder to the `<API-M_4.0.0_HOME>` directory.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400.md
@@ -3368,7 +3368,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     1.  Download the identity component migration resources and unzip it in a local directory.
   
-        Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+        Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     2.  Copy the `migration-resources` folder from the extracted folder to the `<API-M_4.0.0_HOME>` directory.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400.md
@@ -3163,7 +3163,7 @@ Follow the instructions below to move all the existing API Manager configuration
 
     1.  Download the identity component migration resources and unzip it in a local directory.
 
-        Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+        Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     2.  Copy the `migration-resources` folder from the extracted folder to the `<API-M_4.0.0_HOME>` directory.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400.md
@@ -3138,7 +3138,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
     ```
 1.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
 2.  Copy the `migration-resources` folder from the extracted folder to the `<API-M_4.0.0_HOME>` directory.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400.md
@@ -3488,7 +3488,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 1.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
      
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`. 
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400.md
@@ -2870,7 +2870,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 1.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `org.wso2.carbon.is-migration-x.x.x.zip` under Assets.
+     Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
          
      Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`. 
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400.md
@@ -2223,7 +2223,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 1. Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
          
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`. 
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400.md
@@ -1532,7 +1532,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 1. Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/tags) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 


### PR DESCRIPTION
## Purpose
In https://github.com/wso2-extensions/apim-identity-migration-resources 

- `master` now has the latest IS migration client for IS `6.0.0` to be used for APIM `4.2.0` migrations and onwards. 
- `5.x.x` branch is used for APIM `4.0.0` and `4.1.0` migrations

Therefore the doc links are pointed to the latest stable build for `5.x.x` branch.

raised by : https://github.com/wso2-enterprise/wso2-apim-internal/issues/1161