### PR TITLE
Fix broken link to GraphQL schema in create-graphql-api.md

### DIFF
--- a/en/docs/includes/design/create-graphql-api.md
+++ b/en/docs/includes/design/create-graphql-api.md
@@ -42,7 +42,7 @@ Let's use the Star Wars sample backend server as the backend for the GraphQL API
 
 3. Import the schema by dragging and dropping the file or by uploading the file, and click **Next**.
 
-       Let's use the [StarWarsAPI schema definition](/en/{{site_version}}/assets/attachments/learn/schema_graphql.graphql) to create the schema file. 
+       Let's use the [StarWarsAPI schema definition](../../assets/attachments/learn/schema_graphql.graphql) to create the schema file. 
 
        <div class="admonition note">
        <p class="admonition-title">Note</p>


### PR DESCRIPTION
## Description
This PR fixes the broken link to the StarWarsAPI schema definition file in the GraphQL API creation documentation.

## Problem
The current link uses an absolute path with a template variable `/en/{{site_version}}/assets/attachments/learn/schema_graphql.graphql` which results in a broken link on the documentation site.

## Solution
Changed to use a relative path `../../assets/attachments/learn/schema_graphql.graphql` which correctly navigates from the include file location to the schema file.

## Changes Made
- **File:** `en/docs/includes/design/create-graphql-api.md`
- **Changed from:** `/en/{{site_version}}/assets/attachments/learn/schema_graphql.graphql`
- **Changed to:** `../../assets/attachments/learn/schema_graphql.graphql`

## Verification
✅ Verified the schema file exists at `en/docs/assets/attachments/learn/schema_graphql.graphql`
✅ Confirmed the relative path correctly navigates from `en/docs/includes/design/` to the schema file
✅ The relative path pattern is consistent with other asset links in the documentation

Fixes #9997