### PR TITLE
[4.6.0] Remove WIP banner

### DIFF
--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -35,7 +35,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            {{ config.site_name | replace('WSO2', '') }} <span class="beta-badge">This documentation is a work in progress.</span>
+            {{ config.site_name | replace('WSO2', '') }}
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the documentation header by removing the "This documentation is a work in progress." beta badge from the site name display.