### PR TITLE
Fix broken secure vault documentation link in Windows service installation guide

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
@@ -20,7 +20,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation).
 
 !!! note
     


### PR DESCRIPTION
## Summary
Fixed broken secure vault documentation link in the Windows service installation guide.

The link was pointing to:
`/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation`

Changed to the correct path:
`/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation`

Fix issue: https://github.com/wso2/docs-apim/issues/9213
## Test plan
- [x] Verified the target file exists at the correct path in master branch
- [x] Confirmed the link fix resolves the broken link issue

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>