### PR TITLE
[4.1.0] Update VFS paramters section with StrictHostKeyChecking parameter

### DIFF
--- a/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
@@ -430,6 +430,12 @@ When you use the [transport.vfs.FileURI](#vfs-transport-file_url) parameter, you
             Whether to send files synchronously to the file host. When this parameter is set to <code>true</code>, files will be sent one after another to the file host. This synchronous write can be configured on a per host basis. The default setting is <code>false</code>.
          </td>
       </tr>
+      <tr>
+         <td>transport.vfs.StrictHostKeyChecking</td>
+         <td>
+            Whether the Host key should be checked. When this parameter is set to <code>yes</code>, VFS transport will always verify the public key (fingerprint) of the SSH/SFTP server. The default setting is <code>no</code>. <b>Note</b>: This option is available from U2 level 4.1.0.36 onwards.
+         </td>
+      </tr>
    </tbody>
 </table>
 


### PR DESCRIPTION
## Purpose
Update the VFS parameters section with `StrictHostKeyChecking` parameter introduced via https://github.com/wso2-support/wso2-commons-vfs/pull/94 for WSO2 MI 4.1.0