### PR TITLE
[4.1.0] Adding a note in subscription throttling policies

### DIFF
--- a/en/docs/design/rate-limiting/adding-new-throttling-policies.md
+++ b/en/docs/design/rate-limiting/adding-new-throttling-policies.md
@@ -146,11 +146,9 @@ You have added a new application-level rate limiting policy.
     When you are adding a new Subscription level rate limiting tier, you will see the existing list of subscription tiers in the **Subscription Tier List**. In this list, you will find a tier named **Unauthenticated**, which has a request quota of 500. This is the subscription tier, which is automatically applied when the authentication type of your resources is **'None'.** That is when you can invoke APIs without tokens. And this tier is not visible in the rate limiting tier list of the application. </p>
     </div>
 
-    <div class="admonition info">
-    <p class="admonition-title">Note</p>
-    <p><b> Custom attributes</b></p>
-     <p>If you need to add a custom attribute to the unlimited tier, it is required to create a seperate unlimited policy and add the custom attribute. It is not recommended to modify the existing unlimited tier.</p>
-    </div>
+    !!! note
+         It is not recommended to modify the default Unlimited subscription tier. If required, you can create a separate subscription tier to represent the existing Unlimited tier and do the modifications accordingly.
+         
 
 4.  Fill in the details required by this form and click **Save** once you are done.
 


### PR DESCRIPTION
When adding a custom attribute to throttling policy 'Unlimited' from the Admin portal, it was found that the custom attribute is not returned in the API call.

It is not a good practice to edit the existing policy. Instead we need to created a separate unlimited policy.

Necessary Instructions has beed added to the documentation with a note. 

