### PR TITLE
[3.2.0] Remove docs for Flash SDK

### DIFF
--- a/en/docs/learn/consume-api/generating-sdks/generate-sdks-in-dev-portal.md
+++ b/en/docs/learn/consume-api/generating-sdks/generate-sdks-in-dev-portal.md
@@ -28,7 +28,7 @@ Follow the instructions below to generate and download client-side SDKs via the 
     
 ##  Configuring supported languages for SDK generation
 
-By default, **Android, Java, JavaScript**, and **JMeter** the SDKs that are available to be downloaded via the Developer Portal in WSO2 API Manager (WSO2 API-M). In addition to the latter mentioned SDKs, WSO2 API Manager also supports SDK generation for the following languages. **C-Sharp (C#), Dart, Flash, Groovy, Perl, PHP, Python, Ruby, Swift 5, Clojure**.
+By default, **Android, Java, JavaScript**, and **JMeter** the SDKs that are available to be downloaded via the Developer Portal in WSO2 API Manager (WSO2 API-M). In addition to the latter mentioned SDKs, WSO2 API Manager also supports SDK generation for the following languages. **C-Sharp (C#), Dart, Groovy, Perl, PHP, Python, Ruby, Swift 5, Clojure**.
 
 <div class="admonition note">
 <p class="admonition-title">Changes based on WSO2 Updates</p>
@@ -76,7 +76,7 @@ Follow the instructions below to configure the languages available for SDK gener
 
      ```
      [apim.sdk]
-     supported_languages = ["android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
+     supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
      ```
     
 3.  [Restart the server]({{base_path}}/install-and-setup/installation-guide/running-the-product/) to apply the configuration changes.

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -957,7 +957,7 @@ claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetrieve
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Specify NONE to disable the signing.</p>
+                                        <p>Specify NONE to disbale the sigining.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -4348,7 +4348,7 @@ group_id = "org.wso2"
 artifact_id = "org.wso2.client"
 model_package = "org.wso2.client.model"
 api_package = "org.wso2.client.api"
-supported_languages = ["android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
+supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
                     </code></pre>
                     </div>
                 </div>
@@ -4452,7 +4452,7 @@ supported_languages = ["android", "java", "csharp", "dart", "flash", "groovy", "
                                             <span class="param-default-value">Default: <code>android, java, javascript, jmeter</code></span>
                                         </div>
                                         <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>android, java, javascript, jmeter, csharp, dart, flash, groovy, perl, php, python, ruby, swift5, clojure</code></span>
+                                            <span class="param-possible-values">Possible Values: <code>android, java, javascript, jmeter, csharp, dart, groovy, perl, php, python, ruby, swift5, clojure</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">

--- a/en/tools/config-catalog-generator/data/apim.sdk.toml
+++ b/en/tools/config-catalog-generator/data/apim.sdk.toml
@@ -3,5 +3,5 @@ group_id = "org.wso2"
 artifact_id = "org.wso2.client"
 model_package = "org.wso2.client.model"
 api_package = "org.wso2.client.api"
-supported_languages = ["android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
+supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
                     

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1676,7 +1676,7 @@
                             "type": "string",
                             "required": false,
                             "default": "android, java, javascript, jmeter",
-                            "possible": "android, java, javascript, jmeter, csharp, dart, flash, groovy, perl, php, python, ruby, swift5, clojure",
+                            "possible": "android, java, javascript, jmeter, csharp, dart, groovy, perl, php, python, ruby, swift5, clojure",
                             "description": "Supported programming languages."
                         }
                     ]


### PR DESCRIPTION
## Purpose
This PR removes Flash SDK from the documentation since it is no longer supported.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8902