### PR TITLE
[4.3.0] Add Note About Password and Code Grant Usages to Global Key Manager Documentation

### DIFF
--- a/en/docs/administer/key-managers/configure-global-key-manager.md
+++ b/en/docs/administer/key-managers/configure-global-key-manager.md
@@ -38,6 +38,8 @@ Follow the steps given below to configure the Global Key Manager
 
 ## Trying Out the Global Key Manager
 
+Let's look at a scenario where a single access token generated for an application using the Global Key Manager is used to invoke subscribed APIs of different tenants
+
 1. Stop the WSO2 API Manager if it is already running
 
 2. Enable cross tenant subscriptions by adding the following to the `<API-M_HOME>/repository/conf/deployment.toml`
@@ -77,7 +79,7 @@ Follow the steps given below to configure the Global Key Manager
 
 13. Click **GENERATE KEYS**
 
-14. Click **GENERATE ACCESS TOKEN** to create an application access token. Make sure to copy the generated JWT access token that appears so that you can use it in the future.
+14. Click **GENERATE ACCESS TOKEN** to generate an application access token. Make sure to copy the generated JWT access token that appears so that you can use it in the future.
 
 15. Go to the Developer Portal landing page, select the SampleAPI and [Subscribe]({{base_path}}/consume/manage-subscription/subscribe-to-an-api/#subscribe-to-an-existing-application) to the SampleApp
 
@@ -103,5 +105,3 @@ Follow the steps given below to configure the Global Key Manager
 20. Try Out the API with the same access token generated using the Global Key Manager which was used in Step 16.
 
 A Successful response indicates that the API of a tenant can be invoked using an access token generated for an application using the Global Key Manager. Note that the access token was generated in the super tenant’s Developer Portal, but an API in a different tenant was invoked using this access token
-
-This scenario depicts a use-case where an access token generated for an application using the Global Key Manager is used to invoke subscribed APIs of different tenants

--- a/en/docs/administer/key-managers/configure-global-key-manager.md
+++ b/en/docs/administer/key-managers/configure-global-key-manager.md
@@ -42,12 +42,20 @@ Let's look at a scenario where a single access token generated for an applicatio
 
 1. Stop the WSO2 API Manager if it is already running
 
-2. Enable cross tenant subscriptions by adding the following to the `<API-M_HOME>/repository/conf/deployment.toml`
+2. Enable cross-tenant subscriptions by adding the following to the `<API-M_HOME>/repository/conf/deployment.toml`
 
     ``` toml 
     [apim.devportal]  
     enable_cross_tenant_subscriptions = true
     ```
+
+    !!! Note
+        When using cross-tenant subscriptions, if you are generating access tokens with the **Password grant** or the **Code grant**, add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file.
+
+        ``` toml
+        [oauth.access_token]
+        generate_with_sp_tenant_domain = "true"
+        ```
 
 3. Start the WSO2 API Manager.
 


### PR DESCRIPTION
## Purpose
- Add note about password and code grant usages to Global Key Manager documentation [1] added using [2]

[1] https://apim.docs.wso2.com/en/4.3.0/administer/key-managers/configure-global-key-manager/
[2] https://github.com/wso2/docs-apim/pull/7656