### PR TITLE
[CC 1.0.0.20] Add Mutual SSL Authentication support for CC as an update

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
@@ -1339,7 +1339,7 @@ enableOutboundCertificateHeader = false
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Header name which client certificate coming from the downstream client</p>
+                                        <p>The header name from which the client certificate is coming is from the downstream client</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/enforcer-configurations.md
@@ -1293,7 +1293,7 @@ enabled = true</code></pre>
 
 
 
-## Token Service
+## Mutual SSL
 
 
 <div class="mb-config-catalog">
@@ -1303,6 +1303,123 @@ enabled = true</code></pre>
             
             <input name="13" type="checkbox" id="_tab_13">
                 <label class="tab-selector" for="_tab_13"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[enforcer.security.mutualSSL]
+certificateHeader = "X-WSO2-CLIENT-CERTIFICATE"
+enableClientValidation = true
+clientCertificateEncode = false
+enableOutboundCertificateHeader = false
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[enforcer.security.mutualSSL]</code>
+                            
+                            <p>
+                                Configurations related to Mutual SSL
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>certificateHeader</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>X-WSO2-CLIENT-CERTIFICATE</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Header name which client certificate coming from the downstream client</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enableClientValidation</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Select between directly sending client certificate and sending client certificate within a header</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>clientCertificateEncode</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable/Disable client certificate decode process in Choreo Connect when the certificate is passed in a header.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enableOutboundAuthHeader</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Remove client certificate header from backend request.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Token Service
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="14" type="checkbox" id="_tab_14">
+                <label class="tab-selector" for="_tab_14"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[enforcer.security.tokenService]]
@@ -1478,8 +1595,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="14" type="checkbox" id="_tab_14">
-                <label class="tab-selector" for="_tab_14"><i class="icon fa fa-code"></i></label>
+            <input name="15" type="checkbox" id="_tab_15">
+                <label class="tab-selector" for="_tab_15"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling]
@@ -1635,8 +1752,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="15" type="checkbox" id="_tab_15">
-                <label class="tab-selector" for="_tab_15"><i class="icon fa fa-code"></i></label>
+            <input name="16" type="checkbox" id="_tab_16">
+                <label class="tab-selector" for="_tab_16"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher]
@@ -1711,8 +1828,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="16" type="checkbox" id="_tab_16">
-                <label class="tab-selector" for="_tab_16"><i class="icon fa fa-code"></i></label>
+            <input name="17" type="checkbox" id="_tab_17">
+                <label class="tab-selector" for="_tab_17"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[enforcer.throttling.publisher.URLGroup]]
@@ -1787,8 +1904,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="17" type="checkbox" id="_tab_17">
-                <label class="tab-selector" for="_tab_17"><i class="icon fa fa-code"></i></label>
+            <input name="18" type="checkbox" id="_tab_18">
+                <label class="tab-selector" for="_tab_18"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher.pool]
@@ -1923,8 +2040,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="18" type="checkbox" id="_tab_18">
-                <label class="tab-selector" for="_tab_18"><i class="icon fa fa-code"></i></label>
+            <input name="19" type="checkbox" id="_tab_19">
+                <label class="tab-selector" for="_tab_19"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher.agent]
@@ -2301,8 +2418,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="19" type="checkbox" id="_tab_19">
-                <label class="tab-selector" for="_tab_19"><i class="icon fa fa-code"></i></label>
+            <input name="20" type="checkbox" id="_tab_20">
+                <label class="tab-selector" for="_tab_20"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.metrics]

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
@@ -896,7 +896,7 @@ allowCredentials = false
                             <code>[router.upstream.tls]</code>
                             
                             <p>
-                                The configurations for SSL configuration related to the backend connection in Choreo Connect.
+                                The configurations for SSL related to the downstream in Choreo Connect.
                             </p>
                         </div>
                         <div class="params-wrap">

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
@@ -1033,7 +1033,7 @@ allowCredentials = false
 
 
 
-## Filters used in the Router
+## Downstream TLS
 
 
 <div class="mb-config-catalog">
@@ -1045,6 +1045,86 @@ allowCredentials = false
                 <label class="tab-selector" for="_tab_10"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
+<pre><code class="toml">[router.downstream.tls]
+# the default client ca-certificates
+trustedCertPath = "/etc/ssl/certs/ca-certificates.crt"
+mTLSAPIsEnabled = false
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[router.downstream.tls]</code>
+                            
+                            <p>
+                                The configurations for SSL configuration related to the downstream in Choreo Connect.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>trustedCertPath</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>/etc/ssl/certs/ca-certificates.crt</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Path to trusted ca-certificates</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>mTLSAPIsEnabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable mTLS APIs in Choreo Connect.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Filters used in the Router
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="11" type="checkbox" id="_tab_11">
+                <label class="tab-selector" for="_tab_11"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
 <pre><code class="toml">[router.filters]
   [router.filters.compression]
     enabled = true
@@ -1052,11 +1132,11 @@ allowCredentials = false
   [router.filters.compression.requestDirection]
     enabled = false
     minimumContentLength = 30
-    contentType = ["text/html","application/json"]
+    contentType = ["application/javascript", "application/json", "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"]
   [router.filters.compression.responseDirection]
     enabled = true
     minimumContentLength = 30
-    contentType = ["text/html","application/json"]
+    contentType = ["application/javascript", "application/json", "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"]
     enableForEtagHeader = true
   [router.filters.compression.libraryProperties]
     memoryLevel = 3
@@ -1411,4 +1491,5 @@ allowCredentials = false
         </div>
     </section>
 </div>
+
 

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/supported-features.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/supported-features.md
@@ -26,6 +26,7 @@ The following is a list of Choreo Connect's important features.
     - Scope validation for JWT OAuth2 bearer tokens
     - Backend JWT generation (Passing end user details to the backend services)
     - Support for API keys
+    - Mutual SSL authentication for APIs
 
 - Rate Limiting
     - API/Resource, application, and subscription level rate limiting 
@@ -73,7 +74,6 @@ The Choreo Connect currently does not support the following major functionalitie
 - GraphQL APIs
 - gRPC APIs
 - API Products
-- Mutual SSL authentication for APIs
 - Basic Authentication for APIs
 - Bandwidth based rate limiting
   

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
@@ -71,7 +71,7 @@ Certificate-based authentication on the Choreo Connect is authenticating a reque
       curl -k --location -X GET 'https://localhost:9095/test/1.0/foo' -H 'accept: applicaition/json' -H 'Authorization: Bearer  0ee9aa70-d631-3401-b152-521b431036ca' --key privateKey.key --cert example.pem
      ```
 
-!!!Note
+!!! Note
     `enableClientValidation` configuration should be `true` for sending the client certificates directly to the Choroe Connect. No need to add this configuration to the `config.toml` file since this is the default configuration. If you have added this and changed this to `false`, then the client certificates should be sent within a header.
     ```
      [enforcer.security.mutualSSL]

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
@@ -1,0 +1,132 @@
+# Mutual SSL Authentication
+
+Certificate-based authentication on the Choreo Connect is authenticating a request based on a digital certificate, before granting access to the backend. By way of certificate-based authentication, the Choreo Connect supports mutual SSL. In mutual SSL, both parties the client and the server identifies themselves in order to create a successful SSL connection. Mutual SSL allows a client to make a request without a username and password, provided that the server is aware of the client's certificate.
+
+!!! attention "Update Level 20"
+    This feature is available only as an update, after Update level 1.0.0.20 (released on 14 June 2023) and further. For more information regarding Choreo Connect updates, see [here]({{base_path}}/deploy-and-publish/deploy-on-gateway/choreo-connect/update-choreo-connect/).
+
+### Prerequisites
+
+- Navigate to the `<CHOREO-CONNECT_HOME>/docker-compose/choreo-connect(-with-apim)/conf/config.toml` file.
+- Configure the `mTLSAPIsEnabled` to `true` under the `[router.downstream.tls]` configuration to enable the mTLS APIs in the Choreo Connect.
+
+     ```
+      [router.downstream.tls]
+         trustedCertPath = "/etc/ssl/certs/ca-certificates.crt"  # Default path for client ca-certificates
+         mTLSAPIsEnabled = true
+     ```
+
+    !!! important
+        Make sure to **close** the **HTTP** port when using this feature, and leave only the **HTTPS** port open. This would prevent any attempts to bypass the mTLS authentication. You may close the port by following one of the steps given below.
+
+        <table>
+          <tr>
+            <th>Deployment</th>
+            <th>Configuration</th>
+          </tr>
+          <tr>
+            <td>Docker Compose</td>
+            <td>Set `router.listenerPort` to `0` in the `config.toml` file.</td>
+          </tr>
+          <tr>
+            <td>Kubernetes</td>
+            <td>Set `router.listenerPort` to `0` in the `config-toml-configmap` file.</td>
+          </tr>
+          <tr>
+            <td>Kubernetes with Helm Charts</td>
+            <td>
+            Remove the following section from the `templates/router-service.yaml` file.
+            ```yaml
+            - name: "http-router"
+              port: 9090
+              targetPort: 9090
+              protocol: TCP
+            ```
+            Or else, set `router.listenerPort` to `0` in a new `config-toml-configmap.yaml` file and use this file during deployment with the flag `--set-file wso2.deployment.adapter.configToml=<FILE_PATH_FOR_TEMPLATED_CONFIG_TOML>`. Make sure that the other values are also set correctly in the new Configuration file.
+            </td>
+          </tr>
+        </table>
+          
+
+{!includes/design/create-mtls-api.md!}
+
+!!! Important
+    To invoke mTLS enabled APIs that deployed in Choreo Connect, the CA certificates of the client's public certificates should be added as trusted certificates to the router.
+
+      - [Add a Certificate to Choreo Connect Router as a Trusted Certificate]({{base_path}}/deploy-and-publish/deploy-on-gateway/choreo-connect/security/tls/backend-certificates/#add-a-certificate-to-choreo-connect-router-as-a-trusted-certificate)
+
+    If you need to change the location of the volume mount, the `trustedCertPath` value under the `[router.downstream.tls]` in config.toml should also be changed.
+
+{!includes/design/invoke-mtls-api-using-postman.md!}
+
+### Invoke an API secured with Mutual SSL using cURL
+
+-   
+
+     ``` tab="Format"
+      curl -k --location -X GET "<API_URL>" -H  "accept: application/json" -H  "Authorization: Bearer <access-token>" --key <client_private_key> --cert <client_public_certificate>
+     ```
+
+     ``` tab="Example"
+      curl -k --location -X GET 'https://localhost:9095/test/1.0/foo' -H 'accept: applicaition/json' -H 'Authorization: Bearer  0ee9aa70-d631-3401-b152-521b431036ca' --key privateKey.key --cert example.pem
+     ```
+
+!!!Note
+    `enableClientValidation` configuration should be `true` for sending the client certificates directly to the Choroe Connect. No need to add this configuration to the `config.toml` file since this is the default configuration. If you have added this and changed this to `false`, then the client certificates should be sent within a header.
+    ```
+     [enforcer.security.mutualSSL]
+         enableClientValidation = true
+    ```
+
+### Limitations
+
+Listed below are the known limitations for this feature.
+
+-   Application subscription is not permitted for APIs that are only protected with Mutual SSL. Therefore, subscription or application-level throttling is not applicable to these types of APIs.
+
+-   Resource-level throttling is not applicable to the APIs that are only protected with Mutual SSL.
+
+-   Resource-level security will not be applicable to the APIs that are only protected with Mutual SSL.
+
+-   Scope-level security will not be applicable to the APIs that are only protected with Mutual SSL.
+
+{!includes/design/handling-mtls-ssl-termination.md!}
+
+### Using mTLS Header to invoke APIs secured with Mutual SSL
+
+By default, the Choreo Connect retrieves the client certificate from the **X-WSO2-CLIENT-CERTIFICATE** HTTP header.
+
+Follow the instructions below to enable the mTLS Header and some properties:
+
+1.  Navigate to the `<CHOREO-CONNECT_HOME>/docker-compose/choreo-connect(-with-apim)/conf/config.toml` file.
+2.  Configure the `enableClientValidation` to `false` under the `[enforcer.security.mutualSSL]` configuration to enable the mTLS Header.
+
+    ``` tab="Format"
+     [enforcer.security.mutualSSL]
+        certificateHeader = "<Header Name>"      # This will give a custom header name for the mTLS header
+        enableClientValidation = false           # This should be false to check the header value for the client certificate
+        clientCertificateEncode = false          # This should be true if the client certificate in the header is encoded
+        enableOutboundCertificateHeader = false  # This should be true if the client certificate is needed to be sent to the backend
+    ```
+
+    ``` tab="Example"
+     [enforcer.security.mutualSSL]
+        certificateHeader = "SSL-CLIENT-CERT"
+        enableClientValidation = false
+        clientCertificateEncode = false
+        enableOutboundCertificateHeader = false
+    ```
+
+3.  Start the Server.
+4.  Invoke the API  with the custom header.
+
+     ``` bash tab="Format"
+     curl -k --location -X GET "<API_URL>" -H  "accept: application/json" -H  "Authorization: Bearer <access-token>" -H "<MTSL_Header_name>:<Certificate_Key>"
+     ```
+
+     ``` bash tab="Example"
+     curl -k --location -X GET 'https://localhost:9095/test/1.0/foo' -H 'accept: applicaition/json' -H 'Authorization: Bearer 0ee9aa70-d631-3401-b152-521b431036ca' -H 'SSL-CLIENT-CERT: -----BEGIN CERTIFICATE-----LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURsakNDQW40Q0NRRDc2MUpWekluMGNUQU5CZ2txaGtpRzl3MEJBUXNGQURDQmpERUxNQWtHQTFVRUJoTUMKVTB3eEVEQU9CZ05WQkFnTUIxZGxjM1JsY200eEVEQU9CZ05WQkFjTUIwTnZiRzl0WW04eERUQUxCZ05WQkFvTQpCRmRUVHpJeEN6QUpCZ05WQkFzTUFrTlRNUkl3RUFZRFZRUUREQWxzYjJOaGJHaHZjM1F4S1RBbkJna3Foa2lHCjl3MEJDUUVXR25kaGRHaHpZV3hoYTI5eVlXeGxaMlZBWjIxaGFXd3VZMjl0TUI0WERUSXhNREV4TkRBME16VXoKTlZvWERUSXlNREV4TkRBME16VXpOVm93Z1l3eEN6QUpCZ05WQkFZVEFsTk1NUkF3RGdZRFZRUUlEQWRYWlhOMApaWEp1TVJBd0RnWURWUVFIREFkRGIyeHZiV0p2TVEwd0N3WURWUVFLREFSWFUwOHlNUXN3Q1FZRFZRUUxEQUpEClV6RVNNQkFHQTFVRUF3d0piRzlqWVd4b2IzTjBNU2t3SndZSktvWklodmNOQVFrQkZocDNZWFJvYzJGc1lXdHYKY21Gc1pXZGxRR2R0WVdsc0xtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQgpBTWMrRjhJblZmMzAwZ2FraTh2QUZ6cUFTSGNQV0xZalQ4dmMwOUs1TzZHRjgzaXpUa2F0UDFtYW1ydWlKL2VRCk1KL2VLVGhJdzR3MWEzS3Y4cjJwc3d2bWRjdjAzZnhRNis2aFh3Ykh5VUtHWFFwbVhtL3d5VE01NzRlR1cybXAKM2toTjlIdFV0SU5uS3BzSENLcFI3MFhGKzNrTTZleHJJNnRJUUpxdTdKM2t1OEdqRVI3R1Vma2trYXI1OGs3eApibEpIWG5URkdjWXJNSXAvcS9YUENqR0pGajhub2tNbjhnL0dWTExCVGFXSWJVa3E2ejRJYjk1dHNOd2thU1dhCnh6U2t3K3JIVkZLWnpPTlV1WTdKTk16Zkp6RkllZG5lY0U3c2Y0WnFIRlF6aUpVbW9qWklDMXp5bFdZdzQ4OEUKNUZvaU9xTWpHYTlUMXhXMUpOWTBab01DQXdFQUFUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFSZTdrcWZlbwpjd1htazRLWlBKMmlnaGY2VU9jc2dYSEZqMnVpQTNhSWMrd2xwREJpdkdCbDJHM2gxQXl6UFNtcVpYaUcvTGttCkg1dm43VUpGQXlQRVBlQ25HdWduTk5kZGpnSFp0SEdJLzdXcm1LTHdIOEU3TWdmSWJ6dk5Hd3ZXWmRrZi9DblcKNjNDYzhhTzJQMDhYd0dHU25JSDg2cWF6NEtvZUF1aFlCdHZyekNObERraTFjZ1E1bHczU0djU3dxMlB0eEd4cApvS0xWOUJYUzlVdUNJRDRrYjFqRUo3YlplTis0Z0pDbTVGTldUbWdhWXFDcjdERWIwRkhpWitLVnBsZzJZZ3ZYCkM2Z2ZrRm9NYTVJREwvWGVja0J0dFlITzFKcWUyMElRKy9kVHB4ZWE4RjE5aDVmeDRZWVlsRFhLWS8wRmxiRXoKZ1l2UGFIUnVKWnFlV1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==-----END CERTIFICATE-----'
+     ```
+
+!!! note
+     The MTLS flow described above uses the **Nginx** load balancer. When using a different ELB to configure the MTSL with SSL termination, refer the service provider's documentation and feature catalog to do the necessary configurations.

--- a/en/docs/deploy-and-publish/deploy-on-gateway/deploying-apis-in-api-gateway-vs-choreo-connect.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/deploying-apis-in-api-gateway-vs-choreo-connect.md
@@ -25,11 +25,11 @@ Choreo Connect and the "traditional" API Gateway can be compared in different as
 
 API Gateway and Choreo Connect both support different security mechanisms.
 
-| **Security Mechanism**           | **Choreo Connect**                                              | **API Gateway**                       |
-|------------------------------|:-------------------------------------------------------------:|:---------------------------------:|
+| **Security Mechanism**           |                 **Choreo Connect**                  | **API Gateway**                       |
+|------------------------------|:---------------------------------------------------:|:---------------------------------:|
 | OAuth2                        | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
-| Mutual SSL                   | ![(No)]({{base_path}}/assets/img/deploy/error.svg) | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
-| Basic Auth                   | Custom Filter can be developed                    | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
+| Mutual SSL                   | ![(Yes)]({{base_path}}/assets/img/deploy/error.svg) | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
+| Basic Auth                   |           Custom Filter can be developed            | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
 | API Keys                     | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) | ![(Yes)]({{base_path}}/assets/img/deploy/check.svg) |
 
 #### Feature Comparison

--- a/en/docs/design/api-security/api-authentication/secure-apis-using-mutual-ssl.md
+++ b/en/docs/design/api-security/api-authentication/secure-apis-using-mutual-ssl.md
@@ -4,45 +4,13 @@ In contrast to the usual one-way SSL authentication where a client verifies the 
 
 The following section explains as to how the APIs in WSO2 API Manager can be secured using mutual SSL in addition to OAuth2.
 
-## Create an API secured with Mutual SSL
-
-1.  [Create an API]({{base_path}}/design/create-api/create-rest-api/create-a-rest-api/).
-2.  Click **Develop -> API Configurations -> Runtime**.
-3.  Select **Mutual SSL**.
-    
-     [![Enable mutual SSL]({{base_path}}/assets/img/learn/enable-mutual-ssl.png)]({{base_path}}/assets/img/learn/enable-mutual-ssl.png)
-
-4.  Click **Add Certificate** to upload a new client certificate.
-    
-    !!! note
-        This feature currently supports only the `.crt` format for certificates.
-
-        If you need to use a certificate in any other format, you can convert it using a standard tool before uploading it.
-
-
-5.  Provide an alias and public certificate. Select the tier that should be used to throttle out the calls using this particular client certificate and click **Upload**.
-    
-     [![Upload Certificate]({{base_path}}/assets/img/learn/upload-certificate.png)]({{base_path}}/assets/img/learn/upload-certificate.png)
-    
-6.  **Save and Deploy** the API.
+{!includes/design/create-mtls-api.md!}
 
 !!! note
      If you are on a Windows environment, the HTTPS listener would have started on a host address of 0:0:0:0:0:0:0:0. You can verify that from the Carbon logs.
      In that case, you need to define 0:0:0:0:0:0:0:0 as the bindAddress in `<APIM_HOME>/repository/resources/security/listenerprofiles.xml`  
-    
-### Invoke an API secured with Mutual SSL using Postman
 
-Import the certificate and private key to Postman.
-
-1. Navigate to the certificates tab in Postman settings.
-    
-     [![Add the certificate to Postman]({{base_path}}/assets/img/learn/add-certificate-to-postman.png)]({{base_path}}/assets/img/learn/add-certificate-to-postman.png)
-    
-2. Add the certificate and private key.
-
-     [![Provide certificate and private key]({{base_path}}/assets/img/learn/provide-crt-and-private-key.png)]({{base_path}}/assets/img/learn/provide-crt-and-private-key.png)
-    
-3.  Invoke the API from Postman.
+{!includes/design/invoke-mtls-api-using-postman.md!}
 
 ### Limitations
 
@@ -56,18 +24,7 @@ Listed below are the known limitations for this feature.
 
 -   Scope-level security will not be applicable to the APIs that are only protected with Mutual SSL.
 
-### Handling MTLS when SSL is terminated by the Load Balancer or Reverse Proxy
-
-When SSL termination of API requests takes place at the Load Balancer or Reverse Proxy, the following prerequisites need to be met by the Load Balancer.
-
--   Terminate the mutual SSL connection from the client.
--   Pass the client SSL certificate to the Gateway in an HTTP Header. 
-
-     For more information, see the [Nginx documentation](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_client_certificate).
-
-The following diagram illustrates how Mutual SSL works in such an environment.
-
-[![MTLS Load Balancer]({{base_path}}/assets/img/learn/mtls-loadbalancer.png)]({{base_path}}/assets/img/learn/mtls-loadbalancer.png)
+{!includes/design/handling-mtls-ssl-termination.md!}
 
 ### Using MTLS Header to invoke APIs secured with Mutual SSL
 

--- a/en/docs/includes/design/create-mtls-api.md
+++ b/en/docs/includes/design/create-mtls-api.md
@@ -1,0 +1,22 @@
+## Create an API secured with Mutual SSL
+
+1.  [Create an API](https://apim.docs.wso2.com/en/4.0.0/design/create-api/create-rest-api/create-a-rest-api/).
+2.  Click **Develop -> API Configurations -> Runtime**.
+3.  Select **Mutual SSL**.
+
+    [![Enable mutual SSL](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/enable-mutual-ssl.png)](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/enable-mutual-ssl.png)
+
+4.  Click **Add Certificate** to upload a new client certificate.
+
+    !!! note
+    This feature currently supports only the `.crt` format for certificates.
+
+        If you need to use a certificate in any other format, you can convert it using a standard tool before uploading it.
+
+
+5.  Provide an alias and public certificate. Select the tier that should be used to throttle out the calls using this particular client certificate and click **Upload**.
+
+    [![Upload Certificate](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/upload-certificate.png)](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/upload-certificate.png)
+
+6.  **Save and Deploy** the API.
+

--- a/en/docs/includes/design/handling-mtls-ssl-termination.md
+++ b/en/docs/includes/design/handling-mtls-ssl-termination.md
@@ -1,0 +1,13 @@
+### Handling MTLS when SSL is terminated by the Load Balancer or Reverse Proxy
+
+When SSL termination of API requests takes place at the Load Balancer or Reverse Proxy, the following prerequisites need to be met by the Load Balancer.
+
+-   Terminate the mutual SSL connection from the client.
+-   Pass the client SSL certificate to the Gateway in an HTTP Header.
+
+    For more information, see the [Nginx documentation](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_client_certificate).
+
+The following diagram illustrates how Mutual SSL works in such an environment.
+
+[![MTLS Load Balancer](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/mtls-loadbalancer.png)](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/mtls-loadbalancer.png)
+

--- a/en/docs/includes/design/invoke-mtls-api-using-postman.md
+++ b/en/docs/includes/design/invoke-mtls-api-using-postman.md
@@ -1,0 +1,14 @@
+### Invoke an API secured with Mutual SSL using Postman
+
+Import the certificate and private key to Postman.
+
+1. Navigate to the certificates tab in Postman settings.
+
+   [![Add the certificate to Postman](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/add-certificate-to-postman.png)](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/add-certificate-to-postman.png)
+
+2. Add the certificate and private key.
+
+   [![Provide certificate and private key](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/provide-crt-and-private-key.png)](https://apim.docs.wso2.com/en/4.0.0/assets/img/learn/provide-crt-and-private-key.png)
+
+3.  Invoke the API from Postman.
+

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -244,7 +244,7 @@ nav:
                         - Use an Access Token: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/oauth2-access-tokens.md
                         - Use an API Key: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/api-key-authentication.md
                         - Use an Enforcer Test Key: deploy-and-publish/deploy-on-gateway/choreo-connect/security/generate-a-test-jwt.md
-                        # - Mutual SSL Authentication: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
+                        - Use Mutual SSL: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/mutual-ssl-authentication.md
                         - Configure an External Key Manager: deploy-and-publish/deploy-on-gateway/choreo-connect/security/api-authentication/configuring-an-external-key-manager.md
                         - Use a Custom Authorization Header: deploy-and-publish/deploy-on-gateway/choreo-connect/security/use-a-custom-authorization-header.md
                         - Reject Revoked Tokens: deploy-and-publish/deploy-on-gateway/choreo-connect/security/rejecting-revoked-tokens.md

--- a/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
@@ -460,7 +460,7 @@
               "type": "string",
               "required": true,
               "default": "X-WSO2-CLIENT-CERTIFICATE",
-              "description": "Header name which client certificate coming from the downstream client"
+              "description": "The header name from which the client certificate is coming is from the downstream client"
             },
             {
               "name": "enableClientValidation",

--- a/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/enforcer/configs.json
@@ -448,6 +448,47 @@
       "exampleFile": "auth_header.toml"
     },
     {
+      "title": "Mutual SSL",
+      "options": [
+        {
+          "name": "enforcer.security.mutualSSL",
+          "required": false,
+          "description": "Configurations related to Mutual SSL",
+          "params": [
+            {
+              "name": "certificateHeader",
+              "type": "string",
+              "required": true,
+              "default": "X-WSO2-CLIENT-CERTIFICATE",
+              "description": "Header name which client certificate coming from the downstream client"
+            },
+            {
+              "name": "enableClientValidation",
+              "type": "boolean",
+              "required": true,
+              "default": "true",
+              "description": "Select between directly sending client certificate and sending client certificate within a header"
+            },
+            {
+              "name": "clientCertificateEncode",
+              "type": "boolean",
+              "required": true,
+              "default": "false",
+              "description": "Enable/Disable client certificate decode process in Choreo Connect when the certificate is passed in a header."
+            },
+            {
+              "name": "enableOutboundAuthHeader",
+              "type": "boolean",
+              "required": true,
+              "default": "false",
+              "description": "Remove client certificate header from backend request."
+            }
+          ]
+        }
+      ],
+      "exampleFile": "mutual_ssl.toml"
+    },
+    {
       "title": "Token Service",
       "options": [
         {

--- a/en/tools/config-catalog-generator-cc/data/enforcer/mutual_ssl.toml
+++ b/en/tools/config-catalog-generator-cc/data/enforcer/mutual_ssl.toml
@@ -1,0 +1,5 @@
+[enforcer.security.mutualSSL]
+certificateHeader = "X-WSO2-CLIENT-CERTIFICATE"
+enableClientValidation = true
+clientCertificateEncode = false
+enableOutboundCertificateHeader = false

--- a/en/tools/config-catalog-generator-cc/data/router/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/router/configs.json
@@ -296,7 +296,7 @@
         {
           "name": "router.upstream.tls",
           "required": false,
-          "description": "The configurations for SSL configuration related to the backend connection in Choreo Connect.",
+          "description": "The configurations for SSL related to the downstream in Choreo Connect.",
           "params": [
             {
               "name": "minimumProtocolVersion",

--- a/en/tools/config-catalog-generator-cc/data/router/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/router/configs.json
@@ -350,6 +350,34 @@
       "exampleFile": "upstream_tls.toml"
     },
     {
+      "title": "Downstream TLS",
+      "options": [
+        {
+          "name": "router.downstream.tls",
+          "required": false,
+          "description": "The configurations for SSL configuration related to the downstream in Choreo Connect.",
+          "params": [
+            {
+              "name": "trustedCertPath",
+              "type": "string",
+              "required": true,
+              "default": "/etc/ssl/certs/ca-certificates.crt",
+              "description": "Path to trusted ca-certificates"
+            },
+            {
+              "name": "mTLSAPIsEnabled",
+              "type": "boolean",
+              "required": true,
+              "default": "false",
+              "possible": "true, false",
+              "description": "Enable mTLS APIs in Choreo Connect."
+            }
+          ]
+        }
+      ],
+      "exampleFile": "downstream_tls.toml"
+    },
+    {
       "title": "Filters used in the Router",
       "options": [
         {

--- a/en/tools/config-catalog-generator-cc/data/router/downstream_tls.toml
+++ b/en/tools/config-catalog-generator-cc/data/router/downstream_tls.toml
@@ -1,0 +1,4 @@
+[router.downstream.tls]
+# the default client ca-certificates
+trustedCertPath = "/etc/ssl/certs/ca-certificates.crt"
+mTLSAPIsEnabled = false

--- a/en/tools/config-catalog-generator-cc/dist/control-plane-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/control-plane-configurations.md
@@ -237,7 +237,7 @@ See the example .toml file given below.
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Message broker connection URLs of the control plane with retry count and connect delay (in seconds). The array of endpoints acts as fail-over endpoints.</p>
+                                        <p>Message Broker connection URLs of the Control Plane with retry count and connect delay (in seconds). The array of endpoints acts as fail-over endpoints.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
@@ -1291,7 +1291,7 @@ enabled = true</code></pre>
 
 
 
-## Token Service
+## Mutual SSL
 
 
 <div class="mb-config-catalog">
@@ -1301,6 +1301,123 @@ enabled = true</code></pre>
             
             <input name="13" type="checkbox" id="_tab_13">
                 <label class="tab-selector" for="_tab_13"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[enforcer.security.mutualSSL]
+certificateHeader = "X-WSO2-CLIENT-CERTIFICATE"
+enableClientValidation = true
+clientCertificateEncode = false
+enableOutboundCertificateHeader = false
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[enforcer.security.mutualSSL]</code>
+                            
+                            <p>
+                                Configurations related to Mutual SSL
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>certificateHeader</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>X-WSO2-CLIENT-CERTIFICATE</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Header name which client certificate coming from the downstream client</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enableClientValidation</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Select between directly sending client certificate and sending client certificate within a header</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>clientCertificateEncode</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable/Disable client certificate decode process in Choreo Connect when the certificate is passed in a header.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enableOutboundAuthHeader</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Remove client certificate header from backend request.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Token Service
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="14" type="checkbox" id="_tab_14">
+                <label class="tab-selector" for="_tab_14"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[enforcer.security.tokenService]]
@@ -1476,8 +1593,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="14" type="checkbox" id="_tab_14">
-                <label class="tab-selector" for="_tab_14"><i class="icon fa fa-code"></i></label>
+            <input name="15" type="checkbox" id="_tab_15">
+                <label class="tab-selector" for="_tab_15"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling]
@@ -1633,8 +1750,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="15" type="checkbox" id="_tab_15">
-                <label class="tab-selector" for="_tab_15"><i class="icon fa fa-code"></i></label>
+            <input name="16" type="checkbox" id="_tab_16">
+                <label class="tab-selector" for="_tab_16"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher]
@@ -1709,8 +1826,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="16" type="checkbox" id="_tab_16">
-                <label class="tab-selector" for="_tab_16"><i class="icon fa fa-code"></i></label>
+            <input name="17" type="checkbox" id="_tab_17">
+                <label class="tab-selector" for="_tab_17"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[enforcer.throttling.publisher.URLGroup]]
@@ -1785,8 +1902,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="17" type="checkbox" id="_tab_17">
-                <label class="tab-selector" for="_tab_17"><i class="icon fa fa-code"></i></label>
+            <input name="18" type="checkbox" id="_tab_18">
+                <label class="tab-selector" for="_tab_18"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher.pool]
@@ -1921,8 +2038,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="18" type="checkbox" id="_tab_18">
-                <label class="tab-selector" for="_tab_18"><i class="icon fa fa-code"></i></label>
+            <input name="19" type="checkbox" id="_tab_19">
+                <label class="tab-selector" for="_tab_19"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.throttling.publisher.agent]
@@ -2299,8 +2416,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="19" type="checkbox" id="_tab_19">
-                <label class="tab-selector" for="_tab_19"><i class="icon fa fa-code"></i></label>
+            <input name="20" type="checkbox" id="_tab_20">
+                <label class="tab-selector" for="_tab_20"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[enforcer.metrics]

--- a/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/enforcer-configurations.md
@@ -1337,7 +1337,7 @@ enableOutboundCertificateHeader = false
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Header name which client certificate coming from the downstream client</p>
+                                        <p>The header name from which the client certificate is coming is from the downstream client</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/tools/config-catalog-generator-cc/dist/router-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/router-configurations.md
@@ -898,7 +898,7 @@ allowCredentials = false
                             <code>[router.upstream.tls]</code>
                             
                             <p>
-                                The configurations for SSL configuration related to the backend connection in Choreo Connect.
+                                The configurations for SSL related to the downstream in Choreo Connect.
                             </p>
                         </div>
                         <div class="params-wrap">

--- a/en/tools/config-catalog-generator-cc/dist/router-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/router-configurations.md
@@ -1035,7 +1035,7 @@ allowCredentials = false
 
 
 
-## Filters used in the Router
+## Downstream TLS
 
 
 <div class="mb-config-catalog">
@@ -1047,6 +1047,86 @@ allowCredentials = false
                 <label class="tab-selector" for="_tab_10"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
+<pre><code class="toml">[router.downstream.tls]
+# the default client ca-certificates
+trustedCertPath = "/etc/ssl/certs/ca-certificates.crt"
+mTLSAPIsEnabled = false
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[router.downstream.tls]</code>
+                            
+                            <p>
+                                The configurations for SSL configuration related to the downstream in Choreo Connect.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>trustedCertPath</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>/etc/ssl/certs/ca-certificates.crt</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Path to trusted ca-certificates</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>mTLSAPIsEnabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable mTLS APIs in Choreo Connect.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Filters used in the Router
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="11" type="checkbox" id="_tab_11">
+                <label class="tab-selector" for="_tab_11"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
 <pre><code class="toml">[router.filters]
   [router.filters.compression]
     enabled = true
@@ -1054,11 +1134,11 @@ allowCredentials = false
   [router.filters.compression.requestDirection]
     enabled = false
     minimumContentLength = 30
-    contentType = ["text/html","application/json"]
+    contentType = ["application/javascript", "application/json", "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"]
   [router.filters.compression.responseDirection]
     enabled = true
     minimumContentLength = 30
-    contentType = ["text/html","application/json"]
+    contentType = ["application/javascript", "application/json", "application/xhtml+xml", "image/svg+xml", "text/css", "text/html", "text/plain", "text/xml"]
     enableForEtagHeader = true
   [router.filters.compression.libraryProperties]
     memoryLevel = 3

--- a/en/tools/config-catalog-generator-cc/package-lock.json
+++ b/en/tools/config-catalog-generator-cc/package-lock.json
@@ -533,9 +533,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "optional": true,
       "requires": {


### PR DESCRIPTION
## Purpose
$subject
Backporing: https://github.com/wso2/docs-apim/pull/6225/files

### Tasks
- [ ] Update the release date with the date the docker images are pushed

## Related Issue
https://github.com/wso2-enterprise/wso2-apim-internal/issues/2840

## Samples

### Choreo Connect mTLS Doc

![image](https://github.com/wso2/docs-apim/assets/23183042/5383f3b3-bb21-4237-835b-a2c3cf7a65ba)

### APIM mTLS Doc

Existing page: https://apim.docs.wso2.com/en/4.0.0/design/api-security/api-authentication/secure-apis-using-mutual-ssl/

Updated with this PR (moved common in APIM and CC to "includes" location)

![image](https://github.com/wso2/docs-apim/assets/23183042/105c519a-f74c-4651-b0df-2b15d5d717e1)
