### PR TITLE
Fix broken Configure Alerts link in Choreo Analytics documentation

### DIFF
--- a/en/docs/api-analytics/configure-alerts.md
+++ b/en/docs/api-analytics/configure-alerts.md
@@ -15,4 +15,4 @@ Alerts are subject to a suppression policy to ensure you are not overwhelmed wit
 	- Maxium number of alerts which can be configured is 20 for each organization, env, tenant combination.
 	- Adding an email to an alert configuration is optional. The maximum number of emails per alert configuration is limited to 5.
 
-Please refer [Configure Alerts](https://wso2.com/choreo/docs/insights/configure-alerts/) for more information.
+Please refer [Configure Alerts](https://wso2.com/choreo/docs/monitoring-and-insights/alerts-overview/#configure-alert) for more information.


### PR DESCRIPTION
## Summary
- Fixed broken Configure Alerts link in Choreo Analytics documentation for version 4.0.0

## Test plan
- [x] Verified the link is now pointing to the correct location
- [x] Confirmed documentation renders properly

Related to issue #9355

🤖 Generated with [Claude Code](https://claude.ai/code)