### PR TITLE
Update mutual-ssl-between-api-gateway-and-backend.md

### DIFF
--- a/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
+++ b/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
@@ -54,8 +54,7 @@ To configure APIM for Dynamic SSL Profiles for HTTPS transport Sender, you need 
     <profile>
     <servers>localhost:port</servers>
     <TrustStore>
-    <Location>repository/resources/security/client-truststore.jks
-    </Location>
+    <Location>repository/resources/security/client-truststore.jks</Location>
     <Type>JKS</Type>
     <Password>wso2carbon</Password>
     </TrustStore>
@@ -64,8 +63,7 @@ To configure APIM for Dynamic SSL Profiles for HTTPS transport Sender, you need 
     <profile>
         <servers>10.100.5.130:9444</servers>
         <TrustStore>
-        <Location>repository/resources/security/client-truststore.jks
-        </Location>
+        <Location>repository/resources/security/client-truststore.jks</Location>
         <Type>JKS</Type>
     <Password>wso2carbon</Password>
         </TrustStore>

--- a/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
+++ b/en/docs/learn/api-gateway/mutual-ssl-between-api-gateway-and-backend.md
@@ -85,7 +85,7 @@ To enable dynamic loading of this configuration, add the below configurations to
 
 ``` toml
 [transport.passthru_https.sender.ssl_profile]
-file_path = "repository/deployment/server/mutual_ssl_profiles.xml"
+file_path = "repository/deployment/server/sslprofiles.xml"
 interval = 3600000
 
 [transport.passthru_https.sender.parameters]


### PR DESCRIPTION
Removed an unnecessary newline character that was causing a FileNotFoundException when customers directly used and copied the configuration path. This improvement aims to prevent potential confusion, particularly for customers encountering this issue.

**Details**
Previously, an extra newline in the path caused the following exception when users attempted to load the client truststore file directly:

```
java.io.FileNotFoundException: repository/resources/security/client-truststore.jks
     (No such file or directory)
```

This update ensures the path is correctly formatted to avoid such exceptions, streamlining the setup process and improving usability for end-users.