### PR TITLE
Fix broken link

### DIFF
--- a/en/docs/integrate/examples/file-processing/accessing_windows_share_using_vfs_transport.md
+++ b/en/docs/integrate/examples/file-processing/accessing_windows_share_using_vfs_transport.md
@@ -1,5 +1,5 @@
 # Accessing a Windows Share using VFS
-This example demonstrates how the [VFS transport]({{base_path}}/install-and-setup/setup/mi-setup/transport_configurations/configuring-transports/configuring-the-vfs-transport) in WSO2 Micro Integrator can be used to access a windows share.
+This example demonstrates how the [VFS transport]({{base_path}}/install-and-setup/setup/mi-setup/transport_configurations/configuring-transports/#configuring-the-vfs-transport) in WSO2 Micro Integrator can be used to access a windows share.
 
 ## Synapse configuration
 


### PR DESCRIPTION
## Purpose
This PR is to fix a broken link on the [Accessing a Windows Share using VFS](https://apim.docs.wso2.com/en/4.0.0/integrate/examples/file-processing/accessing_windows_share_using_vfs_transport/#!) page.