### PR TITLE
[3.2.0][APIM-Analytics] Update docs for devportal alert configuration

### DIFF
--- a/en/docs/learn/analytics/configuring-alerts.md
+++ b/en/docs/learn/analytics/configuring-alerts.md
@@ -206,7 +206,7 @@ Follow the instructions below to manage alert types via the Developer Portal:
 #### Create an abnormal requests per minute alert
 
 1.  Sign in to the API Developer Portal with the username and password of a user with the required permission.
-2.  Click on the **SETTINGS** menu, to open the Manage Alert Subscriptions page.
+2.  Click on the user name and choose **Configure Alerts** to open the Manage Alert Subscriptions page.
 ![Publisher alerts settings]({{base_path}}/assets/img/learn/alerts-settings-devportal.png)
 
 3.  Click on the **Configuration** option that corresponds to the Abnormal Requests per Minute option. <br />


### PR DESCRIPTION
## Purpose
 In APIM 3.2.0, `Settings` icon in the `devportal` has been removed. In order to access alert managing page users have to click on user name and choose `Configure Alerts`. However in the documentation for configuring abnormal requests per minute alert, it was mentioned to click on the `Settings` to open the alert managing page. 

![Screenshot 2022-12-05 at 14 49 37](https://user-images.githubusercontent.com/55122994/205629795-be7258b0-0b1f-46c7-bdf2-4185dac515cc.png)
