### PR TITLE
Update documentation for failover fix in load-balanced endpoints

### DIFF
--- a/en/docs/design/endpoints/endpoint-types.md
+++ b/en/docs/design/endpoints/endpoint-types.md
@@ -21,8 +21,8 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints that the service tries to connect to in case of a failure. Selecting the endpoint when the primary endpoint fails, happens in a round-robin manner. Failover Group is a group of leaf endpoints (i.e., address endpoint, HTTP endpoint, and WSDL endpoint). When a failure occurs in the current endpoint (while sending a message), the failover group endpoint will try to send the message to another endpoint. The failover group ensures that the message is delivered as long as there is at least one active endpoint among the listed endpoints.</td>
 </tr>
 <tr>
-<td>Load Balance Endpoint</td>
-<td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
+  <td>Load Balance Endpoint</td>
+  <td>The endpoints distribute incoming requests in a round-robin manner. When session management is set to Transport, SOAP or Client Id (session-affinity based types), failover is handled automatically. When session management is set to None, failover can be explicitly enabled or disabled as required.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
 <td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>

--- a/en/docs/design/endpoints/high-availability-for-endpoints.md
+++ b/en/docs/design/endpoints/high-availability-for-endpoints.md
@@ -19,50 +19,78 @@ When using WSO2 API Manager, you can configure load balancing endpoints via the 
     ![load-balanced]({{base_path}}/assets/img/learn/load-balanced-configured.png)
     
     The following are the other configurations that you need to define in order to specify a load balancing endpoint.
-    <table>
-    <colgroup>
-    <col width="30%" />
-    <col width="70%" />
-    </colgroup>
-    <tbody>
-    <tr class="odd">
-    <td>Production Endpoints</td>
-    <td><div class="content-wrapper">
-    <p>Specify the set of production endpoints here where the requests need to be load balanced. If required, you can specify more than one endpoint by clicking <strong>+</strong>, and can delete the endpoints by clicking on the <strong>bin</strong> icon.</p>
-    </div></td>
-    </tr>
-    <tr class="even">
-    <td>Sandbox endpoints</td>
-    <td><p>The set of sandbox endpoints can be specified here where the requests need to be load balanced. If required, you can specify more than one endpoint by clicking <strong>+</strong>, and can delete the endpoints by clicking on the <strong>bin</strong> icon.</p></td>
-    </tr>
-    <tr class="odd">
-    <td>Algorithm</td>
-    <td><div class="content-wrapper">
-    <p>The load balancing algorithm is specified here.</p>
-    <p>Click on the cogwheel icon to define the algorithm.</p>
-    <p>The default value is the <strong>Round-Robin</strong> Algorithm, which has the <a href="https://synapse.apache.org/apidocs/org/apache/synapse/endpoints/algorithms/RoundRobin.html">org.apache.synapse.endpoints.algorithms.RoundRobin</a> className. If you select another algorithm, you need to specify the class name of the algorithm. Class names of other algorithms can be found <a href="https://synapse.apache.org/apidocs/org/apache/synapse/endpoints/algorithms/package-summary.html">here</a>.</p>
-    <p></p>
-    </div></td>
-    </tr>
-    <tr class="even">
-    <td>Session Management</td>
-    <td>
-    <p>Click on the cogwheel icon to configure session management.</p>
-    <p>This refers to a session management method from the load balancing group. The possible values are as follows:</p>
-    <ul><li><p><strong>None</strong> - If this is selected, session management is not used.</p></li>
-    <li><p><strong>Transport</strong> - If this is selected, session management is done on the transport level using HTTP cookies.</p></li>
-    <li><p><strong>SOAP</strong> - If this is selected, session management is done using SOAP sessions.</p></li>
-    <li>
-    <p><strong>Client ID</strong> - If this is selected, session management is done using an ID sent by the client.</p></li>
-    </td>
-    </tr>
-    <tr class="odd">
-    <td>Session Timeout</td>
-    <td>The number of milliseconds after which the session would time out.
-    <p>Click on the cogwheel icon to set up session timeout</p></td>
-    </tr>
-    </tbody>
-    </table>
+<table>
+     <thead>
+     <tr>
+     <th width="20%"><b>Configuration</b></th>
+     <th width="80%"><b>Description</b></th>
+     </tr>
+     </thead>
+     <tbody>
+     <tr>
+     <td><b>Production Endpoints</b></td>
+     <td>
+     Specify the set of production endpoints here where the requests need to be load balanced.<br/>
+     If required, you can specify more than one endpoint by clicking <strong>+</strong>, and can delete the endpoints by clicking on the <strong>bin</strong> icon.
+     </td>
+     </tr>
+     <tr>
+     <td><b>Sandbox Endpoints</b></td>
+     <td>
+     The set of sandbox endpoints can be specified here where the requests need to be load balanced.<br/>
+     If required, you can specify more than one endpoint by clicking <strong>+</strong>, and can delete the endpoints by clicking on the <strong>bin</strong> icon.
+     </td>
+     </tr>
+     <tr>
+     <td><b>Algorithm</b></td>
+     <td>
+     The load balancing algorithm is specified here.<br/>
+     Click on the cogwheel icon to define the algorithm.<br/>
+     The default value is the <strong>Round-Robin</strong> Algorithm, which has the <a href="https://synapse.apache.org/apidocs/org/apache/synapse/endpoints/algorithms/RoundRobin.html">org.apache.synapse.endpoints.algorithms.RoundRobin</a> className.<br/>
+     If you select another algorithm, you need to specify the class name of the algorithm. Class names of other algorithms can be found <a href="https://synapse.apache.org/apidocs/org/apache/synapse/endpoints/algorithms/package-summary.html">here</a>.
+     </td>
+     </tr>
+     <tr>
+     <td><b>Session Management</b></td>
+     <td>
+     Click on the cogwheel icon to configure session management.<br/>
+     This refers to a session management method from the load balancing group. The possible values are:
+     <ul>
+     <li><strong>None</strong> - Session management is not used.</li>
+     <li><strong>Transport</strong> - Session management is done on the transport level using HTTP cookies.</li>
+     <li><strong>SOAP</strong> - Session management is done using SOAP sessions.</li>
+     <li><strong>Client ID</strong> - Session management is done using an ID sent by the client.</li>
+     </ul>
+     </td>
+     </tr>
+     <tr>
+     <td><b>Session Timeout</b></td>
+     <td>
+     The number of milliseconds after which the session would time out.<br/>
+     Click on the cogwheel icon to set up session timeout.
+     </td>
+     </tr>
+     <tr>
+     <td><b>Enable Failover</b></td>
+     <td>
+     When session management is set to <strong>None</strong>, failover can be explicitly enabled or disabled as required.<br/>
+     The <strong>Enable Failover</strong> button is available for all session management types; however, it only functions when session management is set to <strong>None</strong>.
+
+     <div class="admonition note">
+     <p class="admonition-title">Note</p>
+     <p>The <strong>Enable Failover</strong> button has been available since the GA release but was not functional until update level <em>41</em>.<br/>
+     To enable or disable failover when session management is set to <strong>None</strong>, update your pack to the specified update level and add the following configuration to the <code>deployment.toml</code> file:</p>
+
+     <pre><code>[apim.endpoint_config.loadbalanced]
+     enable_failover = true
+     </code></pre>
+     </div>
+
+     Select the <strong>Enable Failover</strong> checkbox to turn failover on or off.
+     </td>
+     </tr>
+     </tbody>
+</table>
     
 5. Click **SAVE**.
 


### PR DESCRIPTION
## Purpose

- Adds documentation for the updated behavior of failover in load-balanced endpoints, including instructions to enable the fix via `deployment.toml`, while preserving backward compatibility.
- Related to: https://github.com/wso2-enterprise/wso2-apim-internal/issues/10655
