### PR TITLE
[4.3.0] Corrected `http_access_log` config

### DIFF
--- a/en/docs/observe/api-manager/monitoring-http-access-logs.md
+++ b/en/docs/observe/api-manager/monitoring-http-access-logs.md
@@ -16,7 +16,7 @@ In the API Manager, access logs of applications get recorded or written into the
 
     ```properties
     [http_access_log]
-    useLogger = true
+    enabled = true
     ```
 
  3. Open <APIM_HOME>/repository/conf/log4j2.properties file:

--- a/en/tools/config-catalog-generator/data/http_access_log.toml
+++ b/en/tools/config-catalog-generator/data/http_access_log.toml
@@ -1,2 +1,2 @@
 [http_access_log]
-useLogger = true
+enabled = true


### PR DESCRIPTION
This PR will correct the issue in the config of enabling `http_access_log`

Resolves: https://github.com/wso2-enterprise/wso2-apim-internal/issues/4014