### PR TITLE
[4.1.0] Fix JS Injection regex

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
@@ -58,7 +58,11 @@ We recommend the following patterns for denying requests.
         </tr>
         <tr class="odd">
             <td>JavaScript Exception</td>
-            <td><p><code>&lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;</code></p></td>
+            <td><p>
+                ```
+                    &lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;
+                ```
+            </p></td>
         </tr>
         <tr class="even">
             <td>XPath Expanded Syntax Injection</td>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/2549

docs issue : https://github.com/wso2/docs-apim/issues/7722

<img width="788" alt="Screenshot 2024-03-08 at 09 32 32" src="https://github.com/wso2/docs-apim/assets/28379317/cd93e8fd-704e-461e-8057-117dcfbd9331">

Note : Could not find a fix for displaying the special chars in different color. Even ` ```text `did not work.
