### PR TITLE
Fixes #9448: Redirects to Bijira documentation instead of webpage

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -300,7 +300,7 @@ template: templates/single-column.html
         "links": [
             {"name": "Deploy on VM", "url": "install-and-setup/install/installing-the-product/running-the-api-m/"},
             {"name": "Deploy on Kubernetes", "url": "install-and-setup/install/deploying-api-manager-with-kubernetes-resources/"},
-            {"name": "SaaS", "url": "https://wso2.com/bijira/"}
+            {"name": "SaaS", "url": "https://wso2.com/bijira/docs/"}
         ]
     }],
     [{


### PR DESCRIPTION
## Purpose
> "SaaS" under deployment options in index.md should redirect to Bijira documentation instead of the Bijira webpage as stated in #9448. 
## Goals
> Make "SaaS" under deployment redirect to https://wso2.com/bijira/docs/ instead of https://wso2.com/bijira/.
