### PR TITLE
[APIM-4.2.0] Add client_certificate_header config and case sensitivity warning for OAuth mutual TLS

### DIFF
--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -10,7 +10,7 @@ APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, a
     
     The HTTP header name used to pass the client certificate (configured via `client_certificate_header` under `[oauth.mutualtls]` or `certificate_header` under `[apimgt.mutual_ssl]`) **must be specified in lowercase** (for example, `"ssl-client-cert"`).
 
-    Using uppercase or mixed case header names (for example, `"SSL-CLIENT-CERT"`) may cause the API Manager to fail to extract the client certificate correctly. As a result, features like including the client certificate thumbprint in the JWT token's `cnf` claim might not work as expected.
+    Using uppercase or mixed case header names (for example, `"SSL-CLIENT-CERT"`) may cause the API Manager to fail to extract the client certificate correctly. As a result, scenarios like including the client certificate thumbprint in the JWT token's `cnf` claim might not work as expected.
 
     Ensure consistent lowercase usage of header names throughout your deployment and API invocation.
 

--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -6,6 +6,14 @@ While OAuth 2.0 relies on bearer tokens for securing access to protected resourc
 
 APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, also known as Holder of Key Tokens. The following section explains as to how the APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens.
 
+!!! warning
+    
+    The HTTP header name used to pass the client certificate (configured via `client_certificate_header` under `[oauth.mutualtls]` or `certificate_header` under `[apimgt.mutual_ssl]`) **must be specified in lowercase** (for example, `"ssl-client-cert"`).
+
+    Using uppercase or mixed case header names (for example, `"SSL-CLIENT-CERT"`) may cause the API Manager to fail to extract the client certificate correctly. As a result, features like including the client certificate thumbprint in the JWT token's `cnf` claim might not work as expected.
+
+    Ensure consistent lowercase usage of header names throughout your deployment and API invocation.
+
 ## Import client certificate to the truststore
 
  Follow the steps given below to import the CA-signed public key certificate into API Manager's default truststore (client-truststore.jks).
@@ -46,6 +54,27 @@ APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, a
           ```
  
 3. Restart the server if it is already running.    
+
+    !!! Note
+    
+        To generate JWT tokens that include the client certificate thumbprint as the `cnf` claim, you can optionally configure the HTTP header name from which the client certificate is retrieved when invoking the token endpoint.
+        Add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file, replacing `<header-name>` with your header:
+
+        **Format:**
+
+        ```
+        [oauth.mutualtls]
+        client_certificate_header = "<header-name>"
+        ```
+
+        **Example:**
+
+        ```
+        [oauth.mutualtls]
+        client_certificate_header = "ssl-client-cert"
+        ```
+
+        When this is configured, pass the client certificate under the specified header when calling the token endpoint. The generated JWT will then include the certificate thumbprint, binding the token to the client certificate.
      
 ## Create an API secured with OAuth 2.0
 
@@ -100,7 +129,7 @@ Follow the instructions below to change the header:
     === "Example"
           ```toml
           [apimgt.mutual_ssl]
-          certificate_header = "SSL-CLIENT-CERT"
+          certificate_header = "ssl-client-cert"
           enable_client_validation = false
           client_certificate_encode = false
           ```

--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -8,7 +8,7 @@ APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, a
 
 !!! warning
     
-    The HTTP header name used to pass the client certificate (configured via `client_certificate_header` under `[oauth.mutualtls]` or `certificate_header` under `[apimgt.mutual_ssl]`) **must be specified in lowercase** (for example, `"ssl-client-cert"`).
+    In the `<API-M_HOME>/repository/conf/deployment.toml` file, the HTTP header name used to pass the client certificate (configured via `client_certificate_header` under `[oauth.mutualtls]` or `certificate_header` under `[apimgt.mutual_ssl]`) **must be specified in lowercase** (for example, `"ssl-client-cert"`).
 
     Using uppercase or mixed case header names (for example, `"SSL-CLIENT-CERT"`) may cause the API Manager to fail to extract the client certificate correctly. As a result, scenarios like including the client certificate thumbprint in the JWT token's `cnf` claim might not work as expected.
 

--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -58,6 +58,10 @@ APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, a
     !!! Note
     
         To generate JWT tokens that include the client certificate thumbprint as the `cnf` claim, you can optionally configure the HTTP header name from which the client certificate is retrieved when invoking the token endpoint.
+
+        !!! warning "Update Level 42"
+              This capability is available only in Update Level 42 and later releases. For more information, see [Updating WSO2 API Manager]({{base_path}}/administer/product-administration/updating-wso2-api-manager).
+
         Add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file, replacing `<header-name>` with your header:
 
         **Format:**


### PR DESCRIPTION
## Purpose
This PR addresses missing documentation for configuring the client_certificate_header in [oauth.mutualtls] to enable JWT tokens with the client certificate thumbprint (cnf claim) and highlights the case sensitivity issue where uppercase header names prevent proper token generation.

## Goals
To provide clear instructions for configuring the client_certificate_header, explain how to pass the client certificate to the token endpoint, and warn users about the need to use lowercase header names to ensure correct inclusion of the cnf claim in JWT tokens.

## Approach
![screencapture-localhost-8000-en-4-2-0-design-api-security-api-authentication-securing-apis-using-certificate-bound-access-tokens-2025-06-05-06_05_43](https://github.com/user-attachments/assets/7ef4c2a0-0a34-4ddf-a478-92873dbc5eca)
