### PR TITLE
Updated json-examples page

### DIFF
--- a/en/docs/integrate/examples/json_examples/json-examples.md
+++ b/en/docs/integrate/examples/json_examples/json-examples.md
@@ -518,7 +518,7 @@ payload.
 
 ```
 <log>
-  <property name="JSON-Payload" expression="json-eval($.)"/>
+  <property name="JSON-Payload" expression="json-eval($)"/>
 </log>
 ```
 
@@ -933,7 +933,7 @@ proxy service as the request for the following proxy service,
                mc.setPayloadJSON(payload);
              </script>
              <log>
-                <property name="JSON-Payload" expression="json-eval($.)"/>
+                <property name="JSON-Payload" expression="json-eval($)"/>
              </log>
              <respond/>
           </inSequence>


### PR DESCRIPTION
Updated the syntax related to payloadFactory mediation for JSON body retrieval in Json Examples page. The expression `($.)` is updated to `($)` in Json Body.