### PR TITLE
Removing SAML configurations from application sharing page

### DIFF
--- a/en/docs/consume/manage-application/sharing-applications/sharing-applications.md
+++ b/en/docs/consume/manage-application/sharing-applications/sharing-applications.md
@@ -28,15 +28,6 @@ You can enable application sharing with users in a single group or between users
             
     ```
 
-    **SAML**
-
-    ``` java
-    [apim.devportal]
-    enable_application_sharing = true
-    application_sharing_type = "saml"
-            
-    ```
-
     **Custom**
 
     ``` java


### PR DESCRIPTION
This PR was raised to remove SAML config in application sharing page.

Related internal issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/6200