### PR TITLE
fixing 4.2.0 link

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -48,7 +48,8 @@ These are the latest changes that have yet to be released.
         <tr>
             <th>4.2.0</th>
             <td>
-                <a id="pre-release-version-documentation-link">Documentation</a>
+                <!--<a id="pre-release-version-documentation-link">Documentation</a>-->
+                <a href="https://apim.docs.wso2.com/en/4.2.0/" target="_blank">Documentation</a>
             </td>
             <td>
                 <a href="https://github.com/wso2/docs-apim/tree/4.2.0" target="_blank">


### PR DESCRIPTION
## Purpose
- Hard coded 4.2.0 link as the auto link was being generated incorrectly.

Related to https://github.com/wso2/docs-apim/issues/6518