### PR TITLE
Fix: Swap HTTP Verb and URL Pattern values in API Policies documentation [4.2.0]

### DIFF
--- a/en/docs/design/api-policies/regular-gateway-policies/mapping-the-parameters-of-your-backend-urls-with-the-api-publisher-urls.md
+++ b/en/docs/design/api-policies/regular-gateway-policies/mapping-the-parameters-of-your-backend-urls-with-the-api-publisher-urls.md
@@ -32,8 +32,8 @@ Let's do the following API resource to backend mapping in this tutorial as an ex
 
     | Field         |   Value                                                  |
     |---------------|----------------------------------------------------------|
-    | HTTP Verb     |   `/business/{id}/details`                      |
-    | URL pattern   |   GET                                                    |
+    | HTTP Verb     |    GET                                                   |
+    | URL pattern   |   `/business/{id}/details`                               |
 
 3. Delete the auto generated wildcard `/*` resources. Otherwise all the requests will go to them.
 


### PR DESCRIPTION
- Issue: https://github.com/wso2/docs-apim/issues/9099
- Type: Documentation
- Summary: Fixed swapped HTTP Verb and URL Pattern values in the API Policies documentation table
- Verification: mkdocs build passed

**Changes:**
- Corrected HTTP Verb from `/business/{id}/details` to `GET`
- Corrected URL Pattern from `GET` to `/business/{id}/details`