### PR TITLE
Update instructions to support Java 17

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-mi-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-mi-as-a-windows-service.md
@@ -13,14 +13,14 @@ Follow the instructions given below to run the Micro Integrator as a Windows ser
 -	Point the `wso2mi_home` environment variable to the `MI_HOME` directory.
 
 !!! Note 
-    Be sure to use **lower case** letters when setting the `java_home` and `wso2mi_home` in the Windows OS. That is, you must not use `JAVA_HOME` or `WSO2MI_HOME`.
+    Be sure to use **lower case** letters when setting the `wso2mi_home` in the Windows OS. That is, you must not use `WSO2MI_HOME`.
   
 ## Setting up the YAJSW wrapper 
 
 YASJW uses the configurations defined in the `<YAJSW_HOME>/conf/wrapper.conf` file to wrap Java applications. Replace the contents of this file with the configurations that are relevant to the Micro Integrator instance that you want to run as a service. Use the **wrapper.conf** file available in `<MI_HOME>/bin/yajsw` folder to get the relevant configurations.
 
 !!! Info
-    WSO2 recommends Yet Another Java Service Wrapper (YAJSW) version 12.14. If you are running on JDK 11, previous versions of YAJSW will not be compatible.
+    WSO2 recommends Yet Another Java Service Wrapper (YAJSW) version 13.05. If you are running on JDK 11 or JDK 17, previous versions of YAJSW will not be compatible.
 
 !!! tip
     You may encounter the following issue when starting Windows Services when the file "java" or a "dll" used by Java cannot be found by YAJSW. 
@@ -37,7 +37,7 @@ YASJW uses the configurations defined in the `<YAJSW_HOME>/conf/wrapper.conf` fi
 
 ## Installing the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt, and execute the following command: 
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command: 
 
 ```bash
 installService.bat
@@ -45,7 +45,7 @@ installService.bat
 
 ## Starting the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt, and execute the following command: 
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command: 
 
 ```bash
 startService.bat
@@ -53,7 +53,7 @@ startService.bat
 
 ## Stopping the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt and execute the following command: 
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command: 
 
 ```bash
 stopService.bat
@@ -61,7 +61,7 @@ stopService.bat
 
 ## Uninstalling the service
 
-To uninstall the service, navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt and execute the following command: 
+To uninstall the service, navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command: 
  
 ```bash
 uninstallService.bat


### PR DESCRIPTION
## Purpose
- Update docs to include instructions for running MI as a windows service on Java 17 with YAJSW.
- Related Issues: https://github.com/wso2/api-manager/issues/1506

## Approach
- Made the relevant doc changes with updated YAJSW version 13.05.
- Updated the instructions to `Windows command prompt with administrative privileges`

