### PR TITLE
[Master] Remove MariaDB from docs 

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mariadb.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mariadb.md
@@ -1,3 +1,0 @@
-# Changing to MariaDB
-
-By default, WSO2 API Manager uses the embedded H2 database as the database for storing user management and registry data. Follow the same steps and use the same database scripts, drivers, configurations in the documentation: [Changing to MySQL]({{base_path}}/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql) in order to use MariaDB for this purpose. 

--- a/en/docs/install-and-setup/setup/setting-up-databases/overview.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/overview.md
@@ -32,4 +32,3 @@ WSO2 products are shipped with scripts for creating the required tables in all t
 -   [Changing to Oracle RAC]({{base_path}}/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac)
 -   [Changing to PostgreSQL]({{base_path}}/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql)
 -   [Changing to IBM DB2]({{base_path}}/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2)
--   [Changing to MariaDB]({{base_path}}/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mariadb)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1428,7 +1428,6 @@ nav:
                         - Change to MSSQL: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
                         - Change to PostgreSQL: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
                         - Change to Oracle: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
-                        - Change to MariaDB: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mariadb.md
                         - Change to IBM DB2: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
                         - Change to Oracle RAC: install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
                     - Manage Data Growth and Improving Performance: install-and-setup/setup/setting-up-databases/managing-data-growth-and-improving-performance.md


### PR DESCRIPTION
## Purpose

- Removing MariaDB from docs
- Removing as customers are still referring to our docs on how to change the default database to MariaDB