### PR TITLE
Updated link to avoid 404

### DIFF
--- a/en/docs/reference/guides/message-flow-in-the-api-manager-gateway.md
+++ b/en/docs/reference/guides/message-flow-in-the-api-manager-gateway.md
@@ -31,7 +31,7 @@ Each handler performs a specific task as mentioned in the table below. Note that
 
 ### Mediation extensions
 
-Mediation extensions are the custom mediation logic that can be executed in either the inflow or the outflow. For more details on how to configure mediation extensions, see [Adding Mediation Extensions]({{base_path}}/deploy-and-publish/deploy-on-gateway/api-gateway/message-mediation/changing-the-default-mediation-flow-of-api-requests) .
+Mediation extensions are the custom mediation logic that can be executed in either the inflow or the outflow. For more details on how to configure mediation extensions, see [Adding Mediation Extensions]({{base_path}}/design/api-policies/attach-policy) .
 
 ### In sequence and out sequence
 


### PR DESCRIPTION
## Purpose
> Updated link to the correct one. Pointed it to "attach policy" page which is the appropriate page when explaining how to add mediation extensions the GW message flow.