### PR TITLE
Remove trailing / in the endpoint URL

### DIFF
--- a/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/message-mediation/adding-dynamic-endpoints.md
+++ b/en/docs/deploy-and-publish/deploy-on-gateway/api-gateway/message-mediation/adding-dynamic-endpoints.md
@@ -9,13 +9,13 @@ The default endpoint sends the message to the address specified in the **To** he
 !!! example
     ``` xml
     <sequence xmlns="http://ws.apache.org/ns/synapse" name="default-endpoint-seq">
-        <property name="service_ep" expression="fn:concat('http://jsonplaceholder.typicode.com/', 'posts/')"/>
+        <property name="service_ep" expression="fn:concat('http://jsonplaceholder.typicode.com/', 'posts')"/>
         <header name="To" expression="get-property('service_ep')"/>
     </sequence>
     ```
 
 In this example, you have constructed the `service_ep` property dynamically and assigned the value of this property to the **To** header. The default endpoint sends the message to the address specified in the **To** header, in this case, 
-`http://jsonplaceholder.typicode.com/posts/`. 
+`http://jsonplaceholder.typicode.com/posts`. 
 
 !!! info
     The dynamic endpoint functionality is suitable for scenarios where the application client can send an attribute in the request correlating to the intended endpoint (such as an HTTP transport header or as part of the payload), which can be used in the mediation extension.


### PR DESCRIPTION
## Purpose
We configure dynamic endpoints like shown in [this example](https://apim.docs.wso2.com/en/3.2.0/learn/api-gateway/message-mediation/adding-dynamic-endpoints/). When there's a trailing `/` in an endpoint, if we use a resource `/*` in the API, it would be resolved fine.

E.g, if we have an API with:
**Endpoint:** `http://example.com`
**Resource1:** `/*`
**Resource2:** `/test`

**Case1:** When calling **Resource1**, the resolved URL is: `http://example.com/`
**Case2:** But when calling **Resource2**, the resolved URL is: `http://example/com//test` (notice the two slashes), which results in a bad request.

Some customers have misinterpreted this example, and when performing **Case 2**, they've run into issues.


## Goals
This PR removes the trailing `/` from the Endpoint URL, mentioned in the example. So, even if someone uses `/*`, or any other `/test` resource, there won't be double `/`s in between, and won't result in bad request.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.