### PR TITLE
Update deployment documentation to include replica configuration 

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -31,7 +31,8 @@ This is the standard distributed deployment for API Manager. The default configu
         - [2.6 Enable High Availability](#26-enable-high-availability)
     - [3. Universal Gateway Configuration](#3-universal-gateway-configuration)
         - [3.1 Configure Key Manager, Eventhub and Throttling](#31-configure-key-manager-eventhub-and-throttling)
-        - [3.2 Deploy Universal Gateway](#32-deploy-universal-gateway)
+        - [3.2 Enable Replicas](#32-enable-replicas)
+        - [3.3 Deploy Universal Gateway](#33-deploy-universal-gateway)
     - [4. Add a DNS Record Mapping the Hostnames and the External IP](#4-add-a-dns-record-mapping-the-hostnames-and-the-external-ip)
     - [5. Access Management Consoles](#5-access-management-consoles)
 
@@ -404,44 +405,101 @@ wso2:
 
 The following configurations are needed to connect the Universal Gateway to the Control Plane:
 
-1. Configure Control Plane as the Key Manager:
+- Configure Control Plane as the Key Manager:
    ```yaml
    km:
      # -- Key manager service name if default Resident KM is used
      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
    ```
 
-2. Configure Event Hub connection:
-   ```yaml
-   eventhub:
-     # -- Event hub (control plane) load balancer service URL
-     serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
-     # -- Event hub service URLs
-     urls:
-       - "<CONTROL_PLANE_SERVICE_NAME>"
-   ```
+- Configure Event Hub connection:
 
-3. Configure throttling settings:
-   ```yaml
-   throttling:
-     serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
-     portOffset: 0
-     # -- Port of the service URL
-     servicePort: 9443
-     # -- Traffic manager service URLs. You only need to define one if the TM is not in HA.
-     urls:
-       - "<CONTROL_PLANE_SERVICE_NAME>"
-     # -- Enable unlimited throttling tier
-     unlimitedTier: true
-     # -- Enable header-based throttling
-     headerBasedThrottling: false
-     # -- Enable JWT claim-based throttling
-     jwtClaimBasedThrottling: false
-     # -- Enable query param-based throttling
-     queryParamBasedThrottling: false
-   ```
+=== "Single All-in-One"
 
-#### 3.2 Deploy Universal Gateway
+    ```yaml
+    eventhub:
+      # -- Event hub (control plane) load balancer service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Event hub service URLs
+      urls:
+        - "<CONTROL_PLANE_SERVICE_NAME>"
+    ```
+
+=== "All-in-One with High Availability"
+
+    ```yaml
+    eventhub:
+      # -- Event hub (control plane) load balancer service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Event hub service URLs
+      urls:
+        - "<CONTROL_PLANE_1_SERVICE_NAME>"
+        - "<CONTROL_PLANE_2_SERVICE_NAME>"
+    ```
+
+- Configure throttling settings:
+
+=== "Single All-in-One"
+
+    ```yaml
+    throttling:
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      portOffset: 0
+      # -- Port of the service URL
+      servicePort: 9443
+      # -- Traffic manager service URLs. You only need to define one if the TM is not in HA.
+      urls:
+      - "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Enable unlimited throttling tier
+      unlimitedTier: true
+      # -- Enable header-based throttling
+      headerBasedThrottling: false
+      # -- Enable JWT claim-based throttling
+      jwtClaimBasedThrottling: false
+      # -- Enable query param-based throttling
+      queryParamBasedThrottling: false
+    ```
+
+=== "All-in-One with High Availability"
+
+    ```yaml
+    throttling:
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      portOffset: 0
+      # -- Port of the service URL
+      servicePort: 9443
+      # -- Traffic manager service URLs. You only need to define one if the Traffic Manager is not in HA.
+      urls:
+      - "<CONTROL_PLANE_1_SERVICE_NAME>"
+      - "<CONTROL_PLANE_2_SERVICE_NAME>"
+      # -- Enable unlimited throttling tier
+      unlimitedTier: true
+      # -- Enable header-based throttling
+      headerBasedThrottling: false
+      # -- Enable JWT claim-based throttling
+      jwtClaimBasedThrottling: false
+      # -- Enable query param-based throttling
+      queryParamBasedThrottling: false
+    ```
+
+#### 3.2 Enable Replicas
+
+To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
+
+```yaml
+wso2:
+  deployment:
+    replicas: 2
+    minReplicas: 1
+    maxReplicas: 3
+```
+
+!!! info
+    - `replicas`: The initial number of pods to start with (e.g., 2).
+    - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
+    - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
+
+#### 3.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -34,7 +34,8 @@ For advanced details on the deployment pattern, please refer to the official
         - [3.2 Deploy Traffic Manager](#32-deploy-traffic-manager)
     - [4. Universal Gateway Configuration](#4-universal-gateway-configuration)
         - [4.1 Configure Key Manager, Eventhub and Throttling](#41-configure-key-manager-eventhub-and-throttling)
-        - [4.2 Deploy Universal Gateway](#42-deploy-universal-gateway)
+        - [4.2 Enable Replicas](#42-enable-replicas)
+        - [4.3 Deploy Universal Gateway](#43-deploy-universal-gateway)
     - [5. Add a DNS Record Mapping the Hostnames and the External IP](#5-add-a-dns-record-mapping-the-hostnames-and-the-external-ip)
     - [6. Access Management Consoles](#6-access-management-consoles)
 
@@ -496,7 +497,24 @@ helm install <release-name> <helm-chart-path> \
     queryParamBasedThrottling: false
   ```
 
-#### 4.2 Deploy Universal Gateway
+#### 4.2 Enable Replicas
+
+To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
+
+```yaml
+wso2:
+  deployment:
+    replicas: 2
+    minReplicas: 1
+    maxReplicas: 3
+```
+
+!!! info
+    - `replicas`: The initial number of pods to start with (e.g., 2).
+    - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
+    - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
+
+#### 4.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -33,7 +33,8 @@ This is the fully distributed deployment for API Manager. The default configurat
           - [3.2 Deploy Traffic Manager](#32-deploy-traffic-manager)
     - [4. Universal Gateway Configuration](#4-universal-gateway-configuration)
           - [4.1 Configure Key Manager, Eventhub and Throttling](#41-configure-key-manager-eventhub-and-throttling)
-          - [4.2 Deploy Universal Gateway](#42-deploy-universal-gateway)
+          - [4.2 Enable Replicas](#42-enable-replicas)
+          - [4.3 Deploy Universal Gateway](#43-deploy-universal-gateway)
     - [5. Key Manager Configuration](#5-key-manager-configuration)
           - [5.1 Configure Eventhub](#51-configure-eventhub)
           - [5.2 Deploy Key Manager](#52-deploy-key-manager)
@@ -506,7 +507,24 @@ helm install <release-name> <helm-chart-path> \
     queryParamBasedThrottling: false
   ```
 
-#### 4.2 Deploy Universal Gateway
+#### 4.2 Enable Replicas
+
+To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
+
+```yaml
+wso2:
+  deployment:
+    replicas: 2
+    minReplicas: 1
+    maxReplicas: 3
+```
+
+!!! info
+    - `replicas`: The initial number of pods to start with (e.g., 2).
+    - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
+    - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
+
+#### 4.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -41,7 +41,8 @@ This document provides step-by-step instructions to deploy WSO2 API Manager in a
         - [3.2 Deploy Key Manager](#32-deploy-key-manager)
     - [4. Universal Gateway Configuration](#4-universal-gateway-configuration)
         - [4.1 Configure Key Manager, Eventhub, and Throttling](#41-configure-key-manager-eventhub-and-throttling)
-        - [4.2 Deploy Universal Gateway](#42-deploy-universal-gateway)
+        - [4.2 Enable Replicas](#42-enable-replicas)
+        - [4.3 Deploy Universal Gateway](#43-deploy-universal-gateway)
     - [5. Add DNS Records](#5-add-dns-records)
     - [6. Access Management Consoles](#6-access-management-consoles)
 
@@ -473,36 +474,95 @@ km:
 ```
 
 **Configure Event Hub Connection**:
-```yaml
-eventhub:
-  # -- Event hub (control plane) service URL
-  serviceUrl: "<ALL-IN-ONE_SERVICE_NAME>"
-  # -- Event hub service URLs
-  urls:
-    - "<ALL-IN-ONE_SERVICE_NAME>"
-```
+
+=== "Single All-in-One"
+
+    ```yaml
+    eventhub:
+      # -- Event hub (control plane) service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Event hub service URLs
+      urls:
+        - "<CONTROL_PLANE_SERVICE_NAME>"
+    ```
+
+=== "All-in-One with High Availability"
+
+    ```yaml
+    eventhub:
+      # -- Event hub (control plane) load balancer service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Event hub service URLs
+      urls:
+        - "<CONTROL_PLANE_1_SERVICE_NAME>"
+        - "<CONTROL_PLANE_2_SERVICE_NAME>"
+    ```
 
 **Configure Throttling**:
+
+=== "Single All-in-One"
+
+    ```yaml
+    throttling:
+      # -- Traffic Manager service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Port offset
+      portOffset: 0
+      # -- Service port
+      servicePort: 9443
+      # -- Traffic manager service URLs
+      urls:
+        - "<CONTROL_PLANE_1_SERVICE_NAME>"
+      # -- Enable unlimited throttling tier
+      unlimitedTier: true
+      # -- Advanced throttling options
+      headerBasedThrottling: false
+      jwtClaimBasedThrottling: false
+      queryParamBasedThrottling: false
+    ```
+
+=== "All-in-One with High Availability"
+
+    ```yaml
+    throttling:
+      # -- Traffic Manager service URL
+      serviceUrl: "<CONTROL_PLANE_SERVICE_NAME>"
+      # -- Port offset
+      portOffset: 0
+      # -- Service port
+      servicePort: 9443
+      # -- Traffic manager service URLs
+      urls:
+        - "<CONTROL_PLANE_1_SERVICE_NAME>"
+        - "<CONTROL_PLANE_2_SERVICE_NAME>"
+      # -- Enable unlimited throttling tier
+      unlimitedTier: true
+      # -- Advanced throttling options
+      headerBasedThrottling: false
+      jwtClaimBasedThrottling: false
+      queryParamBasedThrottling: false
+
+
+Choose the configuration that matches your deployment pattern. For high availability, specify all Control Plane service URLs under `urls` for both `eventhub` and `throttling` sections.
+
+#### 4.2 Enable Replicas
+
+To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
+
 ```yaml
-throttling:
-  # -- Traffic Manager service URL
-  serviceUrl: "<ALL-IN-ONE_SERVICE_NAME>"
-  # -- Port offset
-  portOffset: 0
-  # -- Service port
-  servicePort: 9443
-  # -- Traffic manager service URLs
-  urls:
-    - "<ALL-IN-ONE_SERVICE_NAME>"
-  # -- Enable unlimited throttling tier
-  unlimitedTier: true
-  # -- Advanced throttling options
-  headerBasedThrottling: false
-  jwtClaimBasedThrottling: false
-  queryParamBasedThrottling: false
+wso2:
+  deployment:
+    replicas: 2
+    minReplicas: 1
+    maxReplicas: 3
 ```
 
-#### 4.2 Deploy Universal Gateway
+!!! info
+    - `replicas`: The initial number of pods to start with (e.g., 2).
+    - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
+    - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
+
+#### 4.3 Deploy Universal Gateway
 
 Deploy the Universal Gateway component with your custom configuration:
 


### PR DESCRIPTION
## Purpose
Improve the Kubernetes deployment guide.

## Goals
- Add a guide on how to enable gateway replicas.
- Add a tab view to separate single-node and HA setup configurations.
