### PR TITLE
[4.3.0] Add CSP meta tag for google fonts

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -29,6 +29,7 @@
       {% endif %}
       <link rel="icon" href="{{ config.theme.favicon | url }}">
       <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-material-9.1.2">
+      <meta http-equiv="Content-Security-Policy" content="style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;">
     {% endblock %}
     {% block htmltitle %}
       {% if page.meta and page.meta.title %}


### PR DESCRIPTION
## Purpose
This PR adds the CSP meta tag for google fonts to mitigate the rendering issue in API docs.

Related issue: https://github.com/wso2/api-manager/issues/2833