### PR TITLE
[4.3.0] Update Issuer URL in IS as a KM Docs

### DIFF
--- a/en/docs/administer/key-managers/configure-wso2is-connector.md
+++ b/en/docs/administer/key-managers/configure-wso2is-connector.md
@@ -156,7 +156,7 @@ Follow the steps given below to configure WSO2 IS as a Key Manager component:
       </tr>
       <tr class="even">
       <td>Issuer</td>
-      <td>The issuer that consumes or validates access tokens </br>e.g., <code>https://localhost:9444/services</code></td>
+      <td>The issuer that consumes or validates access tokens </br>e.g., <code>https://localhost:9444/oauth2/token</code></td>
       <td>Optional</td>
       </tr>
       <tr class="odd">


### PR DESCRIPTION
## Purpose
> $Subject. When copy-pasting values directly from this doc, providing the current value (`https://localhost:9444/services` as the Issuer URL) will lead to an invalid token during token validation.