### PR TITLE
Doc changes for additionalProperties in the params.yaml

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-environment-specific-parameters.md
@@ -226,6 +226,10 @@ environments:
           policies: 
               - <subscription_policy_1_name>
               - <subscription_policy_2_name>
+          additionalProperties:
+              - name: <additional_property_name>
+                value: <additional_property_value>
+                display: <whether_additional_property_is_enabled_for_display_in_devportal>
 ```
 
 The following code snippet contains sample configuration of the parameters file of an API.
@@ -258,6 +262,13 @@ The following code snippet contains sample configuration of the parameters file 
         policies:
             - Gold
             - Silver 
+        additionalProperties:
+            - name: property1
+              value: http://property.name1
+              display: true
+            - name: property2
+              value: http://property.name2
+              display: false
     - name: test
       configs:
         endpoints:
@@ -418,6 +429,10 @@ environments:
                       policies: 
                           - <subscription_policy_1_name_for_api_1>
                           - <subscription_policy_2_name_for_api_1>
+                      additionalProperties:
+                          - name: <additional_property_name>
+                            value: <additional_property_value>
+                            display: <whether_additional_property_is_enabled_for_display_in_devportal>
               <api_2_name>-<api_2_version>:
                       endpoints:
                           production:
@@ -504,6 +519,10 @@ environments:
                       policies: 
                           - <subscription_policy_1_name_for_api_2>
                           - <subscription_policy_2_name_for_api_2>
+                      additionalProperties:
+                          - name: <additional_property_name>
+                            value: <additional_property_value>
+                            display: <whether_additional_property_is_enabled_for_display_in_devportal>
           deploymentEnvironments:
               - displayOnDevportal: <boolean>
 	            deploymentEnvironment: <environment_name>
@@ -515,6 +534,10 @@ environments:
           policies: 
               - <subscription_policy_1_name>
               - <subscription_policy_2_name>
+          additionalProperties:
+              - name: <additional_property_name>
+                value: <additional_property_value>
+                display: <whether_additional_property_is_enabled_for_display_in_devportal>
 ```
 
 The following code snippet contains sample configuration of the parameters file of an API Product.
@@ -558,6 +581,13 @@ The following code snippet contains sample configuration of the parameters file 
                   policies:
                       - Gold
                       - Silver
+                  additionalProperties:
+                      - name: property1
+                        value: http://property.name1
+                        display: true
+                      - name: property2
+                        value: http://property.name2
+                        display: false
               PetstoreAPI-1.0.5:
                   endpoints:
                       production:
@@ -582,6 +612,13 @@ The following code snippet contains sample configuration of the parameters file 
                   policies:
                       - Gold
                       - Silver
+                  additionalProperties:
+                      - name: property1
+                        value: http://property.name1
+                        display: true
+                      - name: property2
+                        value: http://property.name2
+                        display: false
           deploymentEnvironments:
               - displayOnDevportal: true
                 deploymentEnvironment: Label1
@@ -592,6 +629,13 @@ The following code snippet contains sample configuration of the parameters file 
           policies:
               - Gold
               - Silver 
+          additionalProperties:
+              - name: property1
+                value: http://property.name1
+                display: true
+              - name: property2
+                value: http://property.name2
+                display: false
           mutualSslCerts:
               - tierName: Unlimited
                 alias: Prod1


### PR DESCRIPTION
### Purpose
With the PR [1] we have added the support to adding additional Properties to the params.yaml file which can be used to override the additionalProperties of the exported APIs when importing it to the new environment (Similar to overriding the production/sandbox urls using the params.yaml file).

### Goal
Fixes: https://github.com/wso2/api-manager/issues/1862

[1] https://github.com/wso2/carbon-apimgt/pull/12033