### PR TITLE
Fix: Remove extra period in remote_tracer.port configuration for Zipkin [4.4.0]

### DIFF
--- a/en/docs/observe/api-manager/traces/monitoring-with-opentelemetry.md
+++ b/en/docs/observe/api-manager/traces/monitoring-with-opentelemetry.md
@@ -76,7 +76,7 @@ For more information, see [OpenTelemetry Configurations]({{base_path}}/reference
 		remote_tracer.enable = true
 		remote_tracer.name = "zipkin"
 		remote_tracer.hostname = "<hostname-of-zikin-endpoint>"
-		remote_tracer..port = "<port-of-zipkin-endpoint>"
+		remote_tracer.port = "<port-of-zipkin-endpoint>"
 		```
 
 	=== "Example"


### PR DESCRIPTION
- Issue: https://github.com/wso2/docs-apim/issues/9174
- Type: Documentation  
- Summary: Fixed typo in OpenTelemetry Zipkin configuration where `remote_tracer..port` had an extra period and should be `remote_tracer.port`
- Verification: mkdocs build passed