### PR TITLE
Fix: Changing the API-M hostname link is broken

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/running-the-api-m.md
+++ b/en/docs/install-and-setup/install/installing-the-product/running-the-api-m.md
@@ -59,7 +59,7 @@ Note that the server is running on `localhost` by default. You can use these URL
 !!! Info  
     To change the default hostname/port and to secure the API-M portals, see the following topics:
 
-    - [Changing the API-M hostname]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m)
+    - [Changing the API-M hostname]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-hostname) 
     - [Changing the default API-M ports]({{base_path}}/install-and-setup/setup/deployment-best-practices/changing-the-default-ports-with-offset/#changing-the-default-api-m-ports)
     - [Securing API-M Web Portals]({{base_path}}/install-and-setup/setup/security/securing-api-m-web-portals)
 


### PR DESCRIPTION
This PR fixes [Issue#7169](https://github.com/wso2/docs-apim/issues/7169)