### PR TITLE
Add client_certificate_header configuration

### DIFF
--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -46,6 +46,27 @@ APIs in WSO2 API Manager can be secured using Certificate Bound Access Tokens, a
           ```
  
 3. Restart the server if it is already running.    
+
+    !!! Note
+    
+        To generate JWT tokens that include the client certificate thumbprint as the `cnf` claim, you can optionally configure the HTTP header name from which the client certificate is retrieved when invoking the token endpoint.
+        Add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file, replacing `<header-name>` with your header:
+
+        **Format:**
+
+        ```
+        [oauth.mutualtls]
+        client_certificate_header = "<header-name>"
+        ```
+
+        **Example:**
+
+        ```
+        [oauth.mutualtls]
+        client_certificate_header = "ssl-client-cert"
+        ```
+
+        When this is configured, pass the client certificate under the specified header when calling the token endpoint. The generated JWT will then include the certificate thumbprint, binding the token to the client certificate.
      
 ## Create an API secured with OAuth 2.0
 
@@ -100,7 +121,7 @@ Follow the instructions below to change the header:
     === "Example"
           ```toml
           [apimgt.mutual_ssl]
-          certificate_header = "SSL-CLIENT-CERT"
+          certificate_header = "ssl-client-cert"
           enable_client_validation = false
           client_certificate_encode = false
           ```


### PR DESCRIPTION
## Purpose
This PR addresses missing documentation for configuring the client_certificate_header in [oauth.mutualtls] to enable JWT tokens with the client certificate thumbprint (cnf claim)

## Goals
To provide clear instructions for configuring the client_certificate_header, explain how to pass the client certificate to the token endpoint, and warn users about the need to use lowercase header names to ensure correct inclusion of the cnf claim in JWT tokens.

## Approach
Since both lowercase and uppercase values for the header name are accepted in the latest versions, there is no need to explicitly mention using lowercase. Instead, only update the example value to lowercase to avoid any potential issues.

![screencapture-localhost-8000-en-latest-design-api-security-api-authentication-securing-apis-using-certificate-bound-access-tokens-2025-06-05-06_44_08](https://github.com/user-attachments/assets/231d1cc1-ef7a-40e1-8ac2-ff861a625cac)
