### PR TITLE
[4.6.0] Fixing formatting issues in Deploy on AWS API Gateway Page

### DIFF
--- a/en/docs/manage-apis/deploy-and-publish/federated-gateways/aws/deploy-on-aws-api-gateway.md
+++ b/en/docs/manage-apis/deploy-and-publish/federated-gateways/aws/deploy-on-aws-api-gateway.md
@@ -91,7 +91,7 @@ Please follow the steps below to configure the security for the API.
 
    i. Navigate to IAM > roles in AWS console and create a new role with below details.
    
-    ```
+   ```
    Trusted Entity Type : AWS Service
    Use Case : Lambda
    ```
@@ -100,7 +100,7 @@ Please follow the steps below to configure the security for the API.
 
    iii. Provide a role name and edit the Trust Policy as below to allow API Gateway service as well.
    
-    ```
+   ```
    {
         "Version": "2012-10-17",
         "Statement": [


### PR DESCRIPTION
## Purpose
Fixing the formatting issue in [deploy-on-aws-api-gateway](https://apim.docs.wso2.com/en/4.6.0/manage-apis/deploy-and-publish/federated-gateways/aws/deploy-on-aws-api-gateway/).

Current issue:
<img width="1503" height="696" alt="Screenshot 2025-10-13 at 10 09 30" src="https://github.com/user-attachments/assets/48a78816-56f7-4710-9ca5-37e1e26f30f6" />

After fix:
<img width="1489" height="699" alt="Screenshot 2025-10-13 at 10 20 01" src="https://github.com/user-attachments/assets/5af3b1e2-afad-490c-b8b1-c9d877dd3c37" />
