### PR TITLE
[APIM Docs 4.4.0] Add warning for UserInfo endpoint correction when using well-known URL in WSO2 IS 7.x config

### DIFF
--- a/en/docs/administer/key-managers/configure-wso2is7-connector.md
+++ b/en/docs/administer/key-managers/configure-wso2is7-connector.md
@@ -95,6 +95,9 @@ Follow the steps given below to configure WSO2 IS 7.x as a Key Manager component
     !!! Note
         You can use `https://localhost:9444/oauth2/token/.well-known/openid-configuration` as the **Well-known URL**, and click on **Import** to populate most of the fields mentioned below, **Grant types**, and the **Certificates** section.
 
+        !!! warning "Important"
+            When importing configurations using the well-known URL, manually set the value of <strong>UserInfo Endpoint</strong> to <code>https://localhost:9444/scim2/Me</code>. The auto-import populates this field with <code>https://localhost:9444/oauth2/userInfo</code>.
+
     | Configuration | Value |
     | --- | --- |
     | Issuer | `https://localhost:9444/oauth2/token` |


### PR DESCRIPTION
## Purpose
> Add warning documentation for UserInfo endpoint configuration issue when using well-known URL auto-import in WSO2 IS 7.x Key Manager setup.

## Goals
> Prevent configuration errors by clearly documenting that the auto-imported UserInfo endpoint may be incorrect and needs manual verification/correction.

## Approach
> Added a warning admonition in the Key Manager Endpoints configuration section to highlight that well-known URL auto-import may set UserInfo endpoint to `/oauth2/userInfo` instead of the correct `/scim2/Me` endpoint.

## Release note
> Added documentation warning for UserInfo endpoint correction when using well-known URL in WSO2 IS 7.x Key Manager configuration.

## Documentation
> This PR directly updates the WSO2 IS 7.x Key Manager configuration documentation to improve setup accuracy.