### PR TITLE
Fix ELK resources not downloading issue

### DIFF
--- a/en/docs/monitoring/api-analytics/on-prem/elk-installation-guide.md
+++ b/en/docs/monitoring/api-analytics/on-prem/elk-installation-guide.md
@@ -301,8 +301,8 @@ Operation and API Policies of the APIs/API Products are loaded to the Analytics 
     ```
 
 5. Download the artifact file from below.<br />
-   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Artifacts v1 - [here]({{base_path}}/assets/img/analytics/cloud/old_export.ndjson)<br />
-   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Artifacts v2 - [here]({{base_path}}/assets/img/analytics/cloud/export.ndjson)
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Artifacts v1 - [here](../../../assets/img/analytics/cloud/old_export.ndjson)<br />
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Artifacts v2 - [here](../../../assets/img/analytics/cloud/export.ndjson)
 6. Navigate to **Stack Management** > **Saved Object** and click on **Import**. Add the downloaded artifact file as an import object, and import
 
 !!! info


### PR DESCRIPTION
## Purpose
This PR fixes the issue where the ELK analytics artifacts at the below location are not downloadable from within the same browser tab.

![Screenshot 2025-06-30 at 14 59 58](https://github.com/user-attachments/assets/7d398203-bda6-4fb0-9d6c-ef66635a586e)

This happens because the {{base_path}} resolves to `https://apim.docs.wso2.com/en/4.5.0` whereas we are in `https://apim.docs.wso2.com/en/latest`.

Fixed this by changing the file paths to relative.
