### PR TITLE
Fixing spelling: Demilitarized

### DIFF
--- a/en/.spelling
+++ b/en/.spelling
@@ -2427,7 +2427,6 @@ kmDcrUrl
 wso2.datasource
 IdPClientFactory
 IdPClient
-demiliterized
 Node1
 Multitenanted
 OpenIDConnect

--- a/en/docs/install-and-setup/setup/single-node/configuring-a-single-node.md
+++ b/en/docs/install-and-setup/setup/single-node/configuring-a-single-node.md
@@ -22,7 +22,7 @@ To create an all purpose keystore or multiple keystores for authentication and p
 
 In order to access the WSO2 API-M Portals and Gateway in both WSO2 API-M instances, you need to front the system with a load balancer. You can use any load balancer that is available to your system.
 
-Follow the steps in [Configuring the Proxy Server and the Load Balancer]({{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer) to configure the load balancer/reverse proxy which is fronting the API-M instance in the demiliterized zone (DMZ).
+Follow the steps in [Configuring the Proxy Server and the Load Balancer]({{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer) to configure the load balancer/reverse proxy which is fronting the API-M instance in the demilitarized zone (DMZ).
 
 ??? tip
     For example, if you are using the hostname `api.am.wso2.com` is used to access all portals (publisher, store, admin, and carbon) and `gw.am.wso2.com` is used to invoke APIs, the `deployment.toml` in `<API-M_HOME>/repository/conf` directory, should have the following reverse proxy configurations.

--- a/en/docs/install-and-setup/setup/single-node/configuring-an-active-active-deployment.md
+++ b/en/docs/install-and-setup/setup/single-node/configuring-an-active-active-deployment.md
@@ -27,7 +27,7 @@ In order to access the WSO2 API-M Portals and Gateway, you need to front the sys
 load balancer that is available to your system.
 
 Follow the steps in [Configuring the Proxy Server and the Load Balancer]({{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer) to configure the load balancer/reverse proxy which is fronting the API-M nodes
-in the demiliterized zone (DMZ).
+in the demilitarized zone (DMZ).
 
 ??? tip
     For example, if you are using the hostname `api.am.wso2.com` is used to access all portals (publisher, store, admin, and carbon) and `gw.am.wso2.com` is used to invoke APIs, the `deployment.toml` in `<API-M_HOME>/repository/conf` directory of both


### PR DESCRIPTION
Was demiliterized, should be demilitarized (roots de-, military,-ize,-ed), from english military and latin militaris (relating to war or armies)

