### PR TITLE
[4.5.0] Add note to mention database replication was done using VMs

### DIFF
--- a/en/docs/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1.md
+++ b/en/docs/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1.md
@@ -6,10 +6,6 @@ All the regions are identical in this pattern. therefore, the documentation will
 
 ## Step 1: Configure the Database with replication
 
-!!! Note
-    WSO2 API Manager has support for DB replication with only MSSQL and Oracle DBs.
-    Our customers have used and tested these two DBs and the necessary primary and secondary keys are available.
-
 WSO2 API Manager comes with the multi-dc database scripts for MSSQL and Oracle. When setting up the database with replication for the multi-dc deployment, it is recommended to use the provided script. The file structure is as follows.
 
 ```bash
@@ -33,6 +29,9 @@ WSO2 API Manager comes with the multi-dc database scripts for MSSQL and Oracle. 
 ```
 
 You should consult your database administrator on replication related configurations.
+
+!!! note
+    Bi-directional replication in the multi-DC setup was tested using Virtual Machine (VM)-based databases. If you intend to use a cloud-based database service, consult the relevant cloud provider for any limitations related to configuring an active-active database setup in their environment.
 
 ## Step 2: Configure the API Manager Nodes
 


### PR DESCRIPTION
## Purpose
This PR adds a note stating that database replication was tested using VM-based setups, and advises users intending to use a cloud service to verify feasibility with the respective cloud provider.