### PR TITLE
[4.3.0] Update documentation of APIM for transport.https.sslHostConfig.properties

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -84,9 +84,7 @@ See <a href="{{base_path}}/administer/managing-users-and-roles/managing-user-sto
 <td>
   <p>To have strong transport-level security, disable SSL protocol versions and enable only TLS protocol 
 versions: TLS 1, TLS 1.1, and TLS 1.2. This can be done by replacing the <code>sslProtocol = "TLS"</code> property with 
-<code>sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2"</code> under <code>[transport.https.sslHostConfig
-.properties]</code> in the <code>deployment.toml</code> file. In addition, configure strong ciphers for 
-<code>ThriftAuthenticationService</code>, Tomcat transport, and PassThrough transport in the <code>deployment.toml</code> file. See the
+<code>protocols="+TLSv1, +TLSv1.1, +TLSv1.2, +TLSv1.3"</code> under <code>[transport.https.sslHostConfig.properties]</code> in the <code>deployment.toml</code> file. You can configure multiple TLS versions or a single TLS version according to your preference. To achieve high security, use the latest TLS version by removing <code>+TLSv1</code>, <code>+TLSv1.1</code>, and <code>+TLSv1.2</code> from the protocols <code>property</code> of the configuration. In addition, configure strong ciphers for <code>ThriftAuthenticationService</code>, Tomcat transport, and PassThrough transport in the <code>deployment.toml</code> file. See the
  following links for instructions:</p>
 <ul>
   <li><a href="{{base_path}}/install-and-setup/setup/security/configuring-transport-level-security/">Configuring Transport Level Security</a></li>
@@ -654,5 +652,5 @@ Follow the steps below to change the default credentials.
     
 3.  Once these changes are configured, restart the server.
     
-    - Linux/Unix : sh wso2server.sh
-    - Windows : wso2server.bat
+    - Linux/Unix : sh api-manager.sh
+    - Windows : api-manager.bat


### PR DESCRIPTION
## Purpose
This PR updates the WSO2 API Manager documentation to replace the deprecated sslEnabledProtocols property with the supported protocols property for SSL/TLS configuration in Tomcat 9 and later. It also clarifies that commas are optional when listing protocols, reflecting the current Tomcat configuration syntax.

## Goals
The goal is to align the documentation with the latest Tomcat standards, improve clarity for users configuring SSL/TLS protocols, and prevent misconfiguration or errors caused by outdated or incorrect property usage.

## Approach
<img width="1075" alt="Screenshot 2025-06-05 at 3 24 14 PM" src="https://github.com/user-attachments/assets/bf10db1c-b21f-4acd-a2fc-36ae048449f4" />

-----

Additionally, corrected the server startup commands:

<img width="1102" alt="Screenshot 2025-06-05 at 3 24 27 PM" src="https://github.com/user-attachments/assets/3622dfb8-893f-495b-a95f-237c92d8f5b1" />
