### PR TITLE
Update documentation for the added config to modify the buffered payload limit in choreo connect.

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md
@@ -52,6 +52,7 @@ See the example .toml file given below.
   enforcerResponseTimeoutInSeconds = 20
   systemHost = "localhost"
   useRemoteAddress = false
+  perConnectionBufferLimitBytes = 1048576
 </code></pre>
                     </div>
                 </div>
@@ -215,6 +216,28 @@ See the example .toml file given below.
                                     </div>
                                     <div class="param-description">
                                         <p>If configured as true, the Router appends the immediate downstream IP address to the x-forward-for header.</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>perConnectionBufferLimitBytes</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>1048576</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The buffer limit per connection in Bytes. Default value is 1 MiB</p>
+                                    </div>
+                                    <div class="admonition attention">
+                                        <p class="admonition-title">Update Level 4</p>
+                                        <p>This feature is available only as an update, after Update level 1.2.0.4 (released on 21 Nov 2023) and further. For more information regarding Choreo Connect updates, see <a href="https://apim.docs.wso2.com/en/4.2.0/deploy-and-publish/deploy-on-gateway/choreo-connect/update-choreo-connect/">here</a>.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator-cc/data/router/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/router/configs.json
@@ -63,6 +63,13 @@
               "required": false,
               "default": false,
               "description": "If configured as true, the Router appends the immediate downstream IP address to the x-forward-for header."
+            },
+            {
+              "name": "perConnectionBufferLimitBytes",
+              "type": "integer",
+              "required": false,
+              "default": "1048576",
+              "description": "The buffered payload limit per connection in Bytes. Default value is 1 MiB"
             }
           ]
         }

--- a/en/tools/config-catalog-generator-cc/data/router/router.toml
+++ b/en/tools/config-catalog-generator-cc/data/router/router.toml
@@ -7,3 +7,4 @@
   enforcerResponseTimeoutInSeconds = 20
   systemHost = "localhost"
   useRemoteAddress = false
+  perConnectionBufferLimitBytes = 1048576

--- a/en/tools/config-catalog-generator-cc/dist/router-configurations.md
+++ b/en/tools/config-catalog-generator-cc/dist/router-configurations.md
@@ -52,6 +52,7 @@ See the example .toml file given below.
   enforcerResponseTimeoutInSeconds = 20
   systemHost = "localhost"
   useRemoteAddress = false
+  perConnectionBufferLimitBytes = 1048576
 </code></pre>
                     </div>
                 </div>
@@ -215,6 +216,25 @@ See the example .toml file given below.
                                     </div>
                                     <div class="param-description">
                                         <p>If configured as true, the Router appends the immediate downstream IP address to the x-forward-for header.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>perConnectionBufferLimitBytes</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>1048576</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The buffered payload limit per connection in Bytes. Default value is 1 MiB</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Purpose
> $subject

The added config will be visible as follows : 
<img width="1307" alt="Screenshot 2023-11-26 at 10 37 21" src="https://github.com/wso2/docs-apim/assets/48326709/1daa7804-42c9-48df-96fa-55fba58dbd5a">


Note: Since the existing structure rendered from config.json doesn't support an additional banner view, it was added into the .md file directly. The corresponding change was not added to the same file in dist because it may cause conflicts in further modifications to config.json. Hence the contents in en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/router-configurations.md and en/tools/config-catalog-generator-cc/dist/router-configurations.md have a diff from this onwards.
