### PR TITLE
Fix Note section expandability in distributed deployment guide for APIM 4.5.0

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed indentation for Note admonition in Step 4 of distributed deployment setup guide
- The Note section in SSL certificates step is now properly expandable in MkDocs Material theme

## Changes Made
- Added proper 4-space indentation to Note content in `deploying-wso2-api-m-in-a-simple-scalable-setup.md`
- This ensures the Note admonition renders correctly as an expandable section

## Test Plan
- [x] Verified documentation builds successfully with `mkdocs build`
- [x] Confirmed Note admonition syntax matches other properly working Note sections in the same file
- [x] Tested that the fix resolves the expandability issue reported in the original issue

## Files Changed
- `en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md`

🤖 Generated with [Claude Code](https://claude.ai/code)