### PR TITLE
[Doc]: Enabling/Disabling Operation Policies in Analytics Event

### DIFF
--- a/en/docs/api-analytics/on-prem/elk-installation-guide.md
+++ b/en/docs/api-analytics/on-prem/elk-installation-guide.md
@@ -191,6 +191,31 @@ Open the `wso2am-4.x.x/repository/conf` directory. To enable logging for a repor
     | "errorMessage"               | string    | The error message associated with the fault.                         |
     | "errorType"                  | string    | The type of error (e.g., THROTTLED).                                 |
 
+    
+#### Step 1.3 - Enabling Operation Policies in Analytics Event
+
+Operation and API Policies of the APIs/API Products are loaded to the Analytics Event by enabling the following property. This can be either provide as an argument or configured in the start up scripts on the server startup.
+
+    - Linux/Mac OS
+    
+        ```toml tab="Format"
+        ./api-manager.sh -DoperationPolicyEnableWithAnalyticsEvent=<enable/disable>
+        ```
+        
+        ```toml tab="Example"
+        ./api-manager.sh -DoperationPolicyEnableWithAnalyticsEvent=true
+        ```
+        
+    - Windows
+    
+        ```toml tab="Format"
+        api-manager.bat -DoperationPolicyEnableWithAnalyticsEvent=<enable/disable>
+        ```
+        
+        ```toml tab="Example"
+        api-manager.bat -DoperationPolicyEnableWithAnalyticsEvent=true
+        ```
+
 ### Step 2 - Configuring ELK
 
 

--- a/en/docs/api-analytics/on-prem/elk-installation-guide.md
+++ b/en/docs/api-analytics/on-prem/elk-installation-guide.md
@@ -194,12 +194,12 @@ Open the `wso2am-4.x.x/repository/conf` directory. To enable logging for a repor
     
 #### Step 1.3 - Enabling Operation Policies in Analytics Event
 
-Operation and API Policies of the APIs/API Products are loaded to the Analytics Event by enabling the following property. This can be either provide as an argument or configured in the start up scripts on the server startup.
+Operation and API Policies of the APIs/API Products are loaded to the Analytics Event by enabling the following property. This can either be provided as an argument at the server startup or configured in the startup scripts.
 
     - Linux/Mac OS
     
         ```toml tab="Format"
-        ./api-manager.sh -DoperationPolicyEnableWithAnalyticsEvent=<enable/disable>
+        ./api-manager.sh -DoperationPolicyEnableWithAnalyticsEvent=<true/false>
         ```
         
         ```toml tab="Example"
@@ -209,7 +209,7 @@ Operation and API Policies of the APIs/API Products are loaded to the Analytics 
     - Windows
     
         ```toml tab="Format"
-        api-manager.bat -DoperationPolicyEnableWithAnalyticsEvent=<enable/disable>
+        api-manager.bat -DoperationPolicyEnableWithAnalyticsEvent=<true/false>
         ```
         
         ```toml tab="Example"


### PR DESCRIPTION
## Purpose
There should be a way to check the policies hit on a request to a specific API. Currently, the Analytics Event does not contain the policy data of the API.

## Goals
Load API and Operation Policies of the APIs/API Products to the gateway and send the corresponding policies in the analytics event.

## Approach
1. Load API Policies and Operation Policies to the gateway on the deployment.
2. Fetch Operation and API Policies related to the the resource and the method on the API invocation.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/12176