### PR TITLE
[4.3.0] Update Index Data Backup Instructions in Updating WSO2 API Manager Documentation

### DIFF
--- a/en/docs/administer/updating-wso2-api-manager.md
+++ b/en/docs/administer/updating-wso2-api-manager.md
@@ -16,12 +16,15 @@ You should manually merge the updated configuration files or use a tool like Pup
 For more information, see [Using WSO2 Updates 2.0](https://updates.docs.wso2.com/en/latest/updates/update-tool/)
 
 !!! warning
+
+    **Persisting Index data**
+
+    The indexing related information of WSO2 API Manager is stored in the `<API-M_HOME>/solr/data` directory. Once the data is indexed, it is stored in the index directory.
     
     !!! tip
         Before you discard the old API Manager instance,
         
-        You must take a backup of the `<API-M_HOME>/repository/data` directory and copy it to the API Manager binary pack in the `<API-M_HOME>/repository/data` directory that is updated.
-        
+        You must take a backup of the `<API-M_HOME>/solr/data` directory and copy it to the API Manager binary pack in the `<API-M_HOME>/solr/data` directory that is updated.
     
     **Persisting WSO2CarbonDB**
     


### PR DESCRIPTION
## Purpose
> Clarifies that the index data is stored in <API-M_HOME>/solr/data and updates the backup steps accordingly.