### PR TITLE
[3.2.0] Fix Tenant Deletion Config Name

### DIFF
--- a/en/docs/administer/multitenancy/managing-tenants.md
+++ b/en/docs/administer/multitenancy/managing-tenants.md
@@ -50,8 +50,8 @@ When you create multiple tenants in an API Manager deployment, the API developer
         1. By default tenant deletion is disabled. To enable the functionality, add the below configurations to the `<APIM-HOME>/repository/conf/deployment.toml` file
 
         ``` toml
-         [tenant_mgt]
-         tenant_deletion=true
+         [Tenant]
+         TenantDelete=true
         ```
         
         2. Open the <API-M_HOME>/repository/conf/deployment.toml file and add the following configuration to enable the Admin Services.


### PR DESCRIPTION
## Purpose
As per API-M 3.2.0 `carbon.xml.j2` the config should change from `tenant_mgt.tenant_deletion` to `Tenant.TenantDelete`

## Related PRs
https://github.com/wso2/docs-apim/pull/6811
