### PR TITLE
Add description to the revisions get query param

### DIFF
--- a/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
@@ -1645,6 +1645,8 @@ paths:
         - $ref: '#/components/parameters/apiId'
         - name: query
           in: query
+          description: |
+            The query filters revisions based on deployment status, where "deployed:true" returns deployed revisions, "deployed:false" returns non-deployed revisions, and any other query returns all revisions of the API.
           schema:
             type: string
       responses:


### PR DESCRIPTION
## Purpose
This PR adds a description for the "query" parameter in the Get Revision List Publisher resource.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/9004