### PR TITLE
[3.2.0] Update version and download links for APICTL 3.2.8

### DIFF
--- a/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/learn/api-controller/getting-started-with-wso2-api-controller.md
@@ -6,11 +6,11 @@ WSO2 API Controller(CTL) is a command-line tool for managing API Manager environ
 
 1.  Download **API Controller** based on your preferred platform (i.e., Mac, Windows, Linux).
 
-    - [For MacOS](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.7/apictl-3.2.7-macosx-x64.tar.gz)
-    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.7/apictl-3.2.7-linux-i586.tar.gz)
-    - [For Linux 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.7/apictl-3.2.7-linux-x64.tar.gz)
-    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.7/apictl-3.2.7-windows-i586.zip)
-    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.7/apictl-3.2.7-windows-x64.zip)
+    - [For MacOS](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.8/apictl-3.2.8-macosx-x64.tar.gz)
+    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.8/apictl-3.2.8-linux-i586.tar.gz)
+    - [For Linux 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.8/apictl-3.2.8-linux-x64.tar.gz)
+    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.8/apictl-3.2.8-windows-i586.zip)
+    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v3.2.8/apictl-3.2.8-windows-x64.zip)
 
 2.  Extract the downloaded archive of the CTL Tool to the desired location.
 3.  Navigate to the working directory where the executable CTL Tool resides.
@@ -66,8 +66,8 @@ Run the following CTL command to check the version of the CTL.
 -   **Response**
 
     ```bash
-    Version: 3.2.7
-    Build Date: 2023-07-20 10:05:43 UTC
+    Version: 3.2.8
+    Build Date: 2023-08-29 08:58:13 UTC
     ```
 
 ## Set mode of the CTL


### PR DESCRIPTION
## Purpose
This PR adds the download links for APICTL 3.2.8 release and update the version in the APICTL docs.