### PR TITLE
[4.1.0] Fix sample curl of add API specific operation policy

### DIFF
--- a/en/docs/reference/product-apis/publisher-apis/publisher-v3/publisher-v3.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v3/publisher-v3.yaml
@@ -7593,7 +7593,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F policyDefinitionFile=@setHeader.j2
+            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F synapsePolicyDefinitionFile=@setHeader.j2
             "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies"'
 
 


### PR DESCRIPTION
This PR fixes the sample cURL command of add API specific operation policy.

```
 +  -F policyDefinitionFile=@setHeader.j2
 -  -F synapsePolicyDefinitionFile=@setHeader.j2
```