### PR TITLE
Add a note on gateway health-check API

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/basic-health-checks.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/basic-health-checks.md
@@ -27,11 +27,30 @@ curl -v http://localhost:9763/services/Version
 ```
 
 ``` java tab="Response"
-<ns:getVersionResponse xmlns:ns="http://version.services.core.carbon.wso2.org"><return>WSO2 API Manager-2.6.0</return></ns:getVersionResponse>
+<ns:getVersionResponse xmlns:ns="http://version.services.core.carbon.wso2.org"><return>WSO2 API Manager-4.2.0</return></ns:getVersionResponse>
 ```
 
 !!! note
     Basic health checks for WebSocket ports 9099 and 8099 can be performed using `curl -v http://<HOSTNAME>:<PORT>/health`. For example, use the `curl -v http://localhost:9099/health` cURL command to check the health of port 9099. The response will be `200 OK` if the port is healthy.
+
+
+When deploying the WSO2 API Manager Gateway, it's a best practice to ensure that all APIs are correctly deployed and ready to accept traffic before directing actual requests to the newly spawned Gateway. It's important to note that merely checking the server status might not be sufficient in this context.
+
+To verify the successful deployment of APIs in the Gateway, we recommend using the Gateway health-check API. This dedicated API allows you to confirm the readiness of **all the APIs** in the Gateway. If everything is in order and **all the APIs** are deployed successfully, the health-check API will respond with a status code of 200 OK. This additional step helps guarantee that your API Gateway is fully prepared to handle incoming traffic.
+
+Sample usages of this are shown below
+
+``` yaml tab="cURL"
+curl -k https://<GATEWAY_HOSTNAME>:<PORT>/api/am/gateway/v2/server-startup-healthcheck
+```
+
+``` yaml tab="Kubernetes"
+readinessProbe:
+  httpGet:
+    path: /api/am/gateway/v2/server-startup-healthcheck
+    port: 9443
+    scheme: HTTPS
+```
 
 ## Micro Integrator health checks
 


### PR DESCRIPTION
## Purpose

Add a note on health-check API for gateway to verify the deployment status of the APIs.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/4752