### PR TITLE
docs(apim): fix pip command consistency and license grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ As an open source project, WSO2 API-M welcomes contributions from the community.
 
 1. Accept the Contributor License Agreement (CLA)
 
-    You need to Accept the Contributor License Agreement (CLA) when prompted by a GitHub email notification after sending your first Pull Request (PR). Subsequent PRs will not require CLA acceptance.
+   You need to Accept the Contributor License Agreement (CLA) when prompted by a GitHub email notification after sending your first Pull Request (PR). Subsequent PRs will not require CLA acceptance.
 
-    If the CLA gets changed for some (unlikely) reason, you will be presented with the new CLA text after sending your first PR after the change.
+   If the CLA gets changed for some (unlikely) reason, you will be presented with the new CLA text after sending your first PR after the change.
 
 2. Fork this repository, make your changes, and send in a pull request (PR). Make sure you are contributing to the correct branch (for example, if your change is relevant to WSO2 API-M 4.4.0 documentation, you should commit your changes to the 4.4.0 branch).
 
 3. Send multiple pull requests to all the relevant branches.
 
-    If your change is relevant to the latest API-M release, please send your change to the respective latest API-M release branch and the master branch, which is the upcoming API-M release documentation branch, as well.
+   If your change is relevant to the latest API-M release, please send your change to the respective latest API-M release branch and the master branch, which is the upcoming API-M release documentation branch, as well.
 
-    For example, if the latest API-M release is 4.4.0, and if your change is relevant to API-M 4.4.0, 4.3.0, and 4.2.0, send PRs to the 4.4.0, 4.3.0, 4.2.0, and the master branches.
+   For example, if the latest API-M release is 4.4.0, and if your change is relevant to API-M 4.4.0, 4.3.0, and 4.2.0, send PRs to the 4.4.0, 4.3.0, 4.2.0, and the master branches.
 
 Check the issue tracker for open issues that interest you. We look forward to receiving your contributions.
 
@@ -31,6 +31,7 @@ Check the issue tracker for open issues that interest you. We look forward to re
 ### Step 1 - Install Python
 
 #### MacOS
+
 If you are using MacOS, you probably already have a version of Python installed on your machine. You can verify this by running the following command.
 
 ```shell
@@ -47,14 +48,14 @@ Once you are done, you will have two versions of Python on your machine; a versi
 Python 3 is pre-installed in these versions, which you can verify with `python3 -V`. Use `sudo apt install -y python3-pip` to install `pip` and verify with `pip3 -V`.
 
 ### Step 2 - Install Pip
->
+
 > **INFO**
 >
 > If pip is not already installed on your machine, download `get-pip.py` to install pip for the first time. Then run the following command to install it:
-> ```shell
-> $ python get-pip.py
-> ```
 >
+> ```shell
+> $ python3 get-pip.py
+> ```
 
 Pip is most likely installed by default. However, you may need to upgrade pip to the latest version:
 
@@ -69,70 +70,72 @@ Follow the steps below to clone the API-M documentation GitHub repository and to
 1. Fork the GitHub repository: `https://github.com/wso2/docs-apim.git`
 2. Navigate to the place where you want to clone the repo.
 
-    Git clone the forked repository.
+   Git clone the forked repository.
 
-    ```shell
-    $ git clone https://github.com/[git-username]/docs-apim.git
-    ```
+   ```shell
+   $ git clone https://github.com/[git-username]/docs-apim.git
+   ```
 
 3. Navigate to the folder containing the repo that you cloned in step 3.2 on a terminal window.
 
-    For example:
+   For example:
 
-    ```shell
-    $ cd docs-apim/<Language-folder>/
-    ```
+   ```shell
+   $ cd docs-apim/<Language-folder>/
+   ```
 
-    ```shell
-    $ cd docs-apim/en/
-    ```
+   ```shell
+   $ cd docs-apim/en/
+   ```
 
 4. Install the required pip packages.
 
-    This will install MkDocs and the required theme, extensions, and plugins.
+   This will install MkDocs and the required theme, extensions, and plugins.
 
-    - If you are using Python2, use the following command:
+   - If you are using Python2, use the following command:
 
-      ```shell
-      $ pip install -r requirements.txt
-      ```
+     ```shell
+     $ pip install -r requirements.txt
+     ```
 
-    - If you are using Python3, use the following command:
+   - If you are using Python3, use the following command:
 
-      ```shell
-      $ pip3 install -r requirements.txt
-      ```
+     ```shell
+     $ pip3 install -r requirements.txt
+     ```
 
 ### Step 4 - Run MkDocs
+
 1. Run the following command to start the server and view the site on your local server.
 
-    ```shell
-    $ python3 -m mkdocs serve
-    ```
+   ```shell
+   $ python3 -m mkdocs serve
+   ```
 
-    > **NOTE:**
-    >
-    > If you are making changes and want to see them on the fly, run the following command to start the server and view the site on your local server.
-    > 1. Navigate to the `mkdocs.yml` file.
-    > 2. Change the following configuration to `false` as shown below. 
-    >     ```
-    >     #Breaks build if there's a warning
-    >     strict: false
-    >     ```
-    > 3. Run the following command to start the server and to make the server load only the changed items and display the changes faster. 
-    >
-    >    `python3 -m mkdocs serve --dirtyreload`
-  
+   > **NOTE:**
+   >
+   > If you are making changes and want to see them on the fly, run the following command to start the server and view the site on your local server.
+   >
+   > 1. Navigate to the `mkdocs.yml` file.
+   > 2. Change the following configuration to `false` as shown below.
+   >    ```
+   >    #Breaks build if there's a warning
+   >    strict: false
+   >    ```
+   > 3. Run the following command to start the server and to make the server load only the changed items and display the changes faster.
+   >
+   >    `python3 -m mkdocs serve --dirtyreload`
+
 2. Open the following URL on a new browser window to view the API-M documentation site locally.
 
-    [http://localhost:8000/getting-started/overview/](http://localhost:8000/getting-started/overview/)
+   [http://localhost:8000/getting-started/overview/](http://localhost:8000/getting-started/overview/)
 
 > **NOTE:**
 >
 > If you were running the `mkdocs serve --dirtyreload` command to run the MkDocs server, make sure to change the configuration in the `mkdocs.yml` file as follows before sending a pull request.
 >
-> `strict: true` 
+> `strict: true`
 
 ## License
 
-Licenses this source under the Apache License, Version 2.0 ([LICENSE](LICENSE)), You may not use this file except in compliance with the License.
+This source is licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE)), You may not use this file except in compliance with the License.


### PR DESCRIPTION
- Changed "$ python get-pip.py" → "$ python3 get-pip.py" for consistency with Python 3 instructions.
- Fixed grammar in License section ("Licenses this source..." → "This source is licensed...").
