### PR TITLE
[4.0.0] Point IS as KM migration docs to the latest stable IS migration client for IS 5.x.x

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-5100-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-5100-to-is-5110.md
@@ -113,7 +113,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 1 and 2 under [Step 3 - Migrate API-M Database]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-320-to-400/#step-3-migrate-api-m-database) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 3.2.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.10.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.10.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-5100-to-is-5110.md
@@ -112,7 +112,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 1 and 2 under [Step 3 - Migrate API-M Database]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-310-to-400/#step-3-migrate-api-m-database) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 3.1.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.10.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.10.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-520-to-is-5110.md
@@ -106,7 +106,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 2 and 3 under [Step 2 - Upgrade API Manager to 4.0.0]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-200-to-400/#step-2-upgrade-api-manager-to-400) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 2.0.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.2.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.2.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-530-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-530-to-is-5110.md
@@ -114,7 +114,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 2 and 3 under [Step 2 - Upgrade API Manager to 4.0.0]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-210-to-400/#step-2-upgrade-api-manager-to-400) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 2.1.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.3.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.3.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-550-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-550-to-is-5110.md
@@ -106,7 +106,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 2 and 3 under [Step 2 - Upgrade API Manager to 4.0.0]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-220-to-400/#step-2-upgrade-api-manager-to-400) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 2.2.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.5.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.5.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-560-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-560-to-is-5110.md
@@ -112,7 +112,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 1 and 2 under [Step 3 - Migrate API-M Database]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-250-to-400/#step-3-migrate-api-m-database) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 2.5.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.6.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.6.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migrating the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-570-to-is-5110.md
@@ -112,7 +112,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 1 and 2 under [Step 3 - Migrate API-M Database]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-260-to-400/#step-3-migrate-api-m-database) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 2.6.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.7.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.7.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migration the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to

--- a/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-is-5110.md
+++ b/en/docs/install-and-setup/upgrading-wso2-is-as-key-manager/upgrading-from-is-km-590-to-is-5110.md
@@ -112,7 +112,7 @@ The following information describes how to upgrade your **WSO2 API Manager (WSO2
 
 1. Follow Step 1 and 2 under [Step 3 - Migrate API-M Database]({{base_path}}/install-and-setup/upgrading-wso2-api-manager/upgrading-from-300-to-400/#step-3-migrate-api-m-database) to backup and upgrade the WSO2 API-M `WSO2AM_DB` from 3.0.0 to 4.0.0. This will be used as the `identity_db` in IS 5.11.0.
 
-2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.9.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [latest release](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/latest) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
+2. Follow the guidelines in [WSO2 IS 5.11.0 migration guide](https://is.docs.wso2.com/en/5.11.0/setup/migrating-to-5110/) to migrate your current IS as KM 5.9.0 distribution to IS 5.11.0. Make sure to use the migration resources downloaded from the [release tag - v1.0.160](https://github.com/wso2-extensions/apim-identity-migration-resources/releases/tag/v1.0.160) under Assets instead of the migration resources found under Step 9 a. in the WSO2 IS 5.11.0 migration guide.
 
     !!! Important
         When following the instructions in [Migration the configurations](https://is.docs.wso2.com/en/5.11.0/setup/migrating-preparing-for-migration/#migrating-the-configurations) section of IS 5.11.0 migration guide, make sure to


### PR DESCRIPTION
## Purpose
In https://github.com/wso2-extensions/apim-identity-migration-resources 

- `master` now has the latest IS migration client for IS `6.0.0` to be used for APIM `4.2.0` migrations and onwards. 
- `5.x.x` branch is used for APIM `4.0.0` and `4.1.0` migrations

Therefore the doc links are pointed to the latest stable build for `5.x.x` branch.

raised by : https://github.com/wso2-enterprise/wso2-apim-internal/issues/1161