### PR TITLE
fixes A1487

### DIFF
--- a/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
+++ b/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
@@ -2,7 +2,7 @@
 
 For a list of cipher suites that are secure and are functional in Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
 
-For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/administer/product-security/configuring-transport-level-security/).
+For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/install-and-setup/setup/security/configuring-transport-level-security/).
 
 !!! Attention 
 

--- a/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
+++ b/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
@@ -1,10 +1,8 @@
 # Supported Cipher Suites
 
-Given below are the cipher suites that are functional in Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols. 
+For a list of cipher suites that are secure and are supported by Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
 
-For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/install-and-setup/setup/security/configuring-transport-level-security).
-
-For a list of cipher suites that are secure and are supported by Tomcat 9 and Oracle JDK 11 and above, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
+For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/administer/product-security/configuring-transport-level-security/).
 
 !!! Attention 
 

--- a/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
+++ b/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
@@ -1,6 +1,6 @@
 # Supported Cipher Suites
 
-For a list of cipher suites that are secure and are supported by Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
+For a list of cipher suites that are secure and are functional in Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
 
 For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/administer/product-security/configuring-transport-level-security/).
 

--- a/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
+++ b/en/docs/install-and-setup/setup/reference/supported-cipher-suites.md
@@ -1,79 +1,23 @@
 # Supported Cipher Suites
 
-Given below are the cipher suites that are functional in Tomcat ( Tomcat
-version 7.0.59 with the JSSE providers 7/8) for the following SSL
-protocols: TLSv1, TLSv1.1 and TLSv1.2. See [Configuring Transport-Level
-Security](../../setup/configuring-transport-level-security) for instructions on
-how to enable the required ciphers and to disable the weak ciphers for
-your WSO2 server.
+Given below are the cipher suites that are functional in Tomcat (Tomcat version 9 with the JSSE provider 11) for the TLSv1.2 protocols. 
 
-See the following topics:  
+For instructions on how to enable the required ciphers and to disable the weak ciphers in API Manager, see [Configuring Transport-Level Security]({{base_path}}/install-and-setup/setup/security/configuring-transport-level-security).
 
-### Cipher suites supported by Tomcat 7.0.59 and Oracle JDK 1.8
+For a list of cipher suites that are secure and are supported by Tomcat 9 and Oracle JDK 11 and above, see the list of ciphers provided in the [secure configuration generator](https://ssl-config.mozilla.org/#server=tomcat&version=9.0.30&config=intermediate&guideline=5.6), which is provided by the Mozilla Foundation.
 
-The following cipher suites are supported by Tomcat version 7.0.59 and
-Oracle JDK 1.8:
+!!! Attention 
 
--   `          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256         `
--   `          TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256         `
--   `          TLS_DHE_RSA_WITH_AES_128_CBC_SHA256         `
--   `          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA         `
--   `          TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA         `
--   `          TLS_DHE_RSA_WITH_AES_128_CBC_SHA         `
--   `          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256         `
--   `          TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         `
--   `          TLS_DHE_RSA_WITH_AES_128_GCM_SHA256         `
+    It is not recommended to use relatively weaker cipher suites, which use DES/3DES, RC4 and MD5, for the following reasons:
 
-The following additional cipher suites will be supported if JCE
-Unlimited Strength Jurisdiction Policy is used with Tomcat 7.0.59 and
-Oracle JDK 1.8:
+    -   DES/3DES are deprecated and should not be used. (e.g., TLS_RSA_WITH_3DES_EDE_CBC_SHA, DES-CBC3-SHA)
 
--   `          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384         `
--   `          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384         `
--   `          TLS_DHE_RSA_WITH_AES_256_CBC_SHA256         `
--   `          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA         `
--   `          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA         `
--   `          TLS_DHE_RSA_WITH_AES_256_CBC_SHA         `
--   `          TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384         `
--   `          TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         `
--   `          TLS_DHE_RSA_WITH_AES_256_GCM_SHA384         `
+    -   MD5 should not be used, due to known collision attacks.
 
-### Weak ciphers
+    -   RC4 should not be used due to crypto-analytical attacks. 
 
-!!! note
-    Listed below are the relatively weaker cipher suites (which use
-    DES/3DES, RC4 and MD5). It is not recommended to use these cipher suites
-    for the following reasons:
-    
-    -   DES/3DES are deprecated and should not be used.
-    
-    -   MD5 should not be used due to known collision attacks.
-    
-    -   RC4 should not be used due to crypto-analytical attacks.
     -   DSS is limited to 1024 bit key size.
-    
-    -   Cipher-suites that do not provide Perfect Forward Secrecy/ Forward
-        Secrecy (PFS/FS).
-    
 
-The following cipher suites are weak for Tomcat version 7.0.59 when
-either JDK version (7/8) is used. The same applies if JCE Unlimited
-Strength Jurisdiction Policy is used.
+    -   Cipher-suites that do not provide Perfect Forward Secrecy/ Forward Secrecy (PFS/FS).
 
--   `          TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA         `
--   `          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA         `
--   `          SSL_RSA_WITH_3DES_EDE_CBC_SHA         `
--   `          TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA         `
--   `          TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA         `
--   `          SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA         `
--   `          SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA         `
-
-The following cipher suites are weak for Tomcat version 7.0.59 and JDK
-version 1.7:
-
--   `          TLS_ECDHE_ECDSA_WITH_RC4_128_SHA         `
--   `          TLS_ECDHE_RSA_WITH_RC4_128_SHA         `
--   `          SSL_RSA_WITH_RC4_128_SHA         `
--   `          TLS_ECDH_ECDSA_WITH_RC4_128_SHA         `
--   `          TLS_ECDH_RSA_WITH_RC4_128_SHA         `
--   `          SSL_RSA_WITH_RC4_128_MD5         `
+    -   Never use even more INSECURE or older ciphers based on RC2, MD4, EXP, EXP1024, AH, ADH, aNULL, eNULL, SEED nor IDEA.


### PR DESCRIPTION
## Purpose
Updated the list of secure Cipher Suites in [1].

<img width="1084" alt="Screenshot 2023-01-04 at 11 15 01 PM" src="https://user-images.githubusercontent.com/5195851/210617549-69a72d42-7a05-440a-8514-01316aaf8275.png">


[1] https://apim.docs.wso2.com/en/3.1.0/install-and-setup/setup/reference/supported-cipher-suites/