### PR TITLE
[4.2.0] Add info on auto reloading of file.properties

### DIFF
--- a/en/docs/reference/mediators/property-reference/accessing-properties-with-xpath.md
+++ b/en/docs/reference/mediators/property-reference/accessing-properties-with-xpath.md
@@ -200,7 +200,7 @@ Syntax:
 
 #### file scope
 
-You can retrieve properties defined in the `file.properties` configuration file using the following syntax. Properties in the file are reloaded periodically according to the time interval defined by the `file.properties.sync.interval` system property in seconds.
+You can retrieve properties defined in the `file.properties` configuration file using the following syntax. Properties in the file are reloaded periodically according to the time interval defined by the `file.properties.sync.interval` system property in seconds. If this interval is not defined, changes to the properties will not be reloaded automatically during runtime.
 
 Syntax:  
 `get-property('file', String propertyName)`

--- a/en/docs/reference/mediators/property-reference/accessing-properties-with-xpath.md
+++ b/en/docs/reference/mediators/property-reference/accessing-properties-with-xpath.md
@@ -200,7 +200,7 @@ Syntax:
 
 #### file scope
 
-You can retrieve properties defined in the `file.properties` configuration file using the following syntax.
+You can retrieve properties defined in the `file.properties` configuration file using the following syntax. Properties in the file are reloaded periodically according to the time interval defined by the `file.properties.sync.interval` system property in seconds.
 
 Syntax:  
 `get-property('file', String propertyName)`


### PR DESCRIPTION
## Purpose
This PR is to add the missing info on auto reloading of `file.properties`.

**Related PR:**
https://github.com/wso2/docs-apim/pull/4252