### PR TITLE
Fix Helm chart reference for Universal Gateway and add MySQL 8+ charset note

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -167,7 +167,7 @@ Deploy API Manager with minimal configuration using the following commands:
 helm install apim wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_values.yaml
 
 # Deploy Universal Gateway
-helm install apim-gw wso2/wso2am-gw --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+helm install apim-gw wso2/wso2am-universal-gw --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
 ```
 
 !!! important

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -139,6 +139,7 @@ Before you begin, ensure you have the following prerequisites in place:
   mysql -h <DB_HOST> -P 3306 -u sharedadmin -p -Dshared_db < './dbscripts/mysql.sql';
   mysql -h <DB_HOST> -P 3306 -u apimadmin -p -Dapim_db < './dbscripts/apimgt/mysql.sql';
   ```
+> **Note:** If you are using **MySQL 8 or later**, and encounter `ERROR 1071 (42000)` related to index key length, consider using `latin1_swedish_ci` instead of `latin1` as the database character set.
 
 ## Minimal Configuration
 


### PR DESCRIPTION
## Purpose
> Fix outdated Helm chart name in WSO2 API Manager Pattern 2 documentation and address a common MySQL error (`ERROR 1071 (42000)`) that occurs due to index key length issues when using `utf8mb4` with InnoDB in MySQL 8+.

## Goals
> - Ensure the correct Helm chart name `wso2am-universal-gw` is used so deployments do not fail.
> - Provide guidance to users on avoiding MySQL key length errors by using `latin1` character set.

## Approach
> - Updated the chart name in the deployment instructions to match the actual chart published on Artifact Hub.
> - Added a documentation note explaining the `latin1` workaround for MySQL 8+ charset compatibility issues.
> - No UI changes.

## User stories
> - As a user deploying WSO2 API Manager, I want the Helm chart instructions to work without errors.
> - As a user setting up MySQL for WSO2 API Manager, I want to avoid charset-related index errors during migration or initialization.

## Release note
> Fixed Helm chart reference for Universal Gateway and added a MySQL charset note to avoid index length errors in MySQL 8+.

## Documentation
> This PR modifies inline documentation in the Pattern 2 deployment and database setup guide.  
> Impacted file(s):  
> `docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md`

## Training
> N/A – No impact on training content

## Certification
> N/A – Does not introduce functionality or configuration changes relevant to certification

## Marketing
> N/A – This is a documentation maintenance update

## Automation tests
 - Unit tests 
   > N/A – Documentation-only change
 - Integration tests
   > N/A – Documentation-only change

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
> N/A – No sample files affected

## Related PRs
> N/A

## Migrations (if applicable)
> No migration steps required

## Test environment
> - Helm v3.13.0  
> - MySQL 9.3.0 
> - Minikube v1.33.0  

## Learning
> - Verified Helm chart availability on [Artifact Hub](https://artifacthub.io/packages/helm/wso2/wso2am-universal-gw)
> - Referenced MySQL 8+ documentation and forums for index length errors with `utf8mb4`
> - Confirmed WSO2 API Manager behavior during database setup
