### PR TITLE
[4.2.0] Fix alignment issue in note

### DIFF
--- a/en/docs/tutorials/edit-an-api-by-modifyng-the-api-definition.md
+++ b/en/docs/tutorials/edit-an-api-by-modifyng-the-api-definition.md
@@ -181,9 +181,8 @@ In this tutorial, let's see how you can add interactive documentation to an API 
                   The summary and description of the GET method that you added is visible when you expand the GET method in the API Publisher.
                   ![]({{base_path}}/assets/img/learn/tutorials/pizza-shack-api-get-summary-and-description-updated.png)
 
-           
-   !!! important
-       Starting from WSO2 API Manager 4.x, the platform ensures that the info.version and info.title fields in the OpenAPI (Swagger) specification are automatically aligned with the version and title of the API that is published on the API Manager. This approach ensures that the version and title in the Swagger definition accurately correspond to the actual API deployed in the API Gateway.
+!!! Important
+    Starting from WSO2 API Manager 4.x, the platform ensures that the `info.version` and `info.title` fields in the OpenAPI (Swagger) specification are automatically aligned with the version and title of the API that is published on the API Manager. This approach ensures that the version and title in the Swagger definition accurately correspond to the actual API deployed in the API Gateway.
 
 
 7. Complete the rest of the API creation process.


### PR DESCRIPTION
## Purpose
This PR fixes an alignment issue in the Important type note section in `edit-an-api-by-modifyng-the-api-definition.md` file

<img width="1512" alt="Screenshot 2024-09-23 at 11 33 50" src="https://github.com/user-attachments/assets/17f31fc0-45a5-43a0-9983-e7c90dc55b6b">