### PR TITLE
[4.1.0] Update accessing_windows_share_using_vfs_transport.md

### DIFF
--- a/en/docs/integrate/examples/file-processing/accessing_windows_share_using_vfs_transport.md
+++ b/en/docs/integrate/examples/file-processing/accessing_windows_share_using_vfs_transport.md
@@ -101,7 +101,7 @@ When the sample is executed, the VFS transport listener picks the file from the 
 Windows share URI format for SMB v2/3 use cases is shown below.
 
 ```
-smb2://[username]:[password]@[hostname]:[port]/[absolute-path
+smb2://[username]:[password]@[hostname]/[absolute-path]
 ```
 You can use the proxy given below to test the SMB2 functionality.
 


### PR DESCRIPTION
## Purpose
This PR is to remove `[port]` from the connection URI format.