### PR TITLE
Fix: Missing Configuration for Default Application Creation 

### DIFF
--- a/en/docs/consume/manage-application/create-application.md
+++ b/en/docs/consume/manage-application/create-application.md
@@ -8,7 +8,7 @@ Applications allow you to:
 -   Subscribe multiple times to a single API with different Service Level Agreements (SLAs)/business plans which 
 operate on per access token basis.
 
-WSO2 API Manager comes with a pre-created default application, which allows unlimited access by default. You can also [create]({{base_path}}/consume/manage-application/create-application/#create-a-new-application) your own.
+WSO2 API Manager comes with a pre-created default application, which allows unlimited access by default. Default application creation can be disabled by adding the configuration `"DisableDefaultApplicationCreation" : true` into the `tenant-config.json` file. You can also [create]({{base_path}}/consume/manage-application/create-application/#create-a-new-application) your own.
 
 ## Create a new application
 

--- a/en/docs/consume/manage-application/create-application.md
+++ b/en/docs/consume/manage-application/create-application.md
@@ -8,7 +8,7 @@ Applications allow you to:
 -   Subscribe multiple times to a single API with different Service Level Agreements (SLAs)/business plans which 
 operate on per access token basis.
 
-WSO2 API Manager comes with a pre-created default application, which allows unlimited access by default. Default application creation can be disabled by adding the configuration `"DisableDefaultApplicationCreation" : true` into the `tenant-config.json` file. You can also [create]({{base_path}}/consume/manage-application/create-application/#create-a-new-application) your own.
+WSO2 API Manager comes with a pre-created default application, which allows unlimited access by default. Default application creation can be disabled by adding the configuration `"DisableDefaultApplicationCreation" : true` in to the `Advanced Configurations` under `Settings` of the `admin` portal. You can also [create]({{base_path}}/consume/manage-application/create-application/#create-a-new-application) your own.
 
 ## Create a new application
 


### PR DESCRIPTION
## Purpose
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/9757