### PR TITLE
Remove WIP Banner from APIM 4.5.0 Docs

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1344,14 +1344,6 @@ html .md-typeset .superfences-tabs>label:hover {
     margin-top: 0;
 }
 
-.beta-badge {
-    display: inline-block;
-    background: #ffd600;
-    font-size: 14px;
-    padding: 5px;
-    line-height: 1;
-}
-
 @media only screen and (min-width: 60em) {
     .md-content {
         margin-right: 12.1rem;

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -35,7 +35,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            {{ config.site_name | replace('WSO2', '') }} <span class="beta-badge">This documentation is a work in progress.</span>
+            {{ config.site_name | replace('WSO2', '') }}
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">


### PR DESCRIPTION
### Purpose
- Remove the WIP banner which was introduced in [1] from the APIM 4.5.0 Docs

[1] https://github.com/wso2/docs-apim/pull/9009/commits/029d5eecced1b315a52dbc9a76fe2e9640709c11