### PR TITLE
Update instructions to support SI 4.2.0 and Java 17

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-si-as-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-si-as-windows-service.md
@@ -9,28 +9,19 @@
 ### Prerequisites
 
 -   Install JDK and set up the `JAVA_HOME` environment variable.
--   Download and install a service wrapper library to use for running WSO2 API Manager as a Windows service. WSO2 recommends Yet Another Java Service Wrapper ( YAJSW ) versions [11.03](https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable11.03/yajsw-stable-11.03.zip/download) or [12.14](https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-12.14/), and several WSO2 products provide a default `wrapper.conf` file in their `<PRODUCT_HOME>/bin/yajsw/` directory. The instructions below describe how to set up this file.
+-   Download and install a service wrapper library to use for running WSO2 Streaming Integrator as a Windows service. WSO2 recommends Yet Another Java Service Wrapper ( YAJSW ) version [13.05](https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.05/yajsw-stable-13.05.zip/download), and several WSO2 products provide a default `wrapper.conf` file in their `<PRODUCT_HOME>/bin/yajsw/` directory. The instructions below describe how to set up this file.
 
 !!! important
-    Please note that JDK 11 might not be compatible with YAJSW 11.03. Use JDK 8 for YAJSW 11.03 and JDK 11 for YAJSW 12.14.
+    Use YAJSW 13.05 for both JDK 11 and JDK 17.
 
 ### Setting up the YAJSW wrapper configuration file
 
-The configuration file used for wrapping Java Applications by YAJSW is `wrapper.conf` , which is located in the `<YAJSW_HOME>/conf/` directory. The configuration file in `<PRODUCT_HOME>/bin/yajsw/` directory of many WSO2 products can be used as a reference for this. Following is the minimal `wrapper.conf` configuration for running a WSO2 product as a Windows service. Open your `wrapper.conf` file in `<YAJSW_HOME>/conf/` directory, set its properties as follows, and save it.
+The configuration file used for wrapping Java Applications by YAJSW is `wrapper.conf` , which is located in the `<YAJSW_HOME>/conf/` directory. Following is the minimal `wrapper.conf` configuration for running a WSO2 Streaming Integrator as a Windows service. Open your `wrapper.conf` file in `<YAJSW_HOME>/conf/` directory, set its properties as follows, and save it.
 
 !!! info
     
     If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
 
-!!! note
-    
-    Manual Configurations
-
-    Add the following class path to the `wrapper.conf` file manually to avoid errors in the WSO2 API Manager Management Console:
-
-    ``` bash
-    wrapper.java.classpath.3 = ${carbon_home}/repository/components/plugins/commons-lang_2.6.0.wso2v1.jar 
-    ```
 
 !!! tip
     You may encounter the following issue when starting Windows Services when the file "java" or a "dll" used by Java cannot be found by YAJSW. 
@@ -68,7 +59,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
     # One of the following properties MUST be defined
     #********************************************************************
     # Java Application main class
-    wrapper.java.app.mainclass=org.wso2.carbon.bootstrap.Bootstrap
+    wrapper.java.app.mainclass=org.wso2.carbon.launcher.Main
     # Log Level for console output.  (See docs for log levels)
     wrapper.console.loglevel=INFO
     # Log file to use for wrapper output logging.
@@ -87,16 +78,16 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
     #  files are deleted.  The default value of 0 implies no limit.
     wrapper.logfile.maxfiles=10
     # Title to use when running as a console
-    wrapper.console.title=WSO2 Carbon
+    wrapper.console.title="WSO2 Streaming Integrator"
     #********************************************************************
     # Wrapper Windows Service and Posix Daemon Properties
     #********************************************************************
     # Name of the service
-    wrapper.ntservice.name=WSO2CARBON
+    wrapper.ntservice.name=WSO2SI
     # Display name of the service
-    wrapper.ntservice.displayname=WSO2 Carbon
+    wrapper.ntservice.displayname=WSO2 Streaming Integrator 4.2.0
     # Description of the service
-    wrapper.ntservice.description=Carbon Kernel
+    wrapper.ntservice.description=Provides the ability to run WSO2 Streaming Integrator 4.2.0 as a Windows Service
     #********************************************************************
     # Wrapper System Tray Properties
     #********************************************************************
@@ -123,51 +114,35 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
     #********************************************************************
     placeHolderSoGenPropsComeHere=
     wrapper.java.command = java
-    wrapper.java.classpath.1 = ${carbon_home}/bin/*.jar
-    wrapper.java.classpath.2 = ${carbon_home}/lib/commons-lang-*.jar
-    wrapper.java.classpath.3 = ${carbon_home}/lib/*.jar
-    wrapper.app.parameter.1 = org.wso2.carbon.bootstrap.Bootstrap
-    wrapper.app.parameter.2 = RUN
-    wrapper.java.additional.1 = -Xbootclasspath/a:${carbon_home}/lib/xboot/*.jar
+    wrapper.java.classpath.1 = ${carbon_home}/bin/bootstrap/*.jar
+    wrapper.app.parameter.1 = RUN
+    wrapper.app.parameter.2 = --run
+    wrapper.java.additional.1 = -Xbootclasspath/a:
     wrapper.java.additional.2 = -Xms256m
     wrapper.java.additional.3 = -Xmx1024m
-    wrapper.java.additional.4 = -XX:MaxPermSize=256m
-    wrapper.java.additional.5 = -XX:+HeapDumpOnOutOfMemoryError
-    wrapper.java.additional.6 = -XX:HeapDumpPath=${carbon_home}/repository/logs/heap-dump.hprof
-    wrapper.java.additional.7 = -Dcom.sun.management.jmxremote
-    wrapper.java.additional.8 = -Dcarbon.registry.root=\/
-    wrapper.java.additional.9 = -Dcarbon.home=${carbon_home}
-    wrapper.java.additional.10 = -Dwso2.server.standalone=true
-    wrapper.java.additional.11 = -Djava.command=${java_home}/bin/java
+    wrapper.java.additional.4 = -XX:+HeapDumpOnOutOfMemoryError
+    wrapper.java.additional.5 = -XX:HeapDumpPath=${carbon_home}/logs/heap-dump.hprof
+    wrapper.java.additional.6 = -Dcom.sun.management.jmxremote
+    wrapper.java.additional.7 = -Dcarbon.home=${carbon_home}
+    wrapper.java.additional.8 = -Dcarbon.config.dir.path=${carbon_home}/conf
+    wrapper.java.additional.9 = -Dwso2.runtime.path=${carbon_home}\wso2\server
+    wrapper.java.additional.10 = -Dwso2.runtime=server
+    wrapper.java.additional.11 = -Djava.command= java
     wrapper.java.additional.12 = -Djava.io.tmpdir=${carbon_home}/tmp
-    wrapper.java.additional.13 = -Dcatalina.base=${carbon_home}/lib/tomcat
-    wrapper.java.additional.14 = -Djava.util.logging.config.file=${carbon_home}/repository/conf/etc/logging-bridge.properties
-    wrapper.java.additional.15 = -Dcarbon.config.dir.path=${carbon_home}/repository/conf
-    wrapper.java.additional.16 = -Dcarbon.logs.path=${carbon_home}/repository/logs
-    wrapper.java.additional.17 = -Dcomponents.repo=${carbon_home}/repository/components/plugins
-    wrapper.java.additional.18 = -Dconf.location=${carbon_home}/repository/conf
-    wrapper.java.additional.19 = -Dcom.atomikos.icatch.file=${carbon_home}/lib/transactions.properties
-    wrapper.java.additional.20 = -Dcom.atomikos.icatch.hide_init_file_path=true
-    wrapper.java.additional.21 = -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true
-    wrapper.java.additional.22 = -Dcom.sun.jndi.ldap.connect.pool.authentication=simple
-    wrapper.java.additional.23 = -Dcom.sun.jndi.ldap.connect.pool.timeout=3000
-    wrapper.java.additional.24 = -Dorg.terracotta.quartz.skipUpdateCheck=true
-    wrapper.java.additional.25 = -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false
-    wrapper.java.additional.26 = -Dfile.encoding=UTF8
-    wrapper.java.additional.27 = -DworkerNode=false
-    wrapper.java.additional.28 = -Dhttpclient.hostnameVerifier=DefaultAndLocalhost
-    wrapper.java.additional.29 = -Dcarbon.new.config.dir.path=${carbon_home}/repository/resources/conf
+    wrapper.java.additional.13 = -Djava.util.logging.config.file=${carbon_home}/conf/server/etc/pax-logging.properties
 ```
 
 ### Setting up CARBON\_HOME
 
-Extract WSO2 API Manager that you want to run as a Windows service, and then set the Windows environment variable `CARBON_HOME` to the extracted product directory location which is for example wso2am-2.1.0 here.
+Extract WSO2 Streaming Integrator that you want to run as a Windows service, and then set the Windows environment variable `carbon_home` to the extracted product directory location which is for example wso2si-4.2.0 here.
+
+
 
 ### Running the product in console mode
 
-You will now verify that YAJSW is configured correctly for running the WSO2 API Manager as a Windows service.
+You will now verify that YAJSW is configured correctly for running the WSO2 Streaming Integrator as a Windows service.
 
-1.  Open a Windows command prompt and go to the `<YAJSW_HOME>/bat/` directory. For example:
+1.  Open a Windows command prompt with administrative privileges and go to the `<YAJSW_HOME>/bat/` directory. For example:
 
     ``` java
     cd C:\Documents and Settings\yajsw_home\bat
@@ -179,25 +154,14 @@ You will now verify that YAJSW is configured correctly for running the WSO2 API 
     runConsole.bat
     ```
 
-    For example:
+### Working with the WSO2SI service
 
-    ![]({{base_path}}/assets/attachments/28717183/29364287.png)
-
-If the configurations are set properly for YAJSW, you will see console output similar to the following and can now access the WSO2 management console from your web browser via <https://localhost:9443/carbon>.
-
-![]({{base_path}}/assets/attachments/28717183/29364286.png)
-
-### Working with the WSO2CARBON service
-
-To install the Carbon-based product WSO2 API Manager as a Windows service, execute the following command in the `<YAJSW_HOME>/bat/` directory:
+To install the Carbon-based product WSO2 Streaming Integrator as a Windows service, execute the following command in a comand prompt with administrative privileges in the `<YAJSW_HOME>/bat/` directory:
 
 ``` java
 installService.bat
 ```
 
-The console will display a message confirming that the WSO2CARBON service was installed.
-
-![]({{base_path}}/assets/attachments/28717183/29364285.png)
 
 To start the service, execute the following command in the same console window:
 
@@ -205,9 +169,6 @@ To start the service, execute the following command in the same console window:
 startService.bat
 ```
 
-The console will display a message confirming that the WSO2CARBON service was started.
-
-![]({{base_path}}/assets/attachments/28717183/29364288.png)
 
 To stop the service, execute the following command in the same console window:
 
@@ -215,16 +176,9 @@ To stop the service, execute the following command in the same console window:
 stopService.bat
 ```
 
-The console will display a message confirming that the WSO2CARBON service has stopped.
-
-![]({{base_path}}/assets/attachments/28717183/29364290.png)
 
 To uninstall the service, execute the following command in the same console window:
 
 ``` java
 uninstallService.bat
 ```
-
-The console will display a message confirming that the WSO2CARBON service was removed.
-
-![]({{base_path}}/assets/attachments/28717183/29364291.png)


### PR DESCRIPTION
## Purpose
- Update docs to include instructions for running SI as a windows service on Java 17 with YAJSW.
- Related Issues: https://github.com/wso2/api-manager/issues/1506

## Approach
- Add new `wrapper.conf` for the Streaming Integrator.
- Remove unnecessary instructions and screenshots which were used for the APIM docs. 
- Made the relevant doc changes with updated YAJSW version 13.05.
- Updated the instructions to `Windows command prompt with administrative privileges`.

