### PR TITLE
fix invoke an API link

### DIFF
--- a/en/docs/administer/key-managers/configure-custom-connector.md
+++ b/en/docs/administer/key-managers/configure-custom-connector.md
@@ -465,4 +465,4 @@ When registering a third-party Identity Provider as a Key Manager in the Admin P
     !!! tip
         If you want to generate the tokens with scopes, make sure that those scopes are defined in the Authorization Server.
 
-6. You can now use the generated token to [invoke an API]({{base_path}}/consume/invoke-apis/invoke-apis-using-tools/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console).
+6. You can now use the generated token to [invoke an API]({{base_path}}/consume/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console).


### PR DESCRIPTION
## Purpose
> the link 'invoke an API' is wrong

## Goals
> fix the link 'invoke an API'

## Approach
> I have searched the correct page on the website, compared the URL with the one here and figured out the issue
## User stories
> Improve the user experience when using the 'configure a custom key manager' documentation 

## Release note
> fix 'invoke an API' link on the 'configure a custom key manager' documentation page

## Documentation
> https://apim.docs.wso2.com/en/latest/administer/key-managers/configure-custom-connector/

## Training
> N/A

## Certification
> N/A obviously

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A