### PR TITLE
[4.2.0] Add HSTS related doc

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -129,6 +129,9 @@ Transport Level Security</a>.</p>
 <td><p>Enabling HTTP Strict Transport Security Headers (HSTS)</p></td>
 <td><p>Be sure that HTTP Strict Transport Security (HSTS) is enabled for all the applications deployed in your server. This includes the management console, and any other web applications and/or Jaggery applications.</p>
 <p>Note that (for WSO2 products based on Carbon 4.4.11 or later versions, which implies API-M 2.1.0 and newer) HSTS is disabled for the applications with which the product is shipped by default. This is because HSTS validation can interrupt the development processes by validating signatures of self-signed certificates.</p>
+
+<p>To enable HSTS please follow the instructions <a href="{{base_path}}/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment/#enable-http-strict-transport-security-hsts-headers">Enable HTTP Strict Transport Security (HSTS) Headers</a>.</p>
+
 </tr>
 <tr class="even">
 <td><p>Preventing browser caching</p></td>
@@ -966,3 +969,37 @@ Follow the steps below to change the default credentials.
     
     - Linux/Unix : sh api-manager.sh
     - Windows : api-manager.bat
+
+### Enable HTTP Strict Transport Security (HSTS) Headers
+
+To enable HSTS for all the Tomcat deployed webapps including Management console, Publisher, Developer and Admin portals, please add the below config to the `deployment.toml` file.
+
+```
+[[tomcat.filter]]
+name = "httpHeaderSecurity"
+class = "org.apache.catalina.filters.HttpHeaderSecurityFilter"
+async_supported = true
+
+[tomcat.filter.init_params]
+hstsEnabled = true
+hstsMaxAgeSeconds = 31536000
+hstsIncludeSubDomains = true
+
+[[tomcat.filter_mapping]]
+name = "httpHeaderSecurity"
+url_pattern = "/*"
+dispatchers = "REQUEST"
+```
+
+To enable HSTS only to selected web applications, check whether the HttpHeaderSecurityFilter stored in the `<APIM_HOME>/repository/deployment/server/webapps/` directory is available in the `web.xml` file of that particular web application. If the filter is available, enable HSTS as shown below.
+
+```
+<filter>
+    <filter-name>HttpHeaderSecurityFilter</filter-name>        
+    <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+</filter>
+<filter-mapping>     
+    <filter-name>HttpHeaderSecurityFilter</filter-name>     
+    <url-pattern>*</url-pattern>
+</filter-mapping>
+```

--- a/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
+++ b/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
@@ -156,6 +156,18 @@ Add the following configuration in the `deployment.toml` file (stored in the `<A
 enable = false
 ```
 
+### Adding Response Headers to Web Applications
+
+You can add response headers to all the web applications that are deployed in the Tomcat instance via a Tomcat filter.
+
+1. Add the [response-header-filter.jar](https://github.com/Hory314/response-header-filter/releases/download/1.0.1/response-header-filter.jar) to the `<API-M_HOME>/repository/components/lib` directory (Please find the source code [here](https://github.com/Hory314/response-header-filter)).
+
+2. Change the file `<API-M_HOME>/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2` to include the following lines,
+
+```
+ResponseHeaderFilter com.sample.tomcat.filter.ResponseHeaderFilter Content-Security-Policy default-src 'self' script-src 'unsafe-inline' ResponseHeaderFilter /*
+```
+
 ## What's Next?
 
 See the [Security Guidelines for Production Deployment]({{base_path}}/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment) for the full list of security-related recommendations for WSO2 API Manager.


### PR DESCRIPTION
### Purpose
This PR adds missing content related to enabling HTTP Strict Transport Security (HSTS).

Fixes:
https://github.com/wso2/docs-apim/issues/9198
https://github.com/wso2/docs-apim/issues/9197