### PR TITLE
Add "Enable High Availability" section to deployment patterns

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -28,6 +28,7 @@ This deployment consists of a highly available API-M cluster with multiple nodes
         - [2.2 Configure User Store Properties](#22-configure-user-store-properties)
         - [2.4 Configure JWKS URL](#24-configure-jwks-url)
         - [2.5 Deploy All-in-One](#25-deploy-all-in-one)
+        - [2.6 Enable High Availability](#26-enable-high-availability)
     - [3. Add a DNS Record Mapping the Hostnames and the External IP](#3-add-a-dns-record-mapping-the-hostnames-and-the-external-ip)
     - [4. Access Management Consoles](#4-access-management-consoles)
 
@@ -335,6 +336,10 @@ wso2:
         oauth2JWKSUrl: "https://localhost:9443/oauth2/jwks"
 ```
 
+!!! tip
+    Use Key Manager's service name instead of `localhost` if you are using a different hostname for the Key Manager.
+
+
 #### 2.5 Deploy All-in-One
 
 Now deploy the Helm chart using the following command after creating a namespace for the deployment. Replace `<release-name>` and `<namespace>` with appropriate values. Replace `<helm-chart-path>` with the path to the Helm deployment.
@@ -343,6 +348,16 @@ Now deploy the Helm chart using the following command after creating a namespace
   kubectl create namespace <namespace>
   helm install <release-name> <helm-chart-path> --version 4.5.0-2 --namespace <namespace> --dependency-update -f values.yaml --create-namespace
   ```
+
+#### 2.6 Enable High Availability
+To enable high availability, you can scale the deployment by increasing the number of replicas for the API Manager runtime. This can be done by modifying the `highAvailability` in the `values.yaml` file:
+
+```yaml
+wso2:
+  deployment:
+    highAvailability: true
+```
+
 
 ### 3. Add a DNS Record Mapping the Hostnames and the External IP
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -28,6 +28,7 @@ This is the standard distributed deployment for API Manager. The default configu
         - [2.2 Configure User Store Properties](#22-configure-user-store-properties)
         - [2.4 Configure JWKS URL](#24-configure-jwks-url)
         - [2.5 Deploy Control Plane](#25-deploy-control-plane)
+        - [2.6 Enable High Availability](#26-enable-high-availability)
     - [3. Universal Gateway Configuration](#3-universal-gateway-configuration)
         - [3.1 Configure Key Manager, Eventhub and Throttling](#31-configure-key-manager-eventhub-and-throttling)
         - [3.2 Deploy Universal Gateway](#32-deploy-universal-gateway)
@@ -384,6 +385,16 @@ helm install <release-name> <helm-chart-path> \
     - `<release-name>`: Choose a name for your release (e.g., `apim`)
     - `<namespace>`: Specify the Kubernetes namespace (e.g., `wso2`)
     - `<helm-chart-path>`: Path to the Helm chart (e.g., `./all-in-one` or use the repository URL)
+
+
+#### 2.6 Enable High Availability
+To enable high availability, you can scale the deployment by increasing the number of replicas for the API Manager runtime. This can be done by modifying the `highAvailability` in the `values.yaml` file:
+
+```yaml
+wso2:
+  deployment:
+    highAvailability: true
+```
 
 ### 3. Universal Gateway Configuration
 


### PR DESCRIPTION
## Purpose

This update addresses the need for enhanced deployment resilience and scalability by enabling High Availability (HA) support in the Kubernetes deployment documentation for API Manager. Prior to this update, there was limited guidance on how to configure HA for both all-in-one and distributed deployment patterns. This change ensures users have clear, actionable instructions for enabling HA, improving system uptime and reliability.

## Goals

- Provide clear and structured guidance on enabling High Availability for both deployment patterns (all-in-one and distributed).
- Update the documentation to reflect best practices in configuring the `highAvailability` parameter in the `values.yaml` file.
- Offer helpful configuration tips, such as hostname usage for the Key Manager, to prevent common misconfigurations.
- Enhance the table of contents for easier navigation to new HA-related content.

## Approach

The documentation was updated to include a new section (2.6) in both `am-pattern-1-all-in-one-ha.md` and `am-pattern-2-all-in-one-gw.md` files. These sections guide users on how to enable HA by modifying the `highAvailability` flag in the Helm chart's `values.yaml` file. Additional guidance was added on hostname usage in the Key Manager configuration to support distributed environments. Corr
