### PR TITLE
Remove trailing / in the endpoint URL

### DIFF
--- a/en/docs/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints.md
+++ b/en/docs/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints.md
@@ -9,13 +9,13 @@ The default endpoint sends the message to the address specified in the **To** he
 !!! example
     ``` xml
     <sequence xmlns="http://ws.apache.org/ns/synapse" name="default-endpoint-seq">
-        <property name="service_ep" expression="fn:concat('http://jsonplaceholder.typicode.com/', 'posts/')"/>
+        <property name="service_ep" expression="fn:concat('http://jsonplaceholder.typicode.com/', 'posts')"/>
         <header name="To" expression="get-property('service_ep')"/>
     </sequence>
     ```
 
 In this example, you have constructed the `service_ep` property dynamically and assigned the value of this property to the **To** header. The default endpoint sends the message to the address specified in the **To** header, in this case, 
-`http://jsonplaceholder.typicode.com/posts/`. 
+`http://jsonplaceholder.typicode.com/posts`. 
 
 !!! info
     The dynamic endpoint functionality is suitable for scenarios where the application client can send an attribute in the request correlating to the intended endpoint (such as an HTTP transport header or as part of the payload), which can be used in the mediation extension.


### PR DESCRIPTION
## Purpose
We configure dynamic endpoints like shown in [this example](https://apim.docs.wso2.com/en/3.0.0/learn/api-gateway/message-mediation/adding-dynamic-endpoints/). When there's a trailing `/` in an endpoint, if we use a resource `/*` in the API, it would be resolved fine.

E.g, if we have an API with:
**Endpoint:** `http://example.com`
**Resource1:** `/*`
**Resource2:** `/test`

**Case1:** When calling **Resource1**, the resolved URL is: `http://example.com/`
**Case2:** But when calling **Resource2**, the resolved URL is: `http://example/com//test` (notice the two slashes), which results in a bad request.

Some customers have misinterpreted this example, and when performing **Case 2**, they've run into issues.


## Goals
This PR removes the trailing `/` from the Endpoint URL, mentioned in the example. So, even if someone uses `/*`, or any other `/test` resource, there won't be double `/`s in between, and won't result in bad request.

## Related PRs
https://github.com/wso2/docs-apim/pull/9471
