### PR TITLE
docs: update macOS setting JAVA_HOME

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -13,14 +13,14 @@ Java Development Kit (JDK) is essential to run the product.
 2.  Extract the archive file to a dedicated directory for the API Manager, which will hereafter be referred to as `<API-M_HOME>`.
 
 !!! note
-If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
+    If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
 
 ## Setting up JAVA_HOME
 
 You must set your `JAVA_HOME` environment variable to point to the directory where the Java Development Kit (JDK) is installed on the computer.
 
 !!! info
-Environment variables are global system variables accessible by all the processes running under the operating system.
+    Environment variables are global system variables accessible by all the processes running under the operating system.
 
 ??? note "On Linux/OS X"
 
@@ -31,7 +31,7 @@ Environment variables are global system variables accessible by all the processe
         On Linux:
         export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
-
+             
         On OS X:
         export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
@@ -39,7 +39,7 @@ Environment variables are global system variables accessible by all the processe
     3.  Save the file.
 
         !!! info
-
+        
             If you do not know how to work with text editors in a Linux SSH session, run the following command: `cat >> .bashrc.` Paste the string from the clipboard and press "Ctrl+D."
 
 
@@ -115,8 +115,8 @@ Environment variables are global system variables accessible by all the processe
 
 If you need to set additional system properties when the server starts, you can take the following approaches:
 
-- **Set the properties from a script** : Setting your system properties in the startup script is ideal because it ensures that you set the properties every time you start the server. To avoid having to modify the script each time you upgrade, the best approach is to create your startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
-- **Set the properties from an external registry** : If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [secure vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
+-   **Set the properties from a script** : Setting your system properties in the startup script is ideal because it ensures that you set the properties every time you start the server. To avoid having to modify the script each time you upgrade, the best approach is to create your startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
+-   **Set the properties from an external registry** : If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [secure vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
 
 !!! info
 
@@ -124,4 +124,4 @@ If you need to set additional system properties when the server starts, you can 
 
 ## What's Next?
 
-- [Running the API-M Runtime]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m).
+-   [Running the API-M Runtime]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m).

--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -4,7 +4,7 @@ Follow the steps given below to install the WSO2 API Manager runtime.
 
 ## Before you begin
 
-See the [Installation Prerequisites]({{base_path}}/install-and-setup/install/installation-prerequisites). 
+See the [Installation Prerequisites]({{base_path}}/install-and-setup/install/installation-prerequisites).
 Java Development Kit (JDK) is essential to run the product.
 
 ## Installing the API Manager
@@ -13,25 +13,25 @@ Java Development Kit (JDK) is essential to run the product.
 2.  Extract the archive file to a dedicated directory for the API Manager, which will hereafter be referred to as `<API-M_HOME>`.
 
 !!! note
-    If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
+If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
 
 ## Setting up JAVA_HOME
 
 You must set your `JAVA_HOME` environment variable to point to the directory where the Java Development Kit (JDK) is installed on the computer.
 
 !!! info
-    Environment variables are global system variables accessible by all the processes running under the operating system.
+Environment variables are global system variables accessible by all the processes running under the operating system.
 
 ??? note "On Linux/OS X"
 
-    1.  In your home directory, open the BASHRC file (.bash\_profile file on Mac) using editors such as vi, emacs, pico, or mcedit.
-    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed.
+    1.  In your home directory, open the BASHRC file (.bash\_profile file on older macOS versions) using editors such as nano, vi, emacs, pico, or mcedit. Note that on macOS Catalina and newer, you should use the .zprofile file instead, as Zsh is the default shell.
+    2.  Assuming you have JDK 11 in your system, add the following two lines at the bottom of the file, replacing `/usr/java/jdk-11.0.x` with the actual directory where the JDK is installed (if you are working on macOS, you can use the command `/usr/libexec/java_home` to automatically get the path).
 
         ``` java
         On Linux:
         export JAVA_HOME=/usr/java/jdk-11.0.x
         export PATH=${JAVA_HOME}/bin:${PATH}
-             
+
         On OS X:
         export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
         ```
@@ -39,7 +39,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
     3.  Save the file.
 
         !!! info
-        
+
             If you do not know how to work with text editors in a Linux SSH session, run the following command: `cat >> .bashrc.` Paste the string from the clipboard and press "Ctrl+D."
 
 
@@ -48,7 +48,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
         ``` java
         On Linux:
         echo $JAVA_HOME
-            
+
         On OS X:
         which java
         If the above command gives you a path like /usr/bin/java, then it is a symbolic link to the real location. To get the real location, run the following:
@@ -69,7 +69,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
     3.  Save the file.
 
         !!! info
-            
+
             If you do not know how to work with text editors in an SSH session, run the following command: `cat >> .bashrc          `
 
         Paste the string from the clipboard and press "Ctrl+D."
@@ -115,8 +115,8 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 
 If you need to set additional system properties when the server starts, you can take the following approaches:
 
--   **Set the properties from a script** : Setting your system properties in the startup script is ideal because it ensures that you set the properties every time you start the server. To avoid having to modify the script each time you upgrade, the best approach is to create your startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
--   **Set the properties from an external registry** : If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [secure vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
+- **Set the properties from a script** : Setting your system properties in the startup script is ideal because it ensures that you set the properties every time you start the server. To avoid having to modify the script each time you upgrade, the best approach is to create your startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
+- **Set the properties from an external registry** : If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [secure vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
 
 !!! info
 
@@ -124,5 +124,4 @@ If you need to set additional system properties when the server starts, you can 
 
 ## What's Next?
 
--   [Running the API-M Runtime]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m).
-
+- [Running the API-M Runtime]({{base_path}}/install-and-setup/install/installing-the-product/running-the-api-m).


### PR DESCRIPTION
## Purpose
This PR addresses an issue where the WSO2 documentation for setting up JAVA_HOME on macOS is outdated, resulting in user confusion and setup failures. On macOS Catalina and later, the default shell is Zsh, which uses the .zprofile file instead of the .bash_profile file. This change resolves that problem.

## Goals
Update the documentation to accurately reflect the correct file (.zprofile) for setting up environment variables on modern macOS versions.

Provide a convenient command-line method for macOS users to find the JDK path, simplifying the setup process.

## Approach
I am implementing the solution by editing the documentation file to inform users to look for the .zprofile file for macOS Catalina and newer. Additionally, I am adding a simple command for users to find the JDK path, which will be more reliable than manual navigation. The change does not affect the UI.

## User stories
As a macOS user, I want to be able to follow the WSO2 documentation to set up my JAVA_HOME environment variable without encountering errors due to an outdated shell configuration or being unable to find the said file.

As a user, I want a simpler method to find the JDK path on my computer so I can complete the JAVA_HOME setup quickly.

## Release note
Updated macOS documentation for JAVA_HOME setup to use the correct .zprofile file and added a command-line method for finding the JDK path.

## Documentation
N/A. This PR is a documentation change itself, updating the existing documentation. 

## Training
N/A

## Certification
N/A. The change is to documentation, which does not affect core product features or certification questions.

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
I wanted to set up the WSO2 API Manager on my macOS laptop that uses a newer version of the OS I ran into the problem of not finding the .bashrc_profile file as the documents asked me to. After some research, I found out that after macOS Catalina, the default shell is Zsh, which necessitated the use of the .zprofile file.