### PR TITLE
Add arm compatibility to docs

### DIFF
--- a/en/docs/install-and-setup/install/installation-prerequisites.md
+++ b/en/docs/install-and-setup/install/installation-prerequisites.md
@@ -186,3 +186,34 @@ The following applications are required for running WSO2 API Manager and its sam
  </tr>
  </table>
  </html>
+
+## ARM compatibility
+
+WSO2 API Manager is compatible with ARM processors. It can run on ARM-based systems, such as those with Apple Silicon or ARM-based Linux distributions.
+
+The products have been tested and confirmed to work on the following ARM-based processors:
+
+<html>
+<table>
+<tr>
+<th> <b>Operating System</b> </th>
+<th> <b>ARM Architecture</b> </th>
+</tr>
+<tr>
+<td>
+<p><b>MacOS</b></p>
+</td>
+<td>
+  <p>M1, M2, M3, M4</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><b>Ubuntu 24.04</b></p>
+</td>
+<td>
+ARMv9
+</td>
+</tr>
+</table>
+</html>


### PR DESCRIPTION
## Purpose
> Test compatibility of APIM 4.5.0 products on Linux ARM.
Related issue - https://github.com/wso2-enterprise/wso2-apim-internal/issues/9895

### Approach
> Tested the following on a VM on Azure with Ubuntu 24.04 and arm64 CPU architecture.
- wso2update_linux_arm64 update tool
- WSO2 APIM 4.5.0 all-in-one distribution
- WSO2 APIM 4.5.0 distributed setup with ACP, Gateway and TM - profile testing
- API Microgateway 3.2.0 toolkit and runtime