### PR TITLE
docs: remove outdated ESB-related content from keystore recommendation section for version 4.0.0 (Resolves: #10105)

### DIFF
--- a/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
+++ b/en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
@@ -157,9 +157,3 @@ Follow the recommendations given below when you set up your keystores.
     ```
 
 -   If you already have the required keystores for your product, you can generate CA-signed certificates and import them into the keystores. It is not recommended to create new keystores for the purpose of replacing the certificates in the keystore. See [Adding CA-signed certificates to keystores]({{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/#adding-ca-signed-certificates-to-keystores) for instructions.
-
--   If you encounter the following error after changing the default keystore, log in to the carbon console and navigate to `/_system/config/repository/esb/inbound` registry location and remove the `inbound-endpoints` resource. Once it is removed, restart the server. 
-    ```
-    FATAL - ServiceBusInitializer Couldn't initialize the ESB...
-    java.lang.IllegalArgumentException: KeyStore File repository/resources/security/xxxx.jks not found
-    ```


### PR DESCRIPTION
## Purpose
> The documentation section "Recommendation for setting up keystores" contains outdated and unclear content.
Specifically, it still references legacy ESB-related components (e.g., `ServiceBusInitializer` and `/_system/config/repository/esb/inbound`) that no longer exist in current WSO2 API Manager versions.

Resolves: #10105

## Goals
> To remove outdated ESB-related references from the “Recommendations for setting up keystores” section of the documentation to ensure relevance, accuracy, and clarity for current WSO2 API Manager deployments.

## Approach
> The outdated bullet point that referenced the `ServiceBusInitializer` and `esb/inbound` registry path was removed from the "Recommendations for setting up keystores" section.
File modified:

'en/docs/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md'

## User stories
> Users configuring keystores for API Manager will no longer encounter misleading or irrelevant ESB-related instructions.

## Release note
> Removed outdated ESB-related references from the "Recommendations for setting up keystores" section of the WSO2 API Manager documentation.

## Documentation
> This PR updates the 4.0.0 "Configuring Keystores in WSO2 API Manager" page:

https://apim.docs.wso2.com/en/4.0.0/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager

## Training
> N/A - no training content affected.

## Certification
>N/A - no certification impact.

## Marketing
> N/A - no marketing content affected.

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> PR #10211 raised for same change in version 4.5.0
PR #10244 raised for same change in version 4.6.0
PR #10245 raised for same change in version 4.4.0
PR #10246 raised for same change in version 4.3.0
PR #10248 raised for same change in version 4.2.0
PR #10249 raised for same change in version 4.1.0

Separate PRs to be raised for relevant versions to fully resolve #10105 

## Migrations (if applicable)
> N/A

## Test environment
> Documentation-only change - no runtime environment required
 
## Learning
> Cross-checked existing documentation consistency across the `setup/security/configuring-keystores` section.