### PR TITLE
Fix: spelling mistakes [4.6.0]

### DIFF
--- a/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
+++ b/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
@@ -55,7 +55,7 @@ First, enable the application registration workflow.
 
      It shows the application access token, consumer key and consumer secret.
     
-    ![Key generation successfull]({{base_path}}/assets/img/learn/application-key-generated.png)
+    ![Key generation successful]({{base_path}}/assets/img/learn/application-key-generated.png)
 
     If the workflow request is rejected  it will show a message.
 

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -193,7 +193,7 @@ apiIdentifier:
         </tr>
         <tr class="odd">
             <td>Docs</td>
-            <td> This folder will contain documentation attached to a particular API Product. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <td> This folder will contain documentation attached to a particular API Product. Each document will have a separate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
             <pre><code>
 type: document
 version: v4.4.0

--- a/en/docs/install-and-setup/setup/api-controller/managing-mcp-servers/migrating-mcp-servers-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-mcp-servers/migrating-mcp-servers-to-different-environments.md
@@ -180,7 +180,7 @@ mcpServerIdentifier:
         </tr>
         <tr class="even">
             <td>Docs</td>
-            <td> This folder will contain documentation attached to a particular MCP Server. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <td> This folder will contain documentation attached to a particular MCP Server. Each document will have a separate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
             <pre><code>
 type: document
 version: v4.4.0

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -17,8 +17,8 @@ Following diagram depicts the architecture of how the WSO2 API Control Plane con
 
 The APIM APK Agent is a component that connects the WSO2 API Control Plane with the WSO2 Kubernetes Gateway. The APIM APK Agent is responsible for the following tasks:
 
-- Recieve JMS Events which relates to API,Application,Subscription management from the APIM Control Plane.
-- Convert the data which is recieved from the APIM Control Plane to the Kubernetes Gateway understandable format which are K8s Custom Resources.
+- Receive JMS Events which relates to API,Application,Subscription management from the APIM Control Plane.
+- Convert the data which is received from the APIM Control Plane to the Kubernetes Gateway understandable format which are K8s Custom Resources.
 - Apply the generated Custom Resources to the K8s cluster to deploy API to Kubernetes Gateway.
 
 ## Supported Features

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
@@ -52,7 +52,7 @@ The official WSO2 Docker images run as a non-root user with a fixed UID. While t
 Also 
 
 1. Starting from v4.5.0, each component has a separate Docker image (All-in-one, Control-plane, Gateway, Traffic-manager).
-2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a seperate DB.
+2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a separate DB.
 3. Download a connector which is compatible with the DB version and copy the connector while building the image
 
 !!! example "Sample Dockerfile for All-in-One Image"

--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -4879,7 +4879,7 @@ components:
         status:
           type: string
           description: Status of the usage publish request
-          example: successfull
+          example: successful
         message:
           type: string
           description: detailed message of the status
@@ -4895,7 +4895,7 @@ components:
         status:
           type: string
           description: Status of usage publish job
-          example: SUCCESSFULL
+          example: SUCCESSFUL
         startedTime:
           type: string
           description: Timestamp of the started time of the Job

--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -785,7 +785,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
 
         `X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
 

--- a/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
+++ b/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
@@ -591,7 +591,7 @@ definitions:
     properties:
       deployStatus:
         description: |
-          This attribute declares whether deployment task is successfull or failed.
+          This attribute declares whether deployment task is successful or failed.
         type: string
         enum:
           - DEPLOYED

--- a/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
@@ -3487,7 +3487,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/documentId'
@@ -6665,7 +6665,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiProductId'
         - $ref: '#/components/parameters/documentId'
@@ -13316,7 +13316,7 @@ components:
         delimiter:
           type: string
           description: |
-            delimiter to seperate the email address
+            delimiter to separate the email address
     MonetizationAttribute:
       title: Monetization attribute object
       type: object


### PR DESCRIPTION
Fixed the following spelling mistakes in version 4.6.0:
- "recieve" → "receive" (4 instances across 3 files)
- "seperate" → "separate" (4 instances across 4 files)
- "successfull" → "successful" (4 instances across 3 files)

Files modified:
- en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
- en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
- en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
- en/docs/install-and-setup/setup/api-controller/managing-mcp-servers/migrating-mcp-servers-to-different-environments.md
- en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
- en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
- en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
- en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
- en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml

🤖 Generated with [Claude Code](https://claude.ai/code)

