### PR TITLE
Update git integration documentation

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/adapter-configurations.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/configurations/adapter-configurations.md
@@ -637,7 +637,7 @@ See the example .toml file given below.
     branch = "main"
     username = "$env{git_username}"
     accessToken = "$env{git_access_token}"
-    sshKeyFile = "/home/wso2/ssh-keys/id_ed25519"
+    SSHKeyFile = "/home/wso2/ssh-keys/id_ed25519"
 ```
                     </div>
                 </div>
@@ -835,7 +835,7 @@ See the example .toml file given below.
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sshKeyFile</code> </span>
+                                  <span class="param-name-wrap"> <code>SSHKeyFile</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>

--- a/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/git-integration.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/choreo-connect/git-integration.md
@@ -98,7 +98,7 @@ Add the following configuration under the Adapter section of the main configurat
         branch = "<branch_name>"
         username = $env{git_username}
         accessToken = $env{git_access_token}
-        sshKeyFile = "/home/wso2/ssh-keys/<private_key_file>"
+        SSHKeyFile = "/home/wso2/ssh-keys/<private_key_file>"
     ```
 
 === "Example"
@@ -118,7 +118,7 @@ Add the following configuration under the Adapter section of the main configurat
         branch = "main"
         username = $env{git_username}
         accessToken = $env{git_access_token}
-        sshKeyFile = "/home/wso2/ssh-keys/id_ed25519"
+        SSHKeyFile = "/home/wso2/ssh-keys/id_ed25519"
     ```
 
 The following table describes the above configuration.
@@ -151,15 +151,15 @@ The following table describes the above configuration.
 <td>The username of the Git repository. If this is set, then you need to also set the <code>accessToken</code>.</td></tr>
 <tr><td><code>accessToken</code></td>                      
 <td>The password or personal access token of the Git repository.</td></tr>
-<tr><td><code>sshKeyFile</code></td>        
-<td><code>sshKeyFile</code> is the optional path to the private key used for authenticating the Git repository. If this is set, then you do not need to set the <code>username</code> and <code>accessToken</code>.</td></tr>
+<tr><td><code>SSHKeyFile</code></td>        
+<td><code>SSHKeyFile</code> is the optional path to the private key used for authenticating the Git repository. If this is set, then you do not need to set the <code>username</code> and <code>accessToken</code>.</td></tr>
 </table>
 
 !!! note
     - Both `artifactsDirectory` configurations should be set to the same directory path.
     - If the `branch` is not specified, the default branch will be used.
-    - If the repository is a public repository (in GitHub), then you do not need to set `username`, `accessToken` and `sshKeyFile`.
-    - If the repository is a private repository, then you need to set either the `username` and `accessToken` or `sshKeyFile`.
+    - If the repository is a public repository (in GitHub), then you do not need to set `username`, `accessToken` and `SSHKeyFile`.
+    - If the repository is a private repository, then you need to set either the `username` and `accessToken` or `SSHKeyFile`.
 
 #### Step 2.2 - Authenticate the source watcher with the repository
 
@@ -201,7 +201,7 @@ To authenticate the repository with basic HTTP authentication, the username and 
               branch = ""
               username = $env{git_username}
               accessToken = $env{git_access_token}
-              sshKeyFile = ""
+              SSHKeyFile = ""
         ```
 
     === "Example"
@@ -221,14 +221,14 @@ To authenticate the repository with basic HTTP authentication, the username and 
               branch = ""
               username = $env{git_username}
               accessToken = $env{git_access_token}
-              sshKeyFile = ""
+              SSHKeyFile = ""
         ```
 
 __________________________________________
 
 #### **Using the SSH Key file**
 
-To authenticate the repository with SSH key, the SSH private key file path should be set in the `sshKeyFile` field. 
+To authenticate the repository with SSH key, the SSH private key file path should be set in the `SSHKeyFile` field. 
 
 1. Generate the SSH Keys that need to be used for authentication.
 
@@ -260,7 +260,7 @@ To authenticate the repository with SSH key, the SSH private key file path shoul
               branch = ""
               username = ""
               accessToken = ""
-              sshKeyFile = "/home/wso2/ssh-keys/<private_key_file>"
+              SSHKeyFile = "/home/wso2/ssh-keys/<private_key_file>"
         ```
 
     === "Example"
@@ -280,7 +280,7 @@ To authenticate the repository with SSH key, the SSH private key file path shoul
               branch = ""
               username = ""
               accessToken = ""
-              sshKeyFile = "/home/wso2/ssh-keys/id_ed25519"
+              SSHKeyFile = "/home/wso2/ssh-keys/id_ed25519"
         ```
 
 3. Copy the generated private key file to the `docker-compose/resources/adapter/ssh-keys` directory.

--- a/en/tools/config-catalog-generator-cc/data/adapter/configs.json
+++ b/en/tools/config-catalog-generator-cc/data/adapter/configs.json
@@ -272,7 +272,7 @@
               "description": "The password or personal access token of the Git repository."
             },
             {
-              "name": "sshKeyFile",
+              "name": "SSHKeyFile",
               "type": "string",
               "required": false,
               "description": "The optional path to the private key used for authenticating the Git repository. If this is set, then you do not need to set the username and accessToken."

--- a/en/tools/config-catalog-generator-cc/data/adapter/source_control.toml
+++ b/en/tools/config-catalog-generator-cc/data/adapter/source_control.toml
@@ -9,4 +9,4 @@
     branch = "main"
     username = "$env{git_username}"
     accessToken = "$env{git_access_token}"
-    sshKeyFile = "/home/wso2/ssh-keys/id_ed25519"
+    SSHKeyFile = "/home/wso2/ssh-keys/id_ed25519"


### PR DESCRIPTION
## Purpose
> Authenticating the Github repository with SSH key fails when integrating Choreo Connect with Git for version controlling of API artifacts.
Related Issue - https://github.com/wso2/product-microgateway/issues/3669

## Goals
> Enable Git for version controlling of API artifacts using SSH by correctly parsing the configuration for the SSH key file.

## Approach
> Rename of the configuration from sshKeyFile to SSHKeyFile matching the configuration key name to the struct defined in the adapter.