### PR TITLE
docs: update Ubuntu compatibility for version 4.2.0 (Resolves #9640)

### DIFF
--- a/en/docs/install-and-setup/setup/reference/product-compatibility.md
+++ b/en/docs/install-and-setup/setup/reference/product-compatibility.md
@@ -13,7 +13,7 @@ As WSO2 API Manager is a Java application, you can generally run it on most oper
 |**Operating System**|**Versions**  |
 |--------------------|--------------|
 |Windows             | 2016         |
-|Ubuntu              | 18.04, 20.04, 22.04 |
+|Ubuntu              | 22.04 |
 |Red Hat Enterprise Linux   | 7.0, 8.7, 9.3   |
 |CentOS              | 7.4, 7.5     |
 |Rockyise Linux   | 9.3   |


### PR DESCRIPTION
## Purpose
> Update the product compatibilty documentation to remove references to unsupported Ubuntu versions (18.04, 20.04) and ensure only Ubuntu 22.04 is listed.

Resolves #9640 

## Goals
> Align installation documentation with Ubuntu's official release lifecycle.
Ensure that users follow up-to-date guidance when installing WSO2 API Manager 4.2.0.

## Approach
> Edited the product compatibility page for version 4.2.0:

'en/docs/install-and-setup/setup/reference/product-compatibility.md'

> Removed Ubuntu 18.04 and 20.04 from the compatibility matrix.
Verified Ubuntu 22.04 as the installed version.

## User stories
> As a user installing/using API Manager 4.2.0, I want documentation that lists only supported OS versions, so I don't waste time with outdated releases.

## Release note
> Updated the product compatibility documentation for WSO2 API Manager 4.2.0 to reflect supported Ubuntu version (22.04 only).

## Documentation
> This PR updates the 4.2.0 compatibility page:

https://apim.docs.wso2.com/en/4.2.0/install-and-setup/setup/reference/product-compatibility/

## Training
> N/A - no training content affected.

## Certification
> N/A - no certification impact.

## Marketing
> N/A - no marketing content affected.

## Automation tests
 - Unit tests 
   > N/A (documentation-only change)
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> PR #9663 raised for same change in version 3.2.0
PR #9664 raised for same change in version 4.0.0
PR #9665 raised for same change in version 4.1.0
A separate PR will be raised for version 4.3.0 to fully resolve #9640 

## Migrations
> N/A

## Test environment
> Documentation-only change - no runtime environment required
 
## Learning
> Referenced Ubuntu EOL documentation:
https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare
https://ubuntu.com/blog/ubuntu-18-04-eol-for-devices