### PR TITLE
Fix MCP documentation issues

### DIFF
--- a/en/docs/mcp/create-from-api.md
+++ b/en/docs/mcp/create-from-api.md
@@ -12,33 +12,35 @@ This approach is faster when:
     Well-structured API resources with clear naming and descriptions will translate into more intuitive MCP tools.
 
 
-   1. **Go to the Publisher Portal**
-      In the navigation, click **Start from Existing API** → **Create MCP Server from Existing API**.
+1. **Go to the Publisher Portal**
+    
+    * In the navigation, click **Start from Existing API** → **Create MCP Server from Existing API**.
 
-   2. **Pick the source API**
+2. **Pick the source API**
 
-      * From the list of available APIs, select the one to generate tools from.
-      * Click **Next**.
+    * From the list of available APIs, select the one to generate tools from.
+    * Click **Next**.
 
-         [![MCP Server from API Validate]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-validate.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-validate.png)
+        [![MCP Server from API Validate]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-validate.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-validate.png)
 
-   3. **Select resources to become tools**
+3. **Select resources to become tools**
 
-      * Choose which API operations should become tools.
-      * Click **Next**.
+    * Choose which API operations should become tools.
+    * Click **Next**.
 
-      [![MCP Server from API Select Tools Selecteded]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-tools-selected.png)
+    [![MCP Server from API Select Tools Selecteded]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-tools-selected.png)
 
-   4. **Enter MCP Server details**
-      Provide the details and click **Create**.
+4. **Enter MCP Server details**
+  
+    Provide the details and click **Create**.
 
-      | Field    | Sample value                                                               |
-      | -------- | -------------------------------------------------------------------------- |
-      | Name     | Petstore                                                                   |
-      | Context  | /petstore                                                                  |
-      | Version  | 1.0.6                                                                      |
+    | Field    | Sample value                                                               |
+    | -------- | -------------------------------------------------------------------------- |
+    | Name     | Petstore                                                                   |
+    | Context  | /petstore                                                                  |
+    | Version  | 1.0.6                                                                      |
 
-      [![MCP Server from API Create]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-create.png)
+    [![MCP Server from API Create]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-api-create.png)
 
 ### Next Step → Update and Deploy Your MCP Server
 

--- a/en/docs/mcp/create-from-mcp-server.md
+++ b/en/docs/mcp/create-from-mcp-server.md
@@ -8,35 +8,39 @@ In the Publisher Portal, you will:
 * Configure upstream and any APIM **policies** (auth, throttling, analytics).
 * Publish to make the proxied MCP tools available to consumers via APIM.
 
+<!-- -->
 
-   1. **Go to the Publisher Portal**
-      In the navigation, click **Proxy Existing MCP Server** → **Proxy an Existing MCP Server**.
+1. **Go to the Publisher Portal**
 
-   2. **Provide the definition**
+    * In the navigation, click **Proxy Existing MCP Server** → **Proxy an Existing MCP Server**.
 
-      * Select **MCP Server URL** and enter:
-      `https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0`
+2. **Provide the definition**
 
-   3. **Select tools to import**
+    * Select **MCP Server URL** and enter:
+    `https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0`
 
-      * Select the tools to expose through the MCP Server in APIM.
-      Click **Next**.
+3. **Select tools to import**
 
-      [![MCP Server Proxy Select Tools]({{base_path}}/assets/img/mcp/create-mcp-server-proxy-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-server-proxy-tools-selected.png)
+    * Select the tools to expose through the MCP Server in APIM.
+    Click **Next**.
 
-   4. **Enter MCP Server details**
-      Fill in the details below and click **Create**.
-      !!! note
-      The **Endpoint** must be the backend base URL your tools will call at runtime—not the OpenAPI document URL.
+    [![MCP Server Proxy Select Tools]({{base_path}}/assets/img/mcp/create-mcp-server-proxy-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-server-proxy-tools-selected.png)
 
-      | Field    | Sample value                                                               |
-      | -------- | -------------------------------------------------------------------------- |
-      | Name     | EverythingMCP                                                                   |
-      | Context  | /everything                                                                  |
-      | Version  | 1.0.0                                                                      |
-      | Endpoint | `https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0` |
+4. **Enter MCP Server details**
 
-      [![MCP Server Proxy Create]({{base_path}}/assets/img/mcp/create-mcp-servers-proxy-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-proxy-create.png)
+    Fill in the details below and click **Create**.
+
+    !!! note
+        The **Endpoint** must be the backend base URL your tools will call at runtime—not the OpenAPI document URL.
+
+    | Field    | Sample value                                                               |
+    | -------- | -------------------------------------------------------------------------- |
+    | Name     | EverythingMCP                                                                   |
+    | Context  | /everything                                                                  |
+    | Version  | 1.0.0                                                                      |
+    | Endpoint | `https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0` |
+
+    [![MCP Server Proxy Create]({{base_path}}/assets/img/mcp/create-mcp-servers-proxy-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-proxy-create.png)
 
 
 ### Next Step → Update and Deploy Your MCP Server

--- a/en/docs/mcp/create-from-openapi.md
+++ b/en/docs/mcp/create-from-openapi.md
@@ -7,40 +7,42 @@ You can then configure your MCP Server details—such as name, context, version,
 !!! tip
     The quality of the imported tools depends on the quality of your OpenAPI definition. Clear operation IDs, descriptions, and parameter schemas will result in more usable and descriptive tools.
 
-   1. **Go to the Publisher Portal**
+1. **Go to the Publisher Portal**
 
-      * In the navigation, click **Import API Definition** → **Create MCP Server from Definition**.
+    * In the navigation, click **Import API Definition** → **Create MCP Server from Definition**.
 
-   2. **Provide the definition**
-      
-      * Select **OpenAPI URL** and enter:
-      `https://petstore3.swagger.io/api/v3/openapi.json`
-      * Click **Next**.
+2. **Provide the definition**
+  
+    * Select **OpenAPI URL** and enter:
+    `https://petstore3.swagger.io/api/v3/openapi.json`
+    * Click **Next**.
 
-      [![MCP Server from OpenAPI Validate]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-validate.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-validate.png)
+    [![MCP Server from OpenAPI Validate]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-validate.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-validate.png)
 
-   3. **Select tools to import**
+3. **Select tools to import**
 
-      * Review all operations from the OpenAPI.
-      * Select the operations to expose as tools.
-      Click **Next**.
+    * Review all operations from the OpenAPI.
+    * Select the operations to expose as tools.
+    Click **Next**.
 
-      [![MCP Server from OpenAPI Select Tools Selected]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-tools-selected.png)
+    [![MCP Server from OpenAPI Select Tools Selected]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-tools-selected.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-tools-selected.png)
 
-   4. **Enter MCP Server details**
-      Fill in the details below and click **Create**.
-      !!! note
-      The **Endpoint** must be the backend base URL your tools will call at runtime—not the OpenAPI document URL.
+4. **Enter MCP Server details**
 
-      | Field    | Sample value                                                               |
-      | -------- | -------------------------------------------------------------------------- |
-      | Name     | Petstore                                                                   |
-      | Context  | /petstore                                                                  |
-      | Version  | 1.0.0                                                                      |
-      | Endpoint | [https://petstore3.swagger.io/api/v3](https://petstore3.swagger.io/api/v3) |
+    Fill in the details below and click **Create**.
+    
+    !!! note
+        The **Endpoint** must be the backend base URL your tools will call at runtime—not the OpenAPI document URL.
+
+    | Field    | Sample value                                                               |
+    | -------- | -------------------------------------------------------------------------- |
+    | Name     | Petstore                                                                   |
+    | Context  | /petstore                                                                  |
+    | Version  | 1.0.0                                                                      |
+    | Endpoint | [https://petstore3.swagger.io/api/v3](https://petstore3.swagger.io/api/v3) |
 
 
-      [![MCP Server frome OpenAPI Create]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-create.png)
+    [![MCP Server from OpenAPI Create]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-create.png){: style="width:90%"}]({{base_path}}/assets/img/mcp/create-mcp-servers-from-open-api-create.png)
 
 
 ### Next Step → Update and Deploy Your MCP Server

--- a/en/docs/mcp/invoke-a-mcp-server-using-playground.md
+++ b/en/docs/mcp/invoke-a-mcp-server-using-playground.md
@@ -6,7 +6,7 @@ Follow the instructions below to use the MCP Playground to test a MCP Server:
 
 !!! prerequisite
     - You need to have an application subscribed to the MCP Server. For more information, see [Subscribe to a MCP Server]({{base_path}}/mcp/subscribe-to-a-mcp-server/).
-    - Obtain an access token for the application. You can use the token endpoint to get a JWT token. For more information, see [Generate an Access Token]({{base_path}}/consume/invoke-apis/invoke-api-using-tools/invoke-an-api-using-the-integrated-api-console/#step-3-get-an-access-token).
+    - Obtain an access token for the application. You can use the token endpoint to get a JWT token. For more information, see [Generate an Access Token]({{base_path}}/consume/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console/#step-3-get-an-access-token).
 
 The examples here use the `Petstore` MCP Server, which was created in [Create a MCP Server from an OpenAPI definition]({{base_path}}/mcp/create-from-openapi/).
 

--- a/en/docs/mcp/overview.md
+++ b/en/docs/mcp/overview.md
@@ -31,7 +31,7 @@ The **Model Context Protocol (MCP)** in WSO2 API Manager provides a standardized
 
 WSO2 API Manager provides a unified platform for managing MCP Servers, enabling you to transform APIs into AI-ready tools and govern their lifecycle. With a centralized control plane, you can create, discover, and manage MCP Servers efficiently—streamlining workflows for both API developers and AI agent builders.
 
-   [![API Manager MCP Architecture]({{base_path}}/assets/img/mcp/mcp-architecture.png)]({{base_path}}/assets/img/mcp/mcp-architecture.png)
+  [![API Manager MCP Architecture]({{base_path}}/assets/img/mcp/mcp-architecture.png)]({{base_path}}/assets/img/mcp/mcp-architecture.png)
 
 
 !!! note

--- a/en/docs/mcp/subscribe-to-a-mcp-server.md
+++ b/en/docs/mcp/subscribe-to-a-mcp-server.md
@@ -10,19 +10,19 @@ If you already have an existing application, follow the instructions below to su
 
 1.  Sign in to the Developer Portal (`https://<hostname>:<port>/devportal`) and click on the MCP Server (e.g., `Petstore`) to go to the MCP Server overview.
 
-     [![MCP Server overview]({{base_path}}/assets/img/mcp/mcp-server-overview.png)]({{base_path}}/assets/img/mcp/mcp-server-overview.png)
+    [![MCP Server overview]({{base_path}}/assets/img/mcp/mcp-server-overview.png)]({{base_path}}/assets/img/mcp/mcp-server-overview.png)
         
 2.  Click **SUBSCRIBE TO AN APPLICATION**.
 
-     <a href="{{base_path}}/assets/img/learn/from-existing-app.png" ><img src="{{base_path}}/assets/img/learn/from-existing-app.png" alt="Subscribe to new app" title="Subscribe to new app" /></a>
+    <a href="{{base_path}}/assets/img/learn/from-existing-app.png" ><img src="{{base_path}}/assets/img/learn/from-existing-app.png" alt="Subscribe to new app" title="Subscribe to new app" /></a>
     
 3.  Select the application, the throttling policy, and click **Subscribe**.
 
-     [![Subscribe to new application]({{base_path}}/assets/img/learn/subscribe-to-app.png)]({{base_path}}/assets/img/learn/subscribe-to-app.png)
+    [![Subscribe to new application]({{base_path}}/assets/img/learn/subscribe-to-app.png)]({{base_path}}/assets/img/learn/subscribe-to-app.png)
     
-     You can see the subscriptions list in the **Subscriptions** section.
+    You can see the subscriptions list in the **Subscriptions** section.
      
-     [![Subscribe to new app]({{base_path}}/assets/img/learn/subscription-list.png)]({{base_path}}/assets/img/learn/subscription-list.png)
+    [![Subscribe to new app]({{base_path}}/assets/img/learn/subscription-list.png)]({{base_path}}/assets/img/learn/subscription-list.png)
 
 
 If you do not have an existing application, you can create one and then subscribe to the MCP Server. For detailed steps, refer to [Subscribe to an API]({{base_path}}/consume/manage-subscription/subscribe-to-an-api/), as the process is similar.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -202,7 +202,7 @@ nav:
                     - Obtain User Profile Information with OpenID Connect: manage-apis/design/api-security/openid-connect/obtaining-user-profile-information-with-openid-connect.md
                 - Open Policy Agent (OPA) Validation:
                     - Overview: manage-apis/design/api-security/opa-validation/overview.md
-                    - Custom OPA Policy for Regualr Gateway: manage-apis/design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
+                    - Custom OPA Policy for Regular Gateway: manage-apis/design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
             - Rate Limiting:
                     - Throttling Use-Cases: manage-apis/design/rate-limiting/introducing-throttling-use-cases.md
                     - Add New Throttling Policies: manage-apis/design/rate-limiting/adding-new-throttling-policies.md
@@ -1180,7 +1180,7 @@ extra:
         helm_chart:
             version: 1.2.0-1
             git_tag: v1.2.0.1
-    site_version: 4.4.0
+    site_version: 4.6.0
     # base_path: http://localhost:8000/en/latest
     base_path: https://apim.docs.wso2.com/en/latest
     envoy_path: https://www.envoyproxy.io/docs/envoy/v1.24.1


### PR DESCRIPTION
This pull request makes small improvements to documentation for MCP Server creation and usage, focusing on clarity, formatting, and correcting minor errors in navigation and references.

Documentation formatting and clarity:

* Updated numbered list formatting in `en/docs/mcp/create-from-api.md` and `en/docs/mcp/create-from-mcp-server.md` to use consistent indentation and bullet points for navigation steps, improving readability. [[1]](diffhunk://#diff-2dc99c4af8e86e793f4aad7b1ac0c0935b98d1185bb2a23d6dd0a7150e3e5a29L16-R17) [[2]](diffhunk://#diff-bf6e8155c4f29ca151c60df598c355fc6088da25b395c30b75bd7cc60e082aa6R11-R15)
* Added spacing and notes to the "Enter MCP Server details" steps in `en/docs/mcp/create-from-api.md`, `en/docs/mcp/create-from-mcp-server.md`, and `en/docs/mcp/create-from-openapi.md` for better separation and emphasis on important information. [[1]](diffhunk://#diff-2dc99c4af8e86e793f4aad7b1ac0c0935b98d1185bb2a23d6dd0a7150e3e5a29R34) [[2]](diffhunk://#diff-bf6e8155c4f29ca151c60df598c355fc6088da25b395c30b75bd7cc60e082aa6R30-R32) [[3]](diffhunk://#diff-e8b1e519c19ca90c3b81e010bc55dfff50cd27e4ad02cf5b6f8c6ff9b23889cdR31-R33)
* Corrected image caption indentation and text in `en/docs/mcp/create-from-openapi.md` for consistency.

Reference and navigation corrections:

* Fixed a broken documentation link for "Generate an Access Token" in `en/docs/mcp/invoke-a-mcp-server-using-playground.md` to point to the correct location.
* Corrected a typo in the navigation entry in `en/mkdocs.yml` ("Regualr Gateway" → "Regular Gateway").

Fixes: [wso2/api-manager/issues#4409](https://github.com/wso2/api-manager/issues/4409)