### PR TITLE
Update script mediator docs with NashornJS removal

### DIFF
--- a/en/docs/integrate/examples/json_examples/json-examples.md
+++ b/en/docs/integrate/examples/json_examples/json-examples.md
@@ -696,8 +696,10 @@ using the `         getPayloadJSON        ` and
 `         setPayloadJSON        ` methods. 
 
 !!! Note
-    If you are using **nashornJS** as the JavaScript language, and also if you have JSON operations defined in the Script mediator, you need to have JDK version `8u112` or a later version in your environment.
+    - If you are using **nashornJS** as the JavaScript language, and also if you have JSON operations defined in the Script mediator, you need to have JDK version `8u112` or a later version in your environment.
     If your environment has an older JDK version, the Script mediator (that uses nashornJS and JSON operations) will not function properly because of this [JDK bug](https://bugs.openjdk.java.net/browse/JDK-8157160). That is, you will encounter server exceptions in the Micro Integrator.
+
+    - If you are using JDK 15 or above, you need to manually copy the [nashorn-core](https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core/15.4) and [asm-util](https://mvnrepository.com/artifact/org.ow2.asm/asm-util/9.5) jars to the <code>&lt;MI_HOME&gt;/lib</code> directory since Nashorn was [removed](https://openjdk.org/jeps/372) from the JDK in Java 15.
 
 **Example**
 

--- a/en/docs/reference/mediators/script-mediator.md
+++ b/en/docs/reference/mediators/script-mediator.md
@@ -69,6 +69,9 @@ and when using Ruby, REXML documents.
 -   If you are using **nashornJS** as the JavaScript language, and also if you have JSON operations defined in the Script mediator, you need to have JDK version `8u112` or a later version in your environment.
     If your environment has an older JDK version, the Script mediator (that uses nashornJS and JSON operations) will not function properly because of this [JDK bug](https://bugs.openjdk.java.net/browse/JDK-8157160). That is, you will encounter server exceptions in the Micro Integrator.
 
+    !!! Note
+         If you are using JDK 15 or above, you need to manually copy the [nashorn-core](https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core/15.4) and [asm-util](https://mvnrepository.com/artifact/org.ow2.asm/asm-util/9.5) jars to the <code>&lt;MI_HOME&gt;/lib</code> directory since Nashorn was [removed](https://openjdk.org/jeps/372) from the JDK in Java 15.
+
 -   Listed below are the prerequisites for writing a Script mediator using
 JavaScript, Groovy, or Ruby.
 


### PR DESCRIPTION
## Purpose
Update script mediator docs with NashornJS removal from JDK and add steps to manually copy the jars

Fixes: https://github.com/wso2/api-manager/issues/1725

![Screenshot from 2023-05-16 10-15-51](https://github.com/wso2/docs-apim/assets/18748929/17358a50-a026-451b-b0e4-bf8ba3bb6f1b)


