### PR TITLE
[3.2.0] Corrected `http_access_log` config

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
+++ b/en/docs/administer/logging-and-monitoring/logging/monitoring-http-access-logs.md
@@ -20,7 +20,7 @@ In the API Manager, access logs of applications get recorded or written into the
 
     ```properties
     [http_access_log]
-    useLogger = true
+    enabled = true
     ```
     
 3. Restart the server.

--- a/en/tools/config-catalog-generator/data/http_access_log.toml
+++ b/en/tools/config-catalog-generator/data/http_access_log.toml
@@ -1,2 +1,2 @@
 [http_access_log]
-useLogger = true
+enabled = true


### PR DESCRIPTION
This PR will correct the issue in the config of enabling `http_access_log`

Resolves : https://github.com/wso2-enterprise/wso2-apim-internal/issues/4014