### PR TITLE
Fix: Spelling mistakes master

### DIFF
--- a/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
+++ b/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
@@ -55,7 +55,7 @@ First, enable the application registration workflow.
 
      It shows the application access token, consumer key and consumer secret.
     
-    ![Key generation successfull]({{base_path}}/assets/img/learn/application-key-generated.png)
+    ![Key generation successful]({{base_path}}/assets/img/learn/application-key-generated.png)
 
     If the workflow request is rejected  it will show a message.
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
@@ -52,7 +52,7 @@ The official WSO2 Docker images run as a non-root user with a fixed UID. While t
 Also 
 
 1. Starting from v4.5.0, each component has a separate Docker image (All-in-one, Control-plane, Gateway, Traffic-manager).
-2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a seperate DB.
+2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a separate DB.
 3. Download a connector which is compatible with the DB version and copy the connector while building the image
 
 !!! example "Sample Dockerfile for All-in-One Image"

--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -69,8 +69,8 @@ info:
     of this document and scope for each resource is given in **authorizations** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd>&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<server_port>/oauth2/token
     ```
     **Sample request**
@@ -527,7 +527,7 @@ paths:
         - Subscription Policy (Individual)
       summary: Get a Subscription Policy
       description: |
-        This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path paramter
+        This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path parameter
       parameters:
         - $ref: '#/components/parameters/policyId'
       responses:
@@ -651,7 +651,7 @@ paths:
         - Subscription Policy (Individual)
       summary: Delete a Subscription Policy
       description: |
-        This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path paramter.
+        This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path parameter.
       parameters:
         - $ref: '#/components/parameters/policyId'
       responses:
@@ -2911,7 +2911,7 @@ paths:
         - System Scopes
       summary: Retrieve Role Alias Mappings
       description: |
-        This operation can be used to retreive role alias mapping
+        This operation can be used to retrieve role alias mapping
       responses:
         200:
           description: |
@@ -4378,12 +4378,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:
@@ -4879,7 +4879,7 @@ components:
         status:
           type: string
           description: Status of the usage publish request
-          example: successfull
+          example: successful
         message:
           type: string
           description: detailed message of the status
@@ -4895,7 +4895,7 @@ components:
         status:
           type: string
           description: Status of usage publish job
-          example: SUCCESSFULL
+          example: SUCCESSFUL
         startedTime:
           type: string
           description: Timestamp of the started time of the Job

--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -785,9 +785,9 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
 
-        `X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
+        `X-WSO2-Tenant` header can be used to retrieve the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
 
         **NOTE:**
         * This operation does not require an Authorization header by default. But in order to see a restricted API's document content, you need to provide Authorization header.
@@ -4561,7 +4561,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         unitTime:
@@ -4929,7 +4929,7 @@ components:
           example: 1.2345678901234568E30
         tokenScopes:
           type: array
-          description: Valid comma seperated scopes for the access token
+          description: Valid comma separated scopes for the access token
           example:
             - default
             - read_api
@@ -5137,7 +5137,7 @@ components:
           example: 3600
         scopes:
           type: array
-          description: Allowed scopes (space seperated) for the access token
+          description: Allowed scopes (space separated) for the access token
           example:
             - apim:subscribe
           items:
@@ -5969,7 +5969,7 @@ components:
           items:
             type: string
     CurrentAndNewPasswords:
-      title: Current and new passowrd of the user
+      title: Current and new password of the user
       type: object
       properties:
         currentPassword:

--- a/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
+++ b/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
@@ -591,7 +591,7 @@ definitions:
     properties:
       deployStatus:
         description: |
-          This attribute declares whether deployment task is successfull or failed.
+          This attribute declares whether deployment task is successful or failed.
         type: string
         enum:
           - DEPLOYED

--- a/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
@@ -68,8 +68,8 @@ info:
     of this document and scope for each resource is given in **authorization** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes seperated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<servlet_port>/oauth2/token
     ```
     **Sample request**
@@ -3487,7 +3487,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/documentId'
@@ -3640,7 +3640,7 @@ paths:
         - name: name
           in: query
           description: |
-            The name of the document which needs to be checked for the existance.
+            The name of the document which needs to be checked for the existence.
           required: true
           schema:
             type: string
@@ -6665,7 +6665,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiProductId'
         - $ref: '#/components/parameters/documentId'
@@ -11366,7 +11366,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         totalTokenCount:
@@ -11608,12 +11608,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:
@@ -13316,7 +13316,7 @@ components:
         delimiter:
           type: string
           description: |
-            delimiter to seperate the email address
+            delimiter to separate the email address
     MonetizationAttribute:
       title: Monetization attribute object
       type: object

--- a/en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml
+++ b/en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml
@@ -66,8 +66,8 @@ info:
     of this document and scope for each resource is given in **authorization** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd>&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<servlet_port>/oauth2/token
     ```
     **Sample request**


### PR DESCRIPTION
Applied all spelling fixes from 4.6.0 plus additional fixes unique to master:

From 4.6.0:
- "recieve" → "receive" (4 instances)
- "seperate" → "separate" (4 instances)
- "successfull" → "successful" (4 instances)

Additional fixes unique to master:
- "seperated" → "separated" (6 instances)
- "retrive" → "retrieve" (1 instance)
- "passowrd" → "password" (5 instances)
- "cliet_id" → "client_id" (5 instances)
- "transfered" → "transferred" (5 instances)
- "existance" → "existence" (1 instance)
- "paramter" → "parameter" (2 instances)
- "retreive" → "retrieve" (1 instance)


modified:   en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
        modified:   en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
        modified:   en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
        modified:   en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
        modified:   en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
        modified:   en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
        modified:   en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml