### PR TITLE
Updated pre-release-version-documentation-link

### DIFF
--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -151,7 +151,7 @@ request.onload = function() {
         
           // Pre-release version update
           document.getElementById('pre-release-version-documentation-link')
-              .setAttribute('href', docSetUrl + 'next/');
+              .setAttribute('href', docSetUrl + '4.2.0/');
       }
       
   } else {


### PR DESCRIPTION
## Purpose
Fixing the pre-release doc link as it is auto added.

Related to https://github.com/wso2/docs-apim/issues/6518