### PR TITLE
Add note to indicate group attributes are not used in read-only LDAP userstores

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-stores/configuring-secondary-user-stores.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-stores/configuring-secondary-user-stores.md
@@ -69,6 +69,9 @@ There are two approaches to configure a secondary user store. It can be configur
 
     !!! note
         Make sure that you do not enter `federated` as the domain name as the term is reserved for federated users.
+    
+    !!! note
+        If you are configuring a `UniqueIDReadOnlyLDAPUserStoreManager`, ensure that the **Enable Group Unique Id** attribute remains unchecked. Additionally, the **Group Id Attribute** setting will not be effective. This is because API Manager does not support group and role separation.
 
 6. Ensure that all the mandatory fields are filled and a valid domain name is given and click **Add**.
 


### PR DESCRIPTION
## Purpose
This PR adds a note to indicate group related attributes are not used in read-only LDAP userstores.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8581