### PR TITLE
[4.1.0] Add limitations of the SOAP to REST feature

### DIFF
--- a/en/docs/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
+++ b/en/docs/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
@@ -1,7 +1,63 @@
 # Generate REST API from SOAP Backend
 
-!!! Warning "Deprecated feature"
-    Note that this feature is deprecated in WSO2 API Manager 4.1.0. The support for this feature will be removed from subsequent versions of WSO2 API Manager.
+!!! Warning "Limitations"
+    APIM supports only a limited set of capabilities with this feature. If you want to process complex WSDL/XML schema please refer [WSO2 Integration Studio documentation](https://apim.docs.wso2.com/en/4.1.0/integrate/develop/creating-artifacts/creating-an-api/).
+
+    This feature has the following known limitations.
+
+    <details>
+        <summary>Unsupported / partially supported component types</summary>
+
+    - **<xs:choice\>**
+    - **<xs:annotation\>**
+    - **<xs:attribute\>** (Attribute type is always string. Default or fixed values are not supported. Attributes cannot be defined as optional or required)
+    - **<xs:restriction\>** (Only the base type is considered. No other elements added)
+    - **<xs:complexType\>** (Deeply nested complex types do not generate the correct mapping)
+    - **<xs:complexContent\>** (Has limitations with nested extensions)
+    - **<xs:simpleContent\>** (Has limitations with nested extensions)
+    - **<xs:all\>** (maxOccurs is not taken into consideration)
+    - **<xs:group\>**
+    - **<xs:attributeGroup\>**
+    - **<xs:any\>**
+    - **<xs:anyAttribute\>**
+    - **<xs:enumaration\>**
+    - **<xs:alternative\>**
+    - **<xs:assert\>**
+    - **<xs:key\>**
+    - **<xs:keyref\>**
+    - **<xs:list\>** (Item types are not defined)
+    - **<xs:unique\>**
+    - **<xs:appinfo\>**
+    - **<xs:documentation\>**
+    - **<xs:union\>**
+    - **minOccurs** (This attribute is ignored)
+    - **maxOccurs** (Only considers the unbounded case for arrays)
+    - **substitutionGroup** (This attribute is ignored)
+    - **Mixed Content** (This is ignored)
+
+    </details>
+
+    <details>
+        <summary>Supported primitive or derived datatypes</summary>
+
+    - string
+    - time (treated as a string)
+    - boolean
+    - int
+    - nonNegativeInteger
+    - integer
+    - positiveInteger
+    - double
+    - float
+    - long
+    - date
+    - dateTime
+    - decimal
+    - anyType
+    - base64Binary (treated as a string with byte format)
+    
+    </details>
+
 
 This feature allows users to expose their legacy SOAP backends as REST APIs through WSO2 API Manager. 
 WSO2 API Manager supports WSDL 1.1 based SOAP backends.
@@ -89,59 +145,3 @@ Follow the instructions below to generate REST APIs in WSO2 API Manager for an e
      ```
 
     The incoming JSON message parameters are stored using properties. A payload factory mediator is used to generate the SOAP payload required for the backend.
-
-!!! Warning "Limitations"
-    Note that this feature has the following known limitations.
-
-    <details>
-        <summary>Unsupported / partially supported component types</summary>
-
-    - **<xs:choice\>**
-    - **<xs:annotation\>**
-    - **<xs:attribute\>** (Attribute type is always string. Default or fixed values are not supported. Attributes cannot be defined as optional or required)
-    - **<xs:restriction\>** (Only the base type is considered. No other elements added)
-    - **<xs:complexType\>** (Deeply nested complex types do not generate the correct mapping)
-    - **<xs:complexContent\>** (Has limitations with nested extensions)
-    - **<xs:simpleContent\>** (Has limitations with nested extensions)
-    - **<xs:all\>** (maxOccurs is not taken into consideration)
-    - **<xs:group\>**
-    - **<xs:attributeGroup\>**
-    - **<xs:any\>**
-    - **<xs:anyAttribute\>**
-    - **<xs:enumaration\>**
-    - **<xs:alternative\>**
-    - **<xs:assert\>**
-    - **<xs:key\>**
-    - **<xs:keyref\>**
-    - **<xs:list\>** (Item types are not defined)
-    - **<xs:unique\>**
-    - **<xs:appinfo\>**
-    - **<xs:documentation\>**
-    - **<xs:union\>**
-    - **minOccurs** (This attribute is ignored)
-    - **maxOccurs** (Only considers the unbounded case for arrays)
-    - **substitutionGroup** (This attribute is ignored)
-    - **Mixed Content** (This is ignored)
-
-    </details>
-
-    <details>
-        <summary>Supported primitive or derived datatypes</summary>
-
-    - string
-    - time (treated as a string)
-    - boolean
-    - int
-    - nonNegativeInteger
-    - integer
-    - positiveInteger
-    - double
-    - float
-    - long
-    - date
-    - dateTime
-    - decimal
-    - anyType
-    - base64Binary (treated as a string with byte format)
-    
-    </details>

--- a/en/docs/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
+++ b/en/docs/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
@@ -90,3 +90,58 @@ Follow the instructions below to generate REST APIs in WSO2 API Manager for an e
 
     The incoming JSON message parameters are stored using properties. A payload factory mediator is used to generate the SOAP payload required for the backend.
 
+!!! Warning "Limitations"
+    Note that this feature has the following known limitations.
+
+    <details>
+        <summary>Unsupported / partially supported component types</summary>
+
+    - **<xs:choice\>**
+    - **<xs:annotation\>**
+    - **<xs:attribute\>** (Attribute type is always string. Default or fixed values are not supported. Attributes cannot be defined as optional or required)
+    - **<xs:restriction\>** (Only the base type is considered. No other elements added)
+    - **<xs:complexType\>** (Deeply nested complex types do not generate the correct mapping)
+    - **<xs:complexContent\>** (Has limitations with nested extensions)
+    - **<xs:simpleContent\>** (Has limitations with nested extensions)
+    - **<xs:all\>** (maxOccurs is not taken into consideration)
+    - **<xs:group\>**
+    - **<xs:attributeGroup\>**
+    - **<xs:any\>**
+    - **<xs:anyAttribute\>**
+    - **<xs:enumaration\>**
+    - **<xs:alternative\>**
+    - **<xs:assert\>**
+    - **<xs:key\>**
+    - **<xs:keyref\>**
+    - **<xs:list\>** (Item types are not defined)
+    - **<xs:unique\>**
+    - **<xs:appinfo\>**
+    - **<xs:documentation\>**
+    - **<xs:union\>**
+    - **minOccurs** (This attribute is ignored)
+    - **maxOccurs** (Only considers the unbounded case for arrays)
+    - **substitutionGroup** (This attribute is ignored)
+    - **Mixed Content** (This is ignored)
+
+    </details>
+
+    <details>
+        <summary>Supported primitive or derived datatypes</summary>
+
+    - string
+    - time (treated as a string)
+    - boolean
+    - int
+    - nonNegativeInteger
+    - integer
+    - positiveInteger
+    - double
+    - float
+    - long
+    - date
+    - dateTime
+    - decimal
+    - anyType
+    - base64Binary (treated as a string with byte format)
+    
+    </details>


### PR DESCRIPTION
## Purpose
This PR adds the limitations of the SOAP to REST feature in APIM. Changes are added to [1].

The doc after the changes look like below.

<img width="1510" alt="Screen Shot 2023-12-06 at 1 59 20 PM" src="https://github.com/wso2/docs-apim/assets/8557410/1714ab48-ec9a-43eb-b6b5-07f134f23716">

After expanding the collapsible sections, the docs look like below.

<img width="1512" alt="Screen Shot 2023-12-06 at 1 59 36 PM" src="https://github.com/wso2/docs-apim/assets/8557410/0934e681-7714-4056-8f84-21cdd59ce14e">

<img width="1512" alt="Screen Shot 2023-12-06 at 2 00 22 PM" src="https://github.com/wso2/docs-apim/assets/8557410/eb41cbfe-816a-4709-8dae-66750e257313">

[1] https://apim.docs.wso2.com/en/4.1.0/design/create-api/create-rest-api/generate-rest-api-from-soap-backend/