### PR TITLE
[v4.5.0] Fix issue #9578: Correct broken anchor links from #Artifact to #artifact in governance concepts

### DIFF
--- a/en/docs/governance/governance-concept.md
+++ b/en/docs/governance/governance-concept.md
@@ -7,7 +7,7 @@ The governance capabilities in WSO2 API Manager builds upon the following core c
 Entity that is subject to governance enforcement. In the context of API governance, the governance artifact is an API.
 
 ## Ruleset
-A ruleset is a **collection of rules** that define governance policies to be enforced on [governance artifacts](#Artifact). 
+A ruleset is a **collection of rules** that define governance policies to be enforced on [governance artifacts](#artifact). 
 
 In the context of API governance, these rules cover various aspects of API management, including security, compliance, performance, and operational guidelines. Rulesets can be defined at the organization level and later applied through policies to ensure governance enforcement.
 
@@ -27,7 +27,7 @@ Rules within a ruleset can have different **severity levels**, such as:
 
 ## Policy
 
-A policy is a **collection of rulesets** that can be enforced on [governance artifacts](#Artifact) to ensure governance compliance.
+A policy is a **collection of rulesets** that can be enforced on [governance artifacts](#artifact) to ensure governance compliance.
 
 In the context of API governance, policies can be created at the organization level and applied to APIs to enforce governance requirements. They also provide the capability to apply different governance rulesets to different groups of APIs based on organizational needs.
 
@@ -59,7 +59,7 @@ Policies can be configured to take specific actions based on the severity of rul
 
 ## Label  
 
-A **label** is a tag that can be attached to a specific [governance artifact](#Artifact) to categorize them based on specific criteria. 
+A **label** is a tag that can be attached to a specific [governance artifact](#artifact) to categorize them based on specific criteria. 
 
 In the context of API governance, labels help group APIs according to their type, purpose, or any other classification relevant to the organization.  
 


### PR DESCRIPTION
Fixes issue #9578

**Problem**: In the Governance Concepts documentation, hyperlinks for governance artifact used incorrect casing (#Artifact) that did not redirect correctly to the actual heading (#artifact).

**Solution**: Fixed all three occurrences of broken anchor links by changing #Artifact to #artifact to match the actual heading case.

**Files Changed**:
- en/docs/governance/governance-concept.md (lines 10, 30, 62)

**Testing**: Verified using mkdocs serve that the documentation builds correctly with the fixes.

Fixes https://github.com/wso2/docs-apim/issues/9578