### PR TITLE
Updated Information on Basic Authentication

### DIFF
--- a/en/docs/design/api-security/api-authentication/secure-apis-using-basic-authentication.md
+++ b/en/docs/design/api-security/api-authentication/secure-apis-using-basic-authentication.md
@@ -29,6 +29,8 @@ anyone of mandatory will skip the authentication.
  
 Note : If OAuth2/Basic Auth is set as mandatory, the request needs to be authenticated using only one of them. If OAuth2 failed only, the Basic Authentication will be applied.
 
+!!! note
+    Basic Authentication type is not supported by throttling policies. Therefore, Basic Authentication requests are categorized under the **Unauthenticated tier**.
 
 ## Invoking an API using Basic Authentication
 

--- a/en/docs/design/api-security/api-authentication/secure-apis-using-basic-authentication.md
+++ b/en/docs/design/api-security/api-authentication/secure-apis-using-basic-authentication.md
@@ -30,7 +30,7 @@ anyone of mandatory will skip the authentication.
 Note : If OAuth2/Basic Auth is set as mandatory, the request needs to be authenticated using only one of them. If OAuth2 failed only, the Basic Authentication will be applied.
 
 !!! note
-    Basic Authentication type is not supported by throttling policies. Therefore, Basic Authentication requests are categorized under the **Unauthenticated tier**.
+    APIs with basic authentication are not tied to an application since they do not require a subscription. Therefore, they do not support application-level throttling. Due to the absence of subscription tier information these requests are categorized under the **Unauthenticated tier**. However, throttling at the API level is still applicable to these APIs.
 
 ## Invoking an API using Basic Authentication
 


### PR DESCRIPTION
This PR is raised to update information on not having throttling policies support for basic authentication type.

This fixes: https://github.com/wso2-enterprise/wso2-apim-internal/issues/6514 doc issue