### PR TITLE
Fix broken hyperlink in API Manager 4.5.0 release notes pointing to an outdated (4.4.0) documentation page

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -4,7 +4,7 @@ WSO2 API Manager is a complete platform for building, integrating, and exposing 
 
 **WSO2 API Manager 4.5.0** is the latest **WSO2 API Manager release** and is the successor of **WSO2 API Manager 4.4.0**.
 
-For more information on WSO2 API Manager, see the [overview]({{base_path}}/getting-started/overview/).
+For more information on WSO2 API Manager, see the [overview](https://apim.docs.wso2.com/en/4.5.0/get-started/overview/).
 
 ## Downloads
 


### PR DESCRIPTION
## Purpose
> Fix an outdated hyperlink in the WSO2 API Manager 4.5.0 release notes that incorrectly pointed to the 4.4.0 documentation overview page.

## Goals
> Ensure users are directed to the correct version (4.5.0) of the API Manager overview documentation when reading the 4.5.0 release notes.

## Approach
> Located the incorrect Markdown link to the overview page (/en/4.4.0/overview/) and updated it to the correct version (/en/4.5.0/overview/).


## User stories
> As a user reading the API Manager 4.5.0 release documentation, I want to access the correct overview page, So that I get accurate and up-to-date information about the product.

## Release note
> Fixed outdated link to overview page in WSO2 API Manager 4.5.0 release documentation.

## Documentation
> Yes – this PR updates a Markdown file to correct the overview link.

## Training
> N/A – No impact on training materials.

## Certification
> N/A – No changes affecting certification.

## Marketing
> N/A – This is a minor documentation fix.

## Automation tests
 - Unit tests 
   > N/A – No code changes.
 - Integration tests
   > N/A – No code changes.

## Security checks
> N/A – This is a documentation-only change.

## Samples
> Orange "Overview" will be navigated to the the current overview page
<img width="1920" height="1020" alt="Screenshot 2025-07-22 151511" src="https://github.com/user-attachments/assets/71b9eff2-e910-4a84-9b02-4cfe55684e7b" />



> **Before fixing**
<img width="1920" height="1020" alt="Screenshot 2025-07-22 151338" src="https://github.com/user-attachments/assets/32172f59-ebce-4f19-ab34-9c93ce90fa8a" />



>**After fixing**
<img width="1920" height="1020" alt="Screenshot 2025-07-22 151408" src="https://github.com/user-attachments/assets/0b8201a7-c671-49dc-a9ad-5f5e7097fe4a" />

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> Reviewed the documentation site and confirmed version mismatch in the link.