### PR TITLE
Update APICTL 4.3.0 docs 

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/cicd-using-cli.md
+++ b/en/docs/install-and-setup/setup/api-controller/cicd-using-cli.md
@@ -464,7 +464,7 @@ For example, let us consider there is an [API Product]({{base_path}}/design/crea
 1.  Export the API Product using `export api-product` command from the development environment (dev). For more information, see [Export an API Product]({{base_path}}/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments/#export-an-api-product).
 
     ```bash
-    $ apictl export api-product -n PetsInfo -e dev --latest
+    $ apictl export api-product -n PetsInfo -v 1.0.0 -e dev --latest
     
     Successfully exported API Product!
     Find the exported API Product at /home/wso2user/.wso2apictl/exported/api-products/dev/PetsInfo_1.0.0.zip

--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -6,13 +6,13 @@
 
 1.  Download **apictl** based on your preferred platform (i.e., Mac, Windows, Linux).
 
-    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-darwin-amd64.tar.gz)
-    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-darwin-arm64.tar.gz)
-    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-linux-i586.tar.gz)
-    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-linux-amd64.tar.gz)
-    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-linux-arm64.tar.gz)
-    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-windows-i586.zip)
-    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.2.1/apictl-4.2.1-windows-x64.zip)
+    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-darwin-amd64.tar.gz)
+    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-darwin-arm64.tar.gz)
+    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-linux-i586.tar.gz)
+    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-linux-amd64.tar.gz)
+    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-linux-arm64.tar.gz)
+    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-windows-i586.zip)
+    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.0-rc/apictl-4.3.0-rc-windows-x64.zip)
 
 2.  Extract the downloaded archive of the apictl to the desired location.
 3.  Navigate to the working directory where the executable apictl resides.
@@ -73,7 +73,7 @@ Run the following apictl command to check the version.
 -   **Response**
 
     ```bash
-    Version: 4.2.0
+    Version: 4.3.0
     Build Date: 2023-03-11 11:14:10 UTC
     ```
 
@@ -161,7 +161,7 @@ You can add environments by either manually editing the `<USER_HOME>/.wso2apictl
 apictl add env <environment-name>
 ```
 
-1.  Make sure that the WSO2 API Manager (WSO2 API-M) 4.2.0 version is started and that the 4.2.0 version of apictl is set up.     
+1.  Make sure that the WSO2 API Manager (WSO2 API-M) 4.3.0 version is started and that the 4.3.0 version of apictl is set up.     
 For more information, see [Download and Initialize the apictl](#download-and-initialize-the-apictl).
 2.  Run the following apictl command to add an environment.
 
@@ -314,7 +314,7 @@ For more information, see [Download and Initialize the apictl](#download-and-ini
 
 ## Remove an environment
 
-1.  Make sure that the WSO2 API-M 4.2.0 version is started and that the 4.2.0 version of apictl is set up.  
+1.  Make sure that the WSO2 API-M 4.3.0 version is started and that the 4.3.0 version of apictl is set up.  
 For more information, see [Download and Initialize the apictl](#download-and-initialize-the-apictl).
 2.  Run the following apictl command to remove an environment.
 
@@ -345,7 +345,7 @@ For more information, see [Download and Initialize the apictl](#download-and-ini
 
 ## Get environments
 
-1.  Make sure that the WSO2 API-M 4.2.0 version is started and that the 4.2.0 version of apictl is set up.    
+1.  Make sure that the WSO2 API-M 4.3.0 version is started and that the 4.3.0 version of apictl is set up.    
 For more information, see [Download and Initialize the apictl](#download-and-initialize-the-apictl).
 2.  Run the following apictl command to list the environments.  
 
@@ -388,7 +388,7 @@ For more information, see [Download and Initialize the apictl](#download-and-ini
 
 After adding an environment, you can log in to the WSO2 API-M instance in that environment using credentials.
 
-1.  Make sure that the WSO2 API-M 4.2.0 version is started and that the 4.2.0 version of apictl is set up.   
+1.  Make sure that the WSO2 API-M 4.3.0 version is started and that the 4.3.0 version of apictl is set up.   
 For more information, see [Download and Initialize the apictl](#download-and-initialize-the-apictl).
 2.  Run any of the following apictl commands to log in to the environment.
 
@@ -450,7 +450,7 @@ For more information, see [Download and Initialize the apictl](#download-and-ini
 
 ## Logout from an environment
 
-1.  Make sure that the WSO2 API-M 4.2.0 version is started and that the 4.2.0 version of apictl is set up.   
+1.  Make sure that the WSO2 API-M 4.3.0 version is started and that the 4.3.0 version of apictl is set up.   
 For more information, see [Download and Initialize the apictl](#download-and-initialize-the-apictl).
 
 2.  Run the following command to log out from the current session of the WSO2 API-M environment.


### PR DESCRIPTION
## Purpose

- Fix https://github.com/wso2/docs-apim/issues/7802
- Update APICTL docs for 4.3.0 release
- Add missing flag for `apictl export api-product`