### PR TITLE
[4.0.0] Remove docs for Scala and Flash SDK

### DIFF
--- a/en/docs/consume/generating-sdks/generate-sdks-in-dev-portal.md
+++ b/en/docs/consume/generating-sdks/generate-sdks-in-dev-portal.md
@@ -28,7 +28,7 @@ Follow the instructions below to generate and download client-side SDKs via the 
     
 ##  Configuring supported languages for SDK generation
 
-By default, **Android, Java, JavaScript**, and **JMeter** the SDKs that are available to be downloaded via the Developer Portal in WSO2 API Manager (WSO2 API-M). In addition to the latter mentioned SDKs, WSO2 API Manager also supports SDK generation for the following languages. **Scala, C-Sharp (C#), Dart, Flash, Groovy, Node.js (NodeJs), Perl, PHP, Python, Ruby, Swift, Clojure, AsyncScala, CsharpDotNet2**.
+By default, **Android, Java, JavaScript**, and **JMeter** the SDKs that are available to be downloaded via the Developer Portal in WSO2 API Manager (WSO2 API-M). In addition to the latter mentioned SDKs, WSO2 API Manager also supports SDK generation for the following languages. **C-Sharp (C#), Dart, Groovy, Node.js (NodeJs), Perl, PHP, Python, Ruby, Swift, Clojure, CsharpDotNet2**.
 
 <div class="admonition note">
 <p class="admonition-title">Changes based on WSO2 Updates</p>
@@ -76,7 +76,7 @@ Follow the instructions below to configure the languages available for SDK gener
 
     ```toml
     [apim.sdk]
-    supported_languages = ["android", "java", "scala", "csharp", "dart", "flash", "groovy", "javascript"]
+    supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript"]
     ```
     
 3.  [Restart the server]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m/) to apply the configuration changes.

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -4437,7 +4437,7 @@ group_id = "org.wso2"
 artifact_id = "org.wso2.client"
 model_package = "org.wso2.client.model"
 api_package = "org.wso2.client.api"
-supported_languages = ["android", "java", "scala", "csharp", "dart", "flash", "groovy", "javascript"]
+supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript"]
                     </code></pre>
                     </div>
                 </div>
@@ -4538,7 +4538,7 @@ supported_languages = ["android", "java", "scala", "csharp", "dart", "flash", "g
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>android,java,scala,csharp,dart,flash,groovy,javascript,jmeter,nodejs,perl,php,python,ruby,swift,clojure,asyncScala,csharpDotNet2</code></span>
+                                            <span class="param-default-value">Default: <code>android,java,csharp,dart,groovy,javascript,jmeter,nodejs,perl,php,python,ruby,swift,clojure,csharpDotNet2</code></span>
                                         </div>
                                         
                                     </div>

--- a/en/tools/config-catalog-generator/data/apim.sdk.toml
+++ b/en/tools/config-catalog-generator/data/apim.sdk.toml
@@ -3,5 +3,5 @@ group_id = "org.wso2"
 artifact_id = "org.wso2.client"
 model_package = "org.wso2.client.model"
 api_package = "org.wso2.client.api"
-supported_languages = ["android", "java", "scala", "csharp", "dart", "flash", "groovy", "javascript"]
+supported_languages = ["android", "java", "csharp", "dart", "groovy", "javascript"]
                     

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1703,7 +1703,7 @@
                             "name": "supported_languages",
                             "type": "string",
                             "required": false,
-                            "default": "android,java,scala,csharp,dart,flash,groovy,javascript,jmeter,nodejs,perl,php,python,ruby,swift,clojure,asyncScala,csharpDotNet2",
+                            "default": "android,java,csharp,dart,groovy,javascript,jmeter,nodejs,perl,php,python,ruby,swift,clojure,csharpDotNet2",
                             "possible": "",
                             "description": "Supported programming languages."
                         }


### PR DESCRIPTION
## Purpose
This PR removes Scala and Flash SDKs from the documentation since they are no longer supported.

Related issues: https://github.com/wso2-enterprise/wso2-apim-internal/issues/9056, https://github.com/wso2-enterprise/wso2-apim-internal/issues/8902