### PR TITLE
[4.1.0] Point migration docs to the latest stable IS migration client for IS 5.x.x

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/260-to-410/upgrading-from-260-to-410.md
@@ -1157,7 +1157,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Mana
     
 3.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under Assets.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/300-to-410/upgrading-from-300-to-410.md
@@ -1061,7 +1061,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 3. Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under Assets.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/310-to-410/upgrading-from-310-to-410.md
@@ -494,7 +494,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Manag
 
 2.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under Assets.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under Assets.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/320-to-410/upgrading-from-320-to-410.md
@@ -268,7 +268,7 @@ Follow the instruction below to upgrade the Identity component in WSO2 API Mana
 
 2.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under Assets.
          
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`. 
 

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-5100-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-5100-to-is-5110.md
@@ -180,7 +180,7 @@ Follow step 1 to step 3 below to upgrade your IS as Key Manager 5.10.0 to IS 5.1
 
 2.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5110.md
@@ -186,7 +186,7 @@ Follow step 1 to step 3 below to upgrade your IS as Key Manager 5.10.0 to IS 5.1
 
 2.  Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-is-5110.md
@@ -755,7 +755,7 @@ Follow step 1 to step 3 below to upgrade your IS as Key Manager 5.7.0 to IS 5.11
 
 4. Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-is-5110.md
@@ -742,7 +742,7 @@ Follow step 1 to step 3 below to upgrade your IS as Key Manager 5.9.0 to IS 5.11
 
 3. Download the identity component migration resources and unzip it in a local directory.
 
-    Navigate to the [latest release tag](https://github.com/wso2-extensions/apim-identity-migration-resources/releases) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
+    Navigate to the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) and download the `wso2is-migration-x.x.x.zip` under **Assets**.
 
     Let's refer to this directory that you downloaded and extracted as `<IS_MIGRATION_TOOL_HOME>`.
 


### PR DESCRIPTION
## Purpose
In https://github.com/wso2-extensions/apim-identity-migration-resources 

- `master` now has the latest IS migration client for IS `6.0.0` to be used for APIM `4.2.0` migrations and onwards. 
- `5.x.x` branch is used for APIM `4.0.0` and `4.1.0` migrations

Therefore the doc links are pointed to the latest stable build for `5.x.x` branch.

raised by : https://github.com/wso2-enterprise/wso2-apim-internal/issues/1161