### PR TITLE
fix "Adding Dynamic Endpoints" link in endpoint-types.md

### DIFF
--- a/en/docs/design/endpoints/endpoint-types.md
+++ b/en/docs/design/endpoints/endpoint-types.md
@@ -25,7 +25,7 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
-<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/design/api-policies/gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
+<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
 </tr>
 <tr><td>Mock Implementation</td>
 <td>


### PR DESCRIPTION
## Purpose
> Link Adding Dynamic Endpoints was wrong.

## Goals
> fix the link.

## Approach
> I search the original linked file in history and I found a commit that rename it. https://github.com/wso2/docs-apim/commit/aac8439e16f532537893e15e688dd7eacbaa1c7a?short_path=8a7ac90#diff-8a7ac90b31ab0df21ef79aea7729afc3a6c85ede1cc4becf392ec6aacf89f111
