### PR TITLE
Fix formatting for Custom Gateway Agent entry

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -278,7 +278,7 @@ nav:
                         - Discover APIs on Kong Gateway in Kubernetes: manage-apis/deploy-and-publish/federated-gateways/kong/kong-kubernetes/discover-apis-on-kong-gateway-in-kubernetes.md
                     - Kong Standalone:
                         - Discover APIs on Kong Gateway: manage-apis/deploy-and-publish/federated-gateways/kong/kong-standalone/discover-apis-on-kong-gateway.md
-                  - Configure a Custom Gateway Agent: manage-apis/deploy-and-publish/deploy-on-gateway/federated-gateways/configure-custom-gateway-agent.md
+                  - Configure a Custom Gateway Agent: manage-apis/deploy-and-publish/federated-gateways/configure-custom-gateway-agent.md
     - Consume APIs:
         - Consume APIs - Overview: consume/consume-api-overview.md
         - Discover APIs:


### PR DESCRIPTION
This pull request makes a minor fix to the documentation navigation structure by correcting the path to the "Configure a Custom Gateway Agent" page. The change ensures the navigation link points to the correct location in the documentation.

- Fixed the path for the "Configure a Custom Gateway Agent" documentation in the `en/mkdocs.yml` navigation to ensure it is correctly referenced.