### PR TITLE
[4.0.0] Add Note About Password and Code Grant Usages to Global Key Manager Documentation

### DIFF
--- a/en/docs/administer/key-managers/configure-global-key-manager.md
+++ b/en/docs/administer/key-managers/configure-global-key-manager.md
@@ -45,12 +45,20 @@ Let's look at a scenario where a single access token generated for an applicatio
 
 1. Stop the WSO2 API Manager if it is already running
 
-2. Enable cross tenant subscriptions by adding the following to the `<API-M_HOME>/repository/conf/deployment.toml`
+2. Enable cross-tenant subscriptions by adding the following to the `<API-M_HOME>/repository/conf/deployment.toml`
 
     ``` toml 
     [apim.devportal]  
     enable_cross_tenant_subscriptions = true
     ```
+
+    !!! Note
+        When using cross-tenant subscriptions, if you are generating access tokens with the **Password grant** or the **Code grant**, add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file.
+
+        ``` toml
+        [oauth.access_token]
+        generate_with_sp_tenant_domain = "true"
+        ```
 
 3. Start the WSO2 API Manager.
 


### PR DESCRIPTION
## Purpose
- Add note about password and code grant usages to Global Key Manager documentation [1] added using [2]

[1] https://apim.docs.wso2.com/en/4.0.0/administer/key-managers/configure-global-key-manager/
[2] https://github.com/wso2/docs-apim/pull/7684