### PR TITLE
[4.1.0] Added the documentation for 'Update Users' in MI management API

### DIFF
--- a/en/docs/observe/mi-observe/working-with-management-api.md
+++ b/en/docs/observe/mi-observe/working-with-management-api.md
@@ -194,6 +194,37 @@ The management API has multiple resources to provide information regarding the d
       “status”:deleted
     }
   	```
+	
+### UPDATE USERS
+
+-	**Resource**: `/users`
+
+	**Description**: Update the password of a user from the [external user store]({{base_path}}/install-and-setup/setup/mi-setup/user_stores/setting_up_a_userstore). Note that only super admin user can remove other users with admin access. Any user with admin access can update the own password and the passwords of non-admin users.
+
+	**Example**:
+
+	First create the following JSON file with user details as shown below. Here we are changing the password of user1.
+
+    ```json
+    {
+     "newPassword": "user111",
+     "confirmPassword": "user111",
+     "oldPassword": "user1"
+    }
+    ```
+    The following request update the password of the `user1` from the user store:
+
+  	```bash tab='Request'
+  	curl -X PATCH -d @user "https://localhost:9164/management/users/user1" -H "accept: application/json" -H "Authorization: Bearer %AccessToken%" -k
+  	```
+
+  	```bash tab='Response'
+    {
+	  "userId":"user1",
+      "status":"Password updated"
+    }
+  	```
+
 
 ### GET Roles
 


### PR DESCRIPTION
## Purpose
Adding new management API to change non-user credentials using any admin user credentials. Admin user credentials can be changed by the same admin or the super admin.

## Approach
Adding a new Management API

## Documentation
https://apim.docs.wso2.com/en/4.1.0/observe/mi-observe/working-with-management-api/

Resolved: https://github.com/wso2/docs-apim/issues/6983