### PR TITLE
[4.1.0] Fix indentation of JS Injection Regex

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/threat-protectors/regular-expression-threat-protection-for-api-gateway.md
@@ -59,9 +59,9 @@ We recommend the following patterns for denying requests.
         <tr class="odd">
             <td>JavaScript Exception</td>
             <td><p>
-                ```
-                    &lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;
-                ```
+            ```
+            &lt;\s*script\b[^&gt;]*&gt;[^&lt;]+&lt;\s*/\s*script\s*&gt;
+            ```
             </p></td>
         </tr>
         <tr class="even">


### PR DESCRIPTION
## Purpose

Fixes indentation of regex.
Related PR : https://github.com/wso2/docs-apim/pull/7731