### PR TITLE
Fix: Change 'should' to 'must' in primary keystore documentation [3.2.0]

### DIFF
--- a/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
+++ b/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
@@ -50,7 +50,7 @@ The elements in the above configuration are described below:
 | **key_password**  | Private key password                                             |
 
 !!! Important
-    Your private key password (**key_password**) and keystore password (**password**) should be the same. This is due to a limitation of some of the internal 3rd party components used by WSO2 API Mananger.
+    Your private key password (**key_password**) and keystore password (**password**) must be the same. This is due to a limitation of some of the internal 3rd party components used by WSO2 API Mananger.
 
 By default, the primary keystore configured as above is used for internal data encryption (encrypting data in internal data stores and configuration files) as well as for signing messages that are communicated with external parties. In other words, if we define the primary keystore only, it will be used as both Secondary Keystore (TLS) and Internal Keystore. However, it is sometimes a common requirement to have separate keystores for SSL/TSL connections, communicating messages with external parties (such as JWT, SAML, OIDC id\_token signing) and for encrypting information in internal data stores. This is because, for signing messages and external communications, the keystore certificates need to be frequently renewed. However, for encrypting information in internal data stores, the keystore certificates should not be changed frequently because the data that is already encrypted will become unusable every time the certificate changes.
 


### PR DESCRIPTION
## Purpose
> Fix the incorrect use of “should” in the keystore configuration documentation.

Resolves: #10202

## Goals
> Ensure the documentation correctly emphasizes that the private key password and keystore password must be the same, as this is a strict requirement due to internal component limitations.

## Approach
> Replaced the phrase:
“Your private key password (key_password) and keystore password (password) should be the same.”
with
“Your private key password (key_password) and keystore password (password) must be the same.”

## User stories
> N/A — documentation correction only.

## Release note
> Corrected a documentation statement in the keystore configuration section to replace “should” with “must.”

## Documentation
> This PR updates the 3.2.0 "Configuring Keystores in WSO2 API Manager" page:

https://apim.docs.wso2.com/en/3.2.0/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore

## Training
> N/A - no training content affected.

## Certification
> N/A - no certification impact.

## Marketing
> N/A - no marketing content affected.

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> PR #10203 raised for same change in version 4.6.0
PR #10204 raised for same change in version 4.5.0
PR #10205 raised for same change in version 4.4.0
PR #10206 raised for same change in version 4.3.0
PR #10207 raised for same change in version 4.2.0
PR #10208 raised for same change in version 4.1.0
PR #10209 raised for same change in version 4.0.0
PR #10210 raised for same change in master

## Migrations (if applicable)
> N/A

## Test environment
> Documentation-only change - no runtime environment required
 
## Learning
> Referenced the issue discussion and prior related PRs for other version to ensure consistency in phrasing and formatting.