### PR TITLE
[4.5.0] Fix broken configuration alerts link

### DIFF
--- a/en/docs/monitoring/api-analytics/choreo-analytics/configure-alerts.md
+++ b/en/docs/monitoring/api-analytics/choreo-analytics/configure-alerts.md
@@ -11,4 +11,4 @@ Alerts are subject to a suppression policy to ensure you are not overwhelmed wit
 	- Maxium number of alerts which can be configured is 20 for each organization, env, tenant combination.
 	- Adding an email to an alert configuration is optional. The maximum number of emails per alert configuration is limited to 5.
 
-Please refer [Configure Alerts](https://wso2.com/choreo/docs/insights/configure-alerts/) for more information.
+Please refer [Configure Alerts](https://wso2.com/choreo/docs/monitoring-and-insights/alerts-overview/#configure-alert) for more information.


### PR DESCRIPTION
## Summary
- Fixed broken Configure Alerts link in Choreo Analytics documentation
- Updated URL from `https://wso2.com/choreo/docs/insights/configure-alerts/` to `https://wso2.com/choreo/docs/monitoring-and-insights/alerts-overview/#configure-alert`
- This is the same fix applied to the 4.4.0 branch, now applied to 4.5.0

## Test plan
- [x] Verified the new URL is accessible and points to the correct documentation
- [x] Confirmed only the intended file is modified with a single line change

🤖 Generated with [Claude Code](https://claude.ai/code)