### PR TITLE
Updated maintaining-logins-and-passwords page

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -23,7 +23,7 @@ Follow the instructions below to change the default admin password:
         Based on the XML specification (<https://www.w3.org/TR/xml/#sec-cdata-sect/>), some special characters can disrupt the configuration.
         For example, the ampersand character (&) must not appear in the literal form in XML files. It can cause a Java Null Pointer exception. You must wrap it with [CDATA](https://www.w3schools.com/xml/dom_cdatasection.asp) as shown below or remove the character:  
 
-    -   When you are creating the admin password do not include **£** character since it causes a buffer owerflow exception. 
+    -   When you are creating the admin password do not include **£** character since it causes a buffer overflow exception. 
 
     -   The above credentials are applied to the `jndi.properties` file.
         -   **It is not possible to use the `@` `{` `}` symbols in the username or password**.

--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -21,7 +21,9 @@ Follow the instructions below to change the default admin password:
 
         If you specify passwords inside XML files, you have to be mindful when defining special characters in the user names and passwords.
         Based on the XML specification (<https://www.w3.org/TR/xml/#sec-cdata-sect/>), some special characters can disrupt the configuration.
-        For example, the ampersand character (&) must not appear in the literal form in XML files. It can cause a Java Null Pointer exception. You must wrap it with [CDATA](https://www.w3schools.com/xml/dom_cdatasection.asp) as shown below or remove the character:    
+        For example, the ampersand character (&) must not appear in the literal form in XML files. It can cause a Java Null Pointer exception. You must wrap it with [CDATA](https://www.w3schools.com/xml/dom_cdatasection.asp) as shown below or remove the character:  
+
+    -   When you are creating the admin password do not include **£** character since it causes a buffer owerflow exception. 
 
     -   The above credentials are applied to the `jndi.properties` file.
         -   **It is not possible to use the `@` `{` `}` symbols in the username or password**.

--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -24,7 +24,8 @@ Follow the instructions below to change the default admin password:
         For example, the ampersand character (&) must not appear in the literal form in XML files. It can cause a Java Null Pointer exception. You must wrap it with [CDATA](https://www.w3schools.com/xml/dom_cdatasection.asp) as shown below or remove the character:  
 
     -   When you are creating the admin password do not include **£** character since it causes a buffer overflow exception. 
-
+        The letter **£** has two values (-62 and -93) as its byte representation. Therefore, limit of ByteBuffer is getting exceeded.
+  
     -   The above credentials are applied to the `jndi.properties` file.
         -   **It is not possible to use the `@` `{` `}` symbols in the username or password**.
         -   **It is also not possible to use the percentage (%) sign in the password**. When building the connection URL, the URL with credentials is parsed.

--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -23,9 +23,9 @@ Follow the instructions below to change the default admin password:
         Based on the XML specification (<https://www.w3.org/TR/xml/#sec-cdata-sect/>), some special characters can disrupt the configuration.
         For example, the ampersand character (&) must not appear in the literal form in XML files. It can cause a Java Null Pointer exception. You must wrap it with [CDATA](https://www.w3schools.com/xml/dom_cdatasection.asp) as shown below or remove the character:  
 
-    -   When you are creating the admin password do not include **£** character since it causes a buffer overflow exception. 
-        The letter **£** has two values (-62 and -93) as its byte representation. Therefore, limit of ByteBuffer is getting exceeded.
-  
+    -   Do not use **£** character in the admin password as it can cause a buffer overflow exception. This happens due to a
+        limitation where a **£** character has two values as its byte representation. 
+
     -   The above credentials are applied to the `jndi.properties` file.
         -   **It is not possible to use the `@` `{` `}` symbols in the username or password**.
         -   **It is also not possible to use the percentage (%) sign in the password**. When building the connection URL, the URL with credentials is parsed.


### PR DESCRIPTION
When creating admin password, "£" is considered as a restricted character since it causes a buffer overflow exception.

Documentation is updated with relevant details with this PR