### PR TITLE
[440] Add wsSharedEventLoopPoolSize configurations for Websocket connections

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -10800,6 +10800,7 @@ bypass_hosts = ["localhost"]
 sender.enable = false
 sender.parameters.ws.outflow.dispatch.sequence = "outflowDispatchSeq"
 sender.parameters.ws.outflow.dispatch.fault.sequence = "outflowFaultSeq"
+sender.parameters.wsSharedEventLoopPoolSize = 5
 sender.parameter.customParameter = ""</code></pre>
                     </div>
                 </div>
@@ -10878,6 +10879,27 @@ sender.parameter.customParameter = ""</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.parameters.wsSharedEventLoopPoolSize</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>5</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The thread pool size of the shared EventLoopGroup used by WebsocketConnectionFactory for managing WebSocket client connections. Note that this configuration only available from U2 level 22 onwards.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
                                   <span class="param-name-wrap"> <code>sender.parameter.customParameter</code> </span>
                                 </div>
                                 <div class="param-info">
@@ -10924,6 +10946,7 @@ sender.parameter.customParameter = ""</code></pre>
 sender.enable = false
 sender.parameters.ws.outflow.dispatch.sequence = "outflowDispatchSeq"
 sender.parameters.ws.outflow.dispatch.fault.sequence = "outflowFaultSeq"
+sender.parameters.wsSharedEventLoopPoolSize = 5
 sender.parameter.customParameter = ""
 sender.trust_store.location = "$ref{truststore.file_name}"
 sender.trust_store.password = "$ref{truststore.password}"</code></pre>
@@ -11000,6 +11023,27 @@ sender.trust_store.password = "$ref{truststore.password}"</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>The fault sequence for the back-end to client mediation path.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>sender.parameters.wsSharedEventLoopPoolSize</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>5</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The thread pool size of the shared EventLoopGroup used by WebsocketConnectionFactory for managing WebSocket client connections. Note that this configuration only available from U2 level 22 onwards.</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/tools/config-catalog-generator/data/_ws-transport.toml
+++ b/en/tools/config-catalog-generator/data/_ws-transport.toml
@@ -2,4 +2,5 @@
 sender.enable = false
 sender.parameters.ws.outflow.dispatch.sequence = "outflowDispatchSeq"
 sender.parameters.ws.outflow.dispatch.fault.sequence = "outflowFaultSeq"
+sender.parameters.wsSharedEventLoopPoolSize = 5
 sender.parameter.customParameter = ""

--- a/en/tools/config-catalog-generator/data/_wss-transport.toml
+++ b/en/tools/config-catalog-generator/data/_wss-transport.toml
@@ -2,6 +2,7 @@
 sender.enable = false
 sender.parameters.ws.outflow.dispatch.sequence = "outflowDispatchSeq"
 sender.parameters.ws.outflow.dispatch.fault.sequence = "outflowFaultSeq"
+sender.parameters.wsSharedEventLoopPoolSize = 5
 sender.parameter.customParameter = ""
 sender.trust_store.location = "$ref{truststore.file_name}"
 sender.trust_store.password = "$ref{truststore.password}"

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -4078,6 +4078,14 @@
                             "description": "The fault sequence for the back-end to client mediation path."
                         },
                         {
+                            "name": "sender.parameters.wsSharedEventLoopPoolSize",
+                            "type": "integer",
+                            "required": false,
+                            "default": "-",
+                            "possible": "5",
+                            "description": "The thread pool size of the shared EventLoopGroup used by WebsocketConnectionFactory for managing WebSocket client connections. Note that this configuration only available from U2 level 22 onwards."
+                        },
+                        {
                             "name": "sender.parameter.customParameter",
                             "type": "string",
                             "required": false,
@@ -4121,6 +4129,14 @@
                             "default": "outflowFaultSeq",
                             "possible": "-",
                             "description": "The fault sequence for the back-end to client mediation path."
+                        },
+                        {
+                            "name": "sender.parameters.wsSharedEventLoopPoolSize",
+                            "type": "integer",
+                            "required": false,
+                            "default": "-",
+                            "possible": "5",
+                            "description": "The thread pool size of the shared EventLoopGroup used by WebsocketConnectionFactory for managing WebSocket client connections. Note that this configuration only available from U2 level 22 onwards."
                         },
                         {
                             "name": "sender.trust_store.location",


### PR DESCRIPTION
Update config catalog with `wsSharedEventLoopPoolSize` config.

Reference: https://github.com/wso2/api-manager/issues/3889