### PR TITLE
[Master] Fix documentation Issues

### DIFF
--- a/en/docs/design/create-api/adding-custom-properties-to-apis.md
+++ b/en/docs/design/create-api/adding-custom-properties-to-apis.md
@@ -81,3 +81,9 @@ For example, if you want to search for the environment property with a specific 
 When you click on the name of the API in the above screen, the respective API Overview page appears. Click on the **Properties** tab to list the API properties that you added.
 
 [![API Properties]({{base_path}}/assets/img/learn/view-custom-api-properties.png)]({{base_path}}/assets/img/learn/view-custom-api-properties.png)
+
+??? note "Note"
+        When devportal visibility is enabled for a property when searching from Publisher, we need to search it in the following manner.
+        <property_name>__display:<property_value>
+
+        For example, if you added a property called env with value dev, we need to search it in the publisher as env__display:dev.

--- a/en/docs/design/create-api/adding-custom-properties-to-apis.md
+++ b/en/docs/design/create-api/adding-custom-properties-to-apis.md
@@ -81,9 +81,3 @@ For example, if you want to search for the environment property with a specific 
 When you click on the name of the API in the above screen, the respective API Overview page appears. Click on the **Properties** tab to list the API properties that you added.
 
 [![API Properties]({{base_path}}/assets/img/learn/view-custom-api-properties.png)]({{base_path}}/assets/img/learn/view-custom-api-properties.png)
-
-??? note "Note"
-        When devportal visibility is enabled for a property when searching from Publisher, we need to search it in the following manner.
-        <property_name>__display:<property_value>
-
-        For example, if you added a property called env with value dev, we need to search it in the publisher as env__display:dev.

--- a/en/docs/design/create-api/change-api-thumbnail.md
+++ b/en/docs/design/create-api/change-api-thumbnail.md
@@ -18,38 +18,3 @@ The thumbnail of an API can be changed by uploading an image for the thumbnail o
     The newly added image appears as the API thumbnail.
     
     <img src="{{base_path}}/assets/img/learn/change-thumbnail-api-updated.png" height="250"/>
-      
-## Design a new API Thumbnail
-
-1. Follow [steps 1 - 3 under Upload new API thumbnail](#Upload-new-API-thumbnail).
-
-2. Click **Design**.
-    [![]({{base_path}}/assets/img/learn/change-thumbnail-design.png)]({{base_path}}/assets/img/learn/change-thumbnail-design.png) 
-    
-4. Select an icon, color, and background for the thumbnail.
-    
-    - **Category**
-        
-        Select the icon category. Currently, the API Publisher supports the following categories.
-        
-        <img src="{{base_path}}/assets/img/learn/change-thumbnail-icon-types.png" height="300"/>
-
-    - **Icon Color**
-        
-        Select the icon color from the color picker.
-    
-        <img src="{{base_path}}/assets/img/learn/change-thumbnail-select-color.png" height="250"/>
-        
-    - **Background**
-        
-        Select the thumbnail background from the designs.
-        
-        <img src="{{base_path}}/assets/img/learn/change-thumbnail-select-background.png" height="150"/>
-          
-5. Click  **SAVE** to save the thumbnail.
-     [![change thumbnail design icon]({{base_path}}/assets/img/learn/change-thumbnail-design-icon.png)]({{base_path}}/assets/img/learn/change-thumbnail-design-icon.png) 
-     
-     The designed thumbnail appears as the API thumbnail.
-
-     <img src="{{base_path}}/assets/img/learn/change-thumbnail-design-icon-changed.png" height="250"/>
-    

--- a/en/docs/design/rate-limiting/adding-new-throttling-policies.md
+++ b/en/docs/design/rate-limiting/adding-new-throttling-policies.md
@@ -43,8 +43,10 @@ You can add advanced rate limiting policies to both APIs and resources.
      <li>
      Note that if you want to add a header, query param, or JSON Web Token (JWT) claim condition, you need to set the `enable_header_based_throttling` , `enable_jwt_claim_based_throttling` or `enable_query_param_based_throttling` element to `true` (depending on which condition you need) under `[apim.throttling]` in the `repository/conf/deployment.toml` file.</li>
       ```toml
-      [transport.passthru_https.sender.parameters]
-      HostnameVerifier = "AllowAll"
+      [apim.throttling]
+      enable_header_based_throttling = true
+      enable_jwt_claim_based_throttling = true
+      enable_query_param_based_throttling = true
       ```
      <li>This JWT is the backend JWT and not the one you use to invoke it. In addition, you need to enable the Backend JWT token to get this rate limiting flow to work.
      </li></ul>

--- a/en/docs/design/rate-limiting/adding-new-throttling-policies.md
+++ b/en/docs/design/rate-limiting/adding-new-throttling-policies.md
@@ -42,6 +42,10 @@ You can add advanced rate limiting policies to both APIs and resources.
      </li>
      <li>
      Note that if you want to add a header, query param, or JSON Web Token (JWT) claim condition, you need to set the `enable_header_based_throttling` , `enable_jwt_claim_based_throttling` or `enable_query_param_based_throttling` element to `true` (depending on which condition you need) under `[apim.throttling]` in the `repository/conf/deployment.toml` file.</li>
+      ```toml
+      [transport.passthru_https.sender.parameters]
+      HostnameVerifier = "AllowAll"
+      ```
      <li>This JWT is the backend JWT and not the one you use to invoke it. In addition, you need to enable the Backend JWT token to get this rate limiting flow to work.
      </li></ul>
      </p>


### PR DESCRIPTION
## Purpose

1. Adding deployment.toml config to make the document clear in the Advanced rate limiting policy document.
Resolves: https://github.com/wso2/docs-apim/issues/8460

2. Removed the 'Design a new API Thumbnail' document since this feature is not available now.
Resolves: https://github.com/wso2/docs-apim/issues/8455