### PR TITLE
Add 4.6.0 version to the doc versions

### DIFF
--- a/en/docs/assets/versions.json
+++ b/en/docs/assets/versions.json
@@ -1,7 +1,7 @@
 {
-  "4.5.0": "4.5.0",
-  "current": "4.5.0",
-  "latest": "4.5.0",
+  "4.6.0": "4.6.0",
+  "current": "4.6.0",
+  "latest": "4.6.0",
   "list": [
     "4.6.0",
     "4.5.0",
@@ -15,13 +15,13 @@
     "3.0.0"
    ],
   "all": {
-    "4.6.0": {
-        "doc": "https://apim.docs.wso2.com/en/4.6.0",
-        "notes": "https://apim.docs.wso2.com/en/4.6.0/get-started/about-this-release"
+    "4.6.0":{
+        "doc": "latest",
+        "notes": "4.6.0/get-started/about-this-release"
     },
     "4.5.0":{
-        "doc": "latest",
-        "notes": "4.5.0/get-started/about-this-release"
+        "doc": "https://apim.docs.wso2.com/en/4.5.0",
+        "notes": "https://apim.docs.wso2.com/en/4.5.0/get-started/about-this-release"
     },
     "4.4.0":{
         "doc": "https://apim.docs.wso2.com/en/4.4.0",


### PR DESCRIPTION
## Purpose
This pull request updates the documentation versioning to reflect the release of version 4.6.0. The main change is the addition of 4.6.0 as the current and latest version in the `versions.json` file, along with the appropriate links for documentation and release notes.

Documentation versioning updates:

* Updated `en/docs/assets/versions.json` to set "4.6.0" as the current and latest version, and added it to the list of available versions.
* Added documentation and release notes links for "4.6.0" and adjusted the entry for "4.5.0" to use absolute URLs.