### PR TITLE
Updated API  Retrieve/Search instructions

### DIFF
--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -142,6 +142,11 @@ paths:
             Eg.
             "provider:wso2" will match an API if the provider of the API is exactly "wso2".
 
+            If you are searching an API using its name, ensure to enclose the name in double quotes.
+
+            Eg. 
+            name:"pizzashack" will match the API with the exact name "pizzashack".
+
             Additionally you can use wildcards.
 
             Eg.


### PR DESCRIPTION
When there are multiple APIs in an environment, it's possible to get details of a specific API by passing the API name as a query parameter.  The solution for this is to include the API name within the double quotes.

The relevant instructions are updated in the documentation with this PR

