### PR TITLE
Adding 4.2.0 link

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -46,12 +46,12 @@ These are the latest changes that have yet to be released.
 <table>
     <tbody>
         <tr>
-            <th>next</th>
+            <th>4.2.0</th>
             <td>
                 <a id="pre-release-version-documentation-link">Documentation</a>
             </td>
             <td>
-                <a href="https://github.com/wso2/docs-apim/tree/master" target="_blank">
+                <a href="https://apim.docs.wso2.com/en/4.2.0" target="_blank">
                     <div class="md-source-code-icon">
                         <svg viewBox="0 0 24 24" width="24" height="24">
                           <use xlink:href="#__github" width="24" height="24"></use>


### PR DESCRIPTION
## Purpose
Added 4.2.0 doc link and version as the pre-release.

Fixes https://github.com/wso2/docs-apim/issues/6518