### PR TITLE
Fix broken secure vault documentation link

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
@@ -20,7 +20,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation).
 
 !!! note
     


### PR DESCRIPTION
Fixed the broken link to secure vault documentation in installing-api-m-as-a-windows-service.md. The link was pointing to an incorrect path:
  /administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation

Changed to the correct path:
  /install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation

Resolves #9213

🤖 Generated with [Claude Code](https://claude.ai/code)