### PR TITLE
Add database scripts and config details for API level policy support

### DIFF
--- a/en/docs/design/api-policies/attach-policy.md
+++ b/en/docs/design/api-policies/attach-policy.md
@@ -39,170 +39,169 @@ Follow the instructions below to attach one or more default policies that are sh
         'enable_api_level_policies' = true
         ```
 
-        2. Update the `WSO2AM_DB` database using the relevant script that have been provided below.
-
+        2. Update the `WSO2AM_DB` database using the relevant script mentioned below.
 
         ??? info "DB Scripts"
-                ```tab="DB2"
-                CREATE TABLE AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                )
-                /
-                ```
+            ```tab="DB2"
+            CREATE TABLE AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            )
+            /
+            ```
 
 
-                ```tab="H2"
-                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                );
-                ```
+            ```tab="H2"
+            CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            );
+            ```
 
 
-                ```tab="MSSQL"
-                IF NOT  EXISTS (SELECT * FROM SYS.OBJECTS WHERE OBJECT_ID = OBJECT_ID(N'[DBO].[AM_API_POLICY_MAPPING]') AND TYPE IN (N'U'))
-                CREATE TABLE AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER IDENTITY(1,1),
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                );
+            ```tab="MSSQL"
+            IF NOT  EXISTS (SELECT * FROM SYS.OBJECTS WHERE OBJECT_ID = OBJECT_ID(N'[DBO].[AM_API_POLICY_MAPPING]') AND TYPE IN (N'U'))
+            CREATE TABLE AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER IDENTITY(1,1),
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            );
 
-                ```
-
-
-                ```tab="MySQL"
-                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                )ENGINE INNODB;
-                ```
+            ```
 
 
-                ```tab="MySQL Cluster"
-                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                )ENGINE=NDB;
-                ```
+            ```tab="MySQL"
+            CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            )ENGINE INNODB;
+            ```
 
 
-                ```tab="Oracle"
-                CREATE TABLE AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                )
-                /
-
-                CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
-                /
-
-                CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
-                                            BEFORE INSERT
-                                    ON AM_API_POLICY_MAPPING
-                                    REFERENCING NEW AS NEW
-                                    FOR EACH ROW
-                                    BEGIN
-                                    SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
-                                    END;
-                /
-
-                ```
+            ```tab="MySQL Cluster"
+            CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            )ENGINE=NDB;
+            ```
 
 
-                ```tab="Oracle RAC"
-                CREATE TABLE AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID INTEGER,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                )
-                /
+            ```tab="Oracle"
+            CREATE TABLE AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            )
+            /
 
-                CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
-                /
+            CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
+            /
 
-                CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
-                                            BEFORE INSERT
-                                    ON AM_API_POLICY_MAPPING
-                                    REFERENCING NEW AS NEW
-                                    FOR EACH ROW
-                                    BEGIN
-                                    SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
-                                    END;
-                /
+            CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
+                                        BEFORE INSERT
+                                ON AM_API_POLICY_MAPPING
+                                REFERENCING NEW AS NEW
+                                FOR EACH ROW
+                                BEGIN
+                                SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
+                                END;
+            /
 
-                ```
+            ```
 
-                
-                ```tab="PostgreSQL"
-                DROP TABLE IF EXISTS AM_API_POLICY_MAPPING;
-                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
-                   API_POLICY_MAPPING_ID SERIAL,
-                   API_UUID VARCHAR(256) NOT NULL,
-                   REVISION_UUID VARCHAR(45),
-                   POLICY_UUID VARCHAR(45) NOT NULL,
-                   POLICY_ORDER INTEGER NOT NULL,
-                   DIRECTION VARCHAR(10) NOT NULL,
-                   PARAMETERS VARCHAR(1024) NOT NULL,
-                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
-                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
-                   PRIMARY KEY(API_POLICY_MAPPING_ID)
-                );
-                ```
+
+            ```tab="Oracle RAC"
+            CREATE TABLE AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID INTEGER,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            )
+            /
+
+            CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
+            /
+
+            CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
+                                        BEFORE INSERT
+                                ON AM_API_POLICY_MAPPING
+                                REFERENCING NEW AS NEW
+                                FOR EACH ROW
+                                BEGIN
+                                SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
+                                END;
+            /
+
+            ```
+
+            
+            ```tab="PostgreSQL"
+            DROP TABLE IF EXISTS AM_API_POLICY_MAPPING;
+            CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                API_POLICY_MAPPING_ID SERIAL,
+                API_UUID VARCHAR(256) NOT NULL,
+                REVISION_UUID VARCHAR(45),
+                POLICY_UUID VARCHAR(45) NOT NULL,
+                POLICY_ORDER INTEGER NOT NULL,
+                DIRECTION VARCHAR(10) NOT NULL,
+                PARAMETERS VARCHAR(1024) NOT NULL,
+                FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                PRIMARY KEY(API_POLICY_MAPPING_ID)
+            );
+            ```
 
 5.  Let’s attach a policy to the `/menu GET` operation. Scroll down through the left side column of the UI and click on `/menu GET` API operation. You should be able to see the below screen when the API operation is expanded.
 

--- a/en/docs/design/api-policies/attach-policy.md
+++ b/en/docs/design/api-policies/attach-policy.md
@@ -29,6 +29,181 @@ Follow the instructions below to attach one or more default policies that are sh
 
 4. Pick out the desired operation and flow to which you want to attach policies. Once that is decided, you can expand that API operation. At this point you will notice that by default the UI will open up the first API operation on initial page visit (for PizzaShack API, `/order POST` is expanded by default).
 
+    !!!note
+        You can utilize the **API Level Policy Support** feature from update level x onwards for WSO2 API Manager 4.2.0. If the feature is enabled, both API level policies and Operation level policies can be attached to any given API, where API level policies are given precedence over Operation level policies. If you wish to enable this support, you have to complete the below mentioned steps and restart the server.
+
+        1. Open the `<API-M_HOME>/repository/conf/deployment.toml` file and add the following configuration:
+
+        ```
+        [apim.policy]
+        'enable_api_level_policies' = true
+        ```
+
+        2. Update the `WSO2AM_DB` database using the relevant script that have been provided below.
+
+
+        ??? info "DB Scripts"
+                ```tab="DB2"
+                CREATE TABLE AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                )
+                /
+                ```
+
+
+                ```tab="H2"
+                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                );
+                ```
+
+
+                ```tab="MSSQL"
+                IF NOT  EXISTS (SELECT * FROM SYS.OBJECTS WHERE OBJECT_ID = OBJECT_ID(N'[DBO].[AM_API_POLICY_MAPPING]') AND TYPE IN (N'U'))
+                CREATE TABLE AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER IDENTITY(1,1),
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                );
+
+                ```
+
+
+                ```tab="MySQL"
+                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                )ENGINE INNODB;
+                ```
+
+
+                ```tab="MySQL Cluster"
+                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER AUTO_INCREMENT,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                )ENGINE=NDB;
+                ```
+
+
+                ```tab="Oracle"
+                CREATE TABLE AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                )
+                /
+
+                CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
+                /
+
+                CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
+                                            BEFORE INSERT
+                                    ON AM_API_POLICY_MAPPING
+                                    REFERENCING NEW AS NEW
+                                    FOR EACH ROW
+                                    BEGIN
+                                    SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
+                                    END;
+                /
+
+                ```
+
+
+                ```tab="Oracle RAC"
+                CREATE TABLE AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID INTEGER,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                )
+                /
+
+                CREATE SEQUENCE AM_API_POLICY_MAPPING_SEQ START WITH 1 INCREMENT BY 1
+                /
+
+                CREATE OR REPLACE TRIGGER AM_API_POLICY_MAPPING_SEQ
+                                            BEFORE INSERT
+                                    ON AM_API_POLICY_MAPPING
+                                    REFERENCING NEW AS NEW
+                                    FOR EACH ROW
+                                    BEGIN
+                                    SELECT AM_API_POLICY_MAPPING_SEQ.nextval INTO :NEW.API_POLICY_MAPPING_ID FROM dual;
+                                    END;
+                /
+
+                ```
+
+                
+                ```tab="PostgreSQL"
+                DROP TABLE IF EXISTS AM_API_POLICY_MAPPING;
+                CREATE TABLE IF NOT EXISTS AM_API_POLICY_MAPPING (
+                   API_POLICY_MAPPING_ID SERIAL,
+                   API_UUID VARCHAR(256) NOT NULL,
+                   REVISION_UUID VARCHAR(45),
+                   POLICY_UUID VARCHAR(45) NOT NULL,
+                   POLICY_ORDER INTEGER NOT NULL,
+                   DIRECTION VARCHAR(10) NOT NULL,
+                   PARAMETERS VARCHAR(1024) NOT NULL,
+                   FOREIGN KEY (API_UUID) REFERENCES AM_API(API_UUID) ON DELETE CASCADE,
+                   FOREIGN KEY (POLICY_UUID) REFERENCES AM_OPERATION_POLICY(POLICY_UUID) ON DELETE CASCADE,
+                   PRIMARY KEY(API_POLICY_MAPPING_ID)
+                );
+                ```
+
 5.  Let’s attach a policy to the `/menu GET` operation. Scroll down through the left side column of the UI and click on `/menu GET` API operation. You should be able to see the below screen when the API operation is expanded.
 
     [![Operation for adding policies]({{base_path}}/assets/img/design/api-policies/attach-policies-2.png){: style="width:90%"}]({{base_path}}/assets/img/design/api-policies/attach-policies-2.png)


### PR DESCRIPTION
#### Purpose

- This PR adds the following doc changes related to the `API Level Policy` feature introduced via https://github.com/wso2-enterprise/wso2-apim-internal/issues/2618. It states how one can enable the API level policy feature.

<img width="845" alt="image" src="https://github.com/wso2/docs-apim/assets/30475839/f961bb87-e992-47b5-aa81-18da2ebd3819">

