### PR TITLE
[4.3.0] Fix 'Missing image in Create and Publish a WebSocket API page'

### DIFF
--- a/en/docs/tutorials/streaming-api/create-and-publish-websocket-api.md
+++ b/en/docs/tutorials/streaming-api/create-and-publish-websocket-api.md
@@ -76,7 +76,7 @@ This will demonstrate a simple command line based chat room which has two channe
 5. Configure the runtime configurations.
     1. Click **Runtime** under the **API Configurations** section, select the required authentication type, and click **Save**.
 
-       <a href="{{base_path}}/assets/img/tutorials/streaming-api/websocket-api-runtime-configurations.png"><img src="{{base_path}}/assets/img/design/create-api/streaming-api/websocket-api-runtime-configurations.png" width="65%" alt="Runtime Configurations of WebSocket API"></a>
+       <a href="{{base_path}}/assets/img/tutorials/streaming-api/websocket-api-runtime-configurations.png"><img src="{{base_path}}/assets/img/tutorials/streaming-api/websocket-api-runtime-configurations.png" width="65%" alt="Runtime Configurations of WebSocket API"></a>
     
 6. Add topics to the WebSocket API.
 


### PR DESCRIPTION
## Purpose

Fixes #8458 in 4.3.0 doc space