### PR TITLE
Update 4.1.0 sample scenario resource location path

### DIFF
--- a/en/docs/tutorials/scenarios/scenario-overview.md
+++ b/en/docs/tutorials/scenarios/scenario-overview.md
@@ -26,8 +26,8 @@ Docker and Docker compose need to be installed. Please refer [https://docs.docke
 
 A basic infrastructure has already been created for you to try out the scenarios. To run the setup please follow these steps.
 
-1. Clone https://github.com/wso2/samples-apim.
-2. Go to samples-apim/apim-tutorial.
+1. Download the [apim-tutorial.zip](https://github.com/wso2/samples-apim/releases/tag/v4.1.0) and unzip.
+2. Go to apim-tutorial folder.
 3. Start the setup using the command `docker-compose up -d`.
 4. You can view the logs using the command `docker-compose logs -d`.
 5. It might take 5-10 minutes for the setup to complete (if it is the first time, based on your download speed it might take longer). 


### PR DESCRIPTION
## Purpose
In the point 1 under the deployment section https://apim.docs.wso2.com/en/4.1.0/tutorials/scenarios/scenario-overview/#deployment, user needs to clone the repo. With this pr, it is changed to download from a release location
