### PR TITLE
[4.2.0] Fix regex for JavaScript Injection

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
@@ -57,8 +57,12 @@ We recommend the following patterns for denying requests.
             </td>
         </tr>
         <tr class="odd">
-            <td>JavaScript Exception</td>
-            <td><p><code>&lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;</code></p></td>
+            <td>JavaScript Injection</td>
+            <td><p>
+                ```
+                &lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;
+                ```
+            </p></td>
         </tr>
         <tr class="even">
             <td>XPath Expanded Syntax Injection</td>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/2549

docs issue : https://github.com/wso2/docs-apim/issues/7722

<img width="783" alt="Screenshot 2024-03-08 at 08 31 29" src="https://github.com/wso2/docs-apim/assets/28379317/16d62285-e114-4468-889d-9892fe91438b">

Note : Could not find a fix for displaying the special chars in different color. Even ` ```text `did not work.