### PR TITLE
[4.0.0] Add doc changes for generating the SecuritySchema of the Swagger using real Key Manager information

### DIFF
--- a/en/docs/reference/product-apis/devportal-apis/devportal-v2/devportal-v2.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v2/devportal-v2.yaml
@@ -249,6 +249,17 @@ paths:
         - $ref: '#/components/parameters/environmentName'
         - $ref: '#/components/parameters/If-None-Match'
         - $ref: '#/components/parameters/requestedTenant'
+        - name: query
+          in: query
+          description: |
+            **Key Manager Specific Swagger Generation**.
+            To retrieve an OpenAPI Specification (OAS) definition for a specific Key Manager, please specify the Key Manager's ID in your request. 
+            
+            For example, by passing the query parameter `kmId:65e30b46-85e4-4788-85b7-b1c3de06b2e0`, you will receive the OAS definition containing all relevant information for the Key Manager associated with that ID.
+            
+            **Important:** If you're using a client that does not automatically handle URL encoding (such as `curl`), please ensure that you encode the URL properly.
+          schema:
+           type: string
       responses:
         200:
           description: |


### PR DESCRIPTION
## Purpose
To add documentation changes for generating the SecuritySchema of the Swagger using real Key Manager information

## Goals
Fixes doc improvements: https://github.com/wso2/api-manager/issues/3044

