### PR TITLE
Remove unapplicable doc content

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-roles.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-roles.md
@@ -40,17 +40,6 @@ Follow the instructions below to create the `creator`, `publisher`, and `subscri
 !!! info
      For more information on **role mapping** or **scope mapping**, see [Adding role permissions]({{base_path}}/administer/product-administration/managing-users-and-roles/managing-permissions/#adding-role-based-permissions)
 
-!!! info "Application Roles"
-    When a user creates an application and generates application keys, a role is created automatically in the following format.
-
-    ``` java
-    "Application/<username>_<applicationUUID>_PRODUCTION"
-    ```
-
-    This is a special case of the `internal` role that is created for a particular service provider application. Only users who are assigned the application role permission can manage the corresponding service provider application.
-
-    These roles do not have any permissions assigned to it, but it is used to manage the visibility of the corresponding service provider that is created in the format of `'<username>_<applicationUUID>_PRODUCTION'` within the Key Manager. The created service provider is only visible to users with the latter mentioned role that has been generated automatically. Only if a user with admin privileges assigns the latter mentioned role to a user, will that user be able to view the details of the service provider that is created per application.
-
 !!! warning
     As a limitation, when you delete a user and create another with the same username, applications of the previous user will be visible on the Developer Portal applications listing page.
     However the new user will not be able to access the details of the application as the service provider is already deleted.


### PR DESCRIPTION
### Purpose
This PR removes a note on creating application role automatically when a new application is created which is incorrect for this version of APIM.