### PR TITLE
[4.0.0] Add internal keystore information to encrypting passwords in config files

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
@@ -78,7 +78,7 @@ The instructions below explain how plain text passwords in configuration files c
 
     You will be prompted to enter the internal key store password for the server. 
 
-5.  When prompted, enter the primary key password, which is by default `wso2carbon` and proceed. 
+5.  When prompted, if you have not configured a separate [internal keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-internal-keystore), enter the primary key password, which is by default `wso2carbon` and proceed. 
 
      If the encryption is successful, you will see the following log.
 
@@ -127,7 +127,7 @@ Follow the instructions below to secure the endpoint's password that is given in
 
      You will be prompted to enter the internal key store password for the server. 
 
-4.  When prompted, enter the primary key password, which is by default `wso2carbon`. 
+4.  When prompted, if you have not configured a separate [internal keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-internal-keystore), enter the primary key password, which is by default `wso2carbon`. 
 
      If the encryption is successful, you will see the following log.
 
@@ -188,7 +188,7 @@ Follow the instructions below to change any password that you have already encry
 -   [Start server as a background job](#start-server-as-a-background-job)
 
 !!! Note
-    If you have secured the plain text passwords in configuration files using Secure Vault, the keystore password and private key password of the product's [primary keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager) will serve as the root passwords for Secure Vault. This is because the keystore passwords are needed to initialize the values encrypted by the **Secret Manager** in the **Secret Repository**. Therefore, the **Secret Callback 
+    If you have secured the plain text passwords in configuration files using Secure Vault, the keystore password and private key password of the product's [primary keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager) will serve as the root passwords for Secure Vault, if you have not configured a separate [internal keystore]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-internal-keystore). This is because the keystore passwords are needed to initialize the values encrypted by the **Secret Manager** in the **Secret Repository**. Therefore, the **Secret Callback 
     handler** is used to resolve these passwords. The default secret CallbackHandler provides the two options given below. For more information on secure vault concepts, see [Secure Vault concepts]({{base_path}}/administer/product-security/logins-and-passwords/carbon-secure-vault-implementation/#elements-of-the-secure-vault-implementation).
 
 


### PR DESCRIPTION
This PR adds internal keystore information to encrypting passwords in config files to avoid confusion with primary keystore information.