### PR TITLE
Update index.md to redirect to the Bijira documentation instead of the webpage

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -300,7 +300,7 @@ template: templates/single-column.html
         "links": [
             {"name": "Deploy on VM", "url": "install-and-setup/install/installing-the-product/running-the-api-m/"},
             {"name": "Deploy on Kubernetes", "url": "install-and-setup/install/deploying-api-manager-with-kubernetes-resources/"},
-            {"name": "SaaS", "url": "https://wso2.com/bijira/"}
+            {"name": "SaaS", "url": "https://wso2.com/bijira/docs/"}
         ]
     }],
     [{


### PR DESCRIPTION
## Purpose
> "SaaS" under deployment options in index.md should redirect to Bijira documentation instead of the Bijira webpage.

## Goals
> Make "SaaS" under deployment redirect to https://wso2.com/bijira/docs/ instead of https://wso2.com/bijira/ in the 4.5.0 documentation.
