### PR TITLE
docs(4.1.0): fix typo (Regular Gateway) 

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -183,7 +183,7 @@ nav:
                 - Obtain User Profile Information with OpenID Connect: design/api-security/openid-connect/obtaining-user-profile-information-with-openid-connect.md
             - Open Policy Agent (OPA) Validation:
                 - Overview: design/api-security/opa-validation/overview.md
-                - Custom OPA Policy for Regualr Gateway: design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
+                - Custom OPA Policy for Regular Gateway: design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
                 - Custom OPA Policy for Choreo Connect: design/api-security/opa-validation/custom-opa-policy-for-choreo-connect.md
         - Rate Limiting:
                 - Throttling Use-Cases: design/rate-limiting/introducing-throttling-use-cases.md


### PR DESCRIPTION
Fixes misspelling **“Regualr” → “Regular”** in

* nav label (`en/mkdocs.yml`)
* page title/H1 (`custom-opa-policy-for-regular-gateway.md`)

No other changes.
