### PR TITLE
Fix: Spelling mistakes [4.3.0]

### DIFF
--- a/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
+++ b/en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
@@ -55,7 +55,7 @@ First, enable the application registration workflow.
 
      It shows the application access token, consumer key and consumer secret.
     
-    ![Key generation successfull]({{base_path}}/assets/img/learn/application-key-generated.png)
+    ![Key generation successful]({{base_path}}/assets/img/learn/application-key-generated.png)
 
     If the workflow request is rejected  it will show a message.
 

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -193,7 +193,7 @@ apiIdentifier:
         </tr>
         <tr class="odd">
             <td>Docs</td>
-            <td> This folder will contain documentation attached to a particular API Product. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <td> This folder will contain documentation attached to a particular API Product. Each document will have a separate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
             <pre><code>
 type: document
 version: v4.2.0

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -17,8 +17,8 @@ Following diagram depicts the architecture of how the WSO2 APIM Control Plane co
 
 The APIM APK Agent is a component that connects the WSO2 API Manager (APIM) control plane with the WSO2 APK Gateway. The APIM APK Agent is responsible for the following tasks:
 
-- Recieve JMS Events which relates to API,Application,Subscription management from the APIM Control Plane.
-- Convert the data which is recieved from the APIM Control Plane to the APK Gateway understandable format which are K8s Custom Resources.
+- Receive JMS Events which relates to API,Application,Subscription management from the APIM Control Plane.
+- Convert the data which is received from the APIM Control Plane to the APK Gateway understandable format which are K8s Custom Resources.
 - Apply the generated Custom Resources to the K8s cluster to deploy API to APK Gateway.
 
 ## Supported Features

--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -71,8 +71,8 @@ info:
     of this document and scope for each resource is given in **authorizations** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd>&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<server_port>/oauth2/token
     ```
     **Sample request**
@@ -524,7 +524,7 @@ paths:
         - Subscription Policy (Individual)
       summary: Get a Subscription Policy
       description: |
-        This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path paramter
+        This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path parameter
       parameters:
         - $ref: '#/components/parameters/policyId'
       responses:
@@ -648,7 +648,7 @@ paths:
         - Subscription Policy (Individual)
       summary: Delete a Subscription Policy
       description: |
-        This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path paramter.
+        This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path parameter.
       parameters:
         - $ref: '#/components/parameters/policyId'
       responses:
@@ -2743,7 +2743,7 @@ paths:
         - System Scopes
       summary: Retrieve Role Alias Mappings
       description: |
-        This operation can be used to retreive role alias mapping
+        This operation can be used to retreieve role alias mapping
       responses:
         200:
           description: |
@@ -4168,12 +4168,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:
@@ -4547,7 +4547,7 @@ components:
         status:
           type: string
           description: Status of the usage publish request
-          example: successfull
+          example: successful
         message:
           type: string
           description: detailed message of the status
@@ -4563,7 +4563,7 @@ components:
         status:
           type: string
           description: Status of usage publish job
-          example: SUCCESSFULL
+          example: SUCCESSFUL
         startedTime:
           type: string
           description: Timestamp of the started time of the Job

--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -771,9 +771,9 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
 
-        `X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
+        `X-WSO2-Tenant` header can be used to retrieve the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
 
         **NOTE:**
         * This operation does not require an Authorization header by default. But in order to see a restricted API's document content, you need to provide Authorization header.
@@ -4467,7 +4467,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         unitTime:
@@ -4835,7 +4835,7 @@ components:
           example: 1.2345678901234568E30
         tokenScopes:
           type: array
-          description: Valid comma seperated scopes for the access token
+          description: Valid comma separated scopes for the access token
           example:
             - default
             - read_api
@@ -5043,7 +5043,7 @@ components:
           example: 3600
         scopes:
           type: array
-          description: Allowed scopes (space seperated) for the access token
+          description: Allowed scopes (space separated) for the access token
           example:
             - apim:subscribe
           items:
@@ -5841,7 +5841,7 @@ components:
           items:
             type: string
     CurrentAndNewPasswords:
-      title: Current and new passowrd of the user
+      title: Current and new password of the user
       type: object
       properties:
         currentPassword:

--- a/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
+++ b/en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
@@ -591,7 +591,7 @@ definitions:
     properties:
       deployStatus:
         description: |
-          This attribute declares whether deployment task is successfull or failed.
+          This attribute declares whether deployment task is successful or failed.
         type: string
         enum:
           - DEPLOYED

--- a/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
@@ -71,8 +71,8 @@ info:
     of this document and scope for each resource is given in **authorization** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<servlet_port>/oauth2/token
     ```
     **Sample request**
@@ -3292,7 +3292,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/documentId'
@@ -3445,7 +3445,7 @@ paths:
         - name: name
           in: query
           description: |
-            The name of the document which needs to be checked for the existance.
+            The name of the document which needs to be checked for the existence.
           required: true
           schema:
             type: string
@@ -6078,7 +6078,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiProductId'
         - $ref: '#/components/parameters/documentId'
@@ -10298,7 +10298,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         unitTime:
@@ -10521,12 +10521,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:
@@ -12050,7 +12050,7 @@ components:
         delimiter:
           type: string
           description: |
-            delimiter to seperate the email address
+            delimiter to separate the email address
     MonetizationAttribute:
       title: Monetization attribute object
       type: object

--- a/en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml
+++ b/en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml
@@ -66,8 +66,8 @@ info:
     of this document and scope for each resource is given in **authorization** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd>&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<servlet_port>/oauth2/token
     ```
     **Sample request**


### PR DESCRIPTION
Applied all spelling fixes from 4.6.0 plus additional fixes unique to 4.3.0:

From 4.6.0:
- "recieve" → "receive" (4 instances)
- "seperate" → "separate" (4 instances)
- "successfull" → "successful" (4 instances)

Additional fixes unique to 4.3.0:
- "seperated" → "separated" (6 instances)
- "retrive" → "retrieve" (1 instance)
- "passowrd" → "password" (5 instances)
- "cliet_id" → "client_id" (5 instances)
- "transfered" → "transferred" (5 instances)
- "existance" → "existence" (1 instance)
- "paramter" → "parameter" (2 instances)
- "retreive" → "retrieve" (1 instance)

modified:   en/docs/consume/manage-application/advanced-topics/adding-an-application-key-generation-workflow.md
        modified:   en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
        modified:   en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
        modified:   en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
        modified:   en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
        modified:   en/docs/reference/product-apis/gateway-apis/gateway-v2/gateway-v2.yaml
        modified:   en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
        modified:   en/docs/reference/product-apis/service-catalog-apis/service-catalog-v1/service-catalog-v1.yaml