### PR TITLE
[4.6.0] Update authorization method in DevOps API doc to Basic Auth

### DIFF
--- a/en/docs/reference/product-apis/devops-apis/devops-v0/devops-v0.yaml
+++ b/en/docs/reference/product-apis/devops-apis/devops-v0/devops-v0.yaml
@@ -22,7 +22,7 @@ info:
     # Try out in Postman
     If you want to try-out the Postman collection, please follow the guidelines listed below.
     * Download and import the following collection to Postman.
-    * All of the OAuth2 secured endpoints have been configured with an Authorization Bearer header with a parameterized access token. Before invoking any REST API resource make sure you run the `Register DCR Application` and `Generate Access Token` requests to fetch an access token with all required scopes.
+    * All of the endpoints have been configured with an Authorization Basic header with encoded credentials. Before invoking any REST API resource make sure you update the credentials.
     * Make sure you have an API Manager instance up and running.
     * Update the `basepath` parameter to match the hostname and port of the APIM instance.
 


### PR DESCRIPTION
## Purpose
Update authorization method in DevOps API doc to Basic Auth

## Approach
Updated the "try out with postman" section. 
The example cURL requests are already given with Basic Auth. So no changes needed for the examples

## Samples
N/A