### PR TITLE
Change instructions to be compatible with MI Dashboard 4.2.0 and java 17

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
@@ -12,7 +12,7 @@
 -   Download and install a service wrapper library to use for running WSO2 API Manager as a Windows service. WSO2 recommends Yet Another Java Service Wrapper ( YAJSW ) version [13.05](https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.05/yajsw-stable-13.05.zip/download) and several WSO2 products provide a default `wrapper.conf` file in their `<PRODUCT_HOME>/bin/yajsw/` directory. The instructions below describe how to set up this file.
 
 !!! important
-    Use YAJSW 13.05 for both JDK 11 and JDK 17 X.
+    Use YAJSW 13.05 for both JDK 11 and JDK 17.
 
 ### Setting up the YAJSW wrapper configuration file
 

--- a/en/docs/install-and-setup/install/installing-the-product/running-the-mi-dashboard-as-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/running-the-mi-dashboard-as-windows-service.md
@@ -33,7 +33,7 @@ YASJW uses the configurations defined in the `<YAJSW_HOME>/conf/wrapper.conf` fi
 
 ## Installing the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt, and execute the following command:
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command:
 
 ```bash
 installService.bat
@@ -41,7 +41,7 @@ installService.bat
 
 ## Starting the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt, and execute the following command:
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command:
 
 ```bash
 startService.bat
@@ -49,7 +49,7 @@ startService.bat
 
 ## Stopping the service
 
-Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt and execute the following command:
+Navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command:
 
 ```bash
 stopService.bat
@@ -57,7 +57,7 @@ stopService.bat
 
 ## Uninstalling the service
 
-To uninstall the service, navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt and execute the following command:
+To uninstall the service, navigate to the `<YAJSW_HOME>/bat/` directory in the Windows command prompt with administrative privileges, and execute the following command:
 
 ```bash
 uninstallServiceService.bat

--- a/en/docs/install-and-setup/install/installing-the-product/running-the-mi-dashboard-as-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/running-the-mi-dashboard-as-windows-service.md
@@ -16,7 +16,7 @@ Follow the instructions given below to run the Micro Integrator Dashboard as a W
 YASJW uses the configurations defined in the `<YAJSW_HOME>/conf/wrapper.conf` file to wrap Java applications. Replace the contents of this file with the configurations that are relevant to the Micro Integrator Dashboard instance that you want to run as a service. Use the **wrapper.conf** file available in `<MI_DASHBOARD_HOME>/bin/yajsw` folder to get the relevant configurations.
 
 !!! Info
-    WSO2 recommends Yet Another Java Service Wrapper (YAJSW) version 12.14. If you are running on JDK 11, previous versions of YAJSW will not be compatible.
+    WSO2 recommends Yet Another Java Service Wrapper (YAJSW) version [13.05](https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.05/yajsw-stable-13.05.zip/download). If you are running on JDK 11 or JDK 17, previous versions of YAJSW will not be compatible.
 
 !!! tip
     You may encounter the following issue when starting Windows Services when the file "java" or a "dll" used by Java cannot be found by YAJSW.
@@ -28,7 +28,7 @@ YASJW uses the configurations defined in the `<YAJSW_HOME>/conf/wrapper.conf` fi
     This can be resolved by providing the "complete java path" for the wrapper.java.command as follows.
 
     ```bash
-    wrapper.java.command = ${JAVA_HOME}/bin/java
+    wrapper.java.command = ${java_home}/bin/java
     ```
 
 ## Installing the service


### PR DESCRIPTION
## Purpose

- When configured according to the docs, cannot run MI Dashboard On windows as a Service with Java 17.
- Related to https://github.com/wso2/api-manager/issues/1506
- Also fix typo in a previous PR.

## Approach
- Made the relevant doc changes with updated yajsw(13.05).
- Added the `open a console with administrative privileges` in relevant places.