### PR TITLE
[4.3.0] Add connect-src content security policy for docs URL

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -29,6 +29,7 @@
       {% endif %}
       <link rel="icon" href="{{ config.theme.favicon | url }}">
       <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-material-9.1.2">
+      <meta http-equiv="Content-Security-Policy" content="connect-src 'self' apim.docs.wso2.com api.github.com;">
     {% endblock %}
     {% block htmltitle %}
       {% if page.meta and page.meta.title %}


### PR DESCRIPTION
## Purpose
This PR adds the connect-src content security policy for docs URL.

Related issue: https://github.com/wso2/docs-apim/pull/7939