### PR TITLE
Fix broken Auth0 Key Manager link in AWS API Gateway deployment guide To fix Issue Number # 9381

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/federated-gateways/deploy-on-aws-api-gateway.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/federated-gateways/deploy-on-aws-api-gateway.md
@@ -43,7 +43,7 @@ Follow the instructions given below to configure AWS API Gateway as a Federated 
 
     `https://localhost:9443/admin`
 
-2. Register a third party KM following instructions in WSO2 documentation. In this guide we will setup Auth0 as the KM following the guide [Configure Auth0 as a Key Manager]({{basepath}}/administer/key-managers/configure-auth0-connector/).
+2. Register a third party KM following instructions in WSO2 documentation. In this guide we will setup Auth0 as the KM following the guide [Configure Auth0 as a Key Manager]({{base_path}}/administer/key-managers/configure-auth0-connector/).
 
 ## Step 4 : Create and Design API
 


### PR DESCRIPTION
  Fixes broken template variable from {{basepath}} to {{base_path}} in Step 3, sub step 2.
  This resolves the page not found error reported by users.

  Fixes issue#9381