### PR TITLE
[4.6.0] Update the product version in the deployment docs

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/basic-health-checks.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/basic-health-checks.md
@@ -28,7 +28,7 @@ A sample cURL command and the response from the `Version` service are given belo
 
 === "Response"
     ``` java
-    <ns:getVersionResponse xmlns:ns="http://version.services.core.carbon.wso2.org"><return>WSO2 API Manager-4.5.0</return></ns:getVersionResponse>
+    <ns:getVersionResponse xmlns:ns="http://version.services.core.carbon.wso2.org"><return>WSO2 API Manager-4.6.0</return></ns:getVersionResponse>
     ```
 
 !!! note

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -68,7 +68,7 @@ If you want to quickly try out WSO2 API Manager on Kubernetes with minimal confi
 Deploy API Manager with minimal configuration using the following command:
 
 ```bash
-helm install apim wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-0-all-in-one/default_values.yaml
+helm install apim wso2/wso2am-all-in-one --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-0-all-in-one/default_values.yaml
 ```
 
 Once the service is up and running, make sure you have the NGINX Ingress Controller deployed by following the steps outlined in the [Add Ingress Controller](#11-add-ingress-controller) section.
@@ -283,7 +283,7 @@ kubectl create namespace <namespace>
 
 # Deploy API Manager using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -63,7 +63,7 @@ Before you begin, ensure you have the following prerequisites in place:
 
   For a production-grade deployment of the desired WSO2 product version, it is highly recommended to use the relevant Docker image that includes WSO2 Updates, available at the [WSO2 Private Docker Registry](https://docker.wso2.com/). To use these images, you need an active [WSO2 Subscription](https://wso2.com/subscription).
 
-- WSO2 API Manager 4.5.0 provides three Docker images:
+- WSO2 API Manager 4.6.0 provides three Docker images:
   - All-in-one - [wso2am](https://hub.docker.com/r/wso2/wso2am)
   - Universal Gateway (GW) - [wso2am-universal-gw](https://hub.docker.com/r/wso2/wso2am-universal-gw)
 
@@ -73,16 +73,16 @@ Before you begin, ensure you have the following prerequisites in place:
   ```
 - If there are any customizations to the JARs in the product, these can also be included in the Docker image itself rather than mounting them from the deployment level (assuming they are common to all environments).
 - Below is a sample Dockerfile to build a custom WSO2 APIM image. Depending on your requirements, you may refer to the following and make the necessary additions. The script will:
-  - Use WSO2 APIM 4.5.0 as the base image
+  - Use WSO2 APIM 4.6.0 as the base image
   - Copy third-party libraries to the `<APIM_HOME>/lib` directory
 
   - Dockerfile for All-in-One:
     ```dockerfile
-    FROM docker.wso2.com/wso2am:4.5.0.0
+    FROM docker.wso2.com/wso2am:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -135,10 +135,10 @@ Deploy API Manager with minimal configuration using the following commands:
 
 ```bash
 # Deploy first instance
-helm install apim-1 wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-1-all-in-one-HA/default_values_1.yaml
+helm install apim-1 wso2/wso2am-all-in-one --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-1-all-in-one-HA/default_values_1.yaml
 
 # Deploy second instance (for high availability)
-helm install apim-2 wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-1-all-in-one-HA/default_values_2.yaml
+helm install apim-2 wso2/wso2am-all-in-one --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-1-all-in-one-HA/default_values_2.yaml
 ```
 
 !!! important
@@ -346,7 +346,7 @@ Now deploy the Helm chart using the following command after creating a namespace
   
   ```bash
   kubectl create namespace <namespace>
-  helm install <release-name> <helm-chart-path> --version 4.5.0-3 --namespace <namespace> --dependency-update -f values.yaml --create-namespace
+  helm install <release-name> <helm-chart-path> --version 4.6.0-1 --namespace <namespace> --dependency-update -f values.yaml --create-namespace
   ```
 
 #### 2.6 Enable High Availability

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -69,7 +69,7 @@ Before you begin, ensure you have the following prerequisites in place:
   For a production-grade deployment of the desired WSO2 product version, it is highly recommended to use the relevant
   Docker image which packages WSO2 Updates, available at [WSO2 Private Docker Registry](https://docker.wso2.com/). To use these images, you need an active [WSO2 Subscription](https://wso2.com/subscription).
 
-- WSO2 API Manager 4.5.0 provides three Docker images:
+- WSO2 API Manager 4.6.0 provides three Docker images:
   - All-in-one - [wso2am](https://hub.docker.com/r/wso2/wso2am)
   - Universal Gateway (GW) - [wso2am-universal-gw](https://hub.docker.com/r/wso2/wso2am-universal-gw)
 
@@ -79,17 +79,17 @@ Before you begin, ensure you have the following prerequisites in place:
   ```
 - Furthermore, if there are any customizations to the JARs in the product, those can also be included in the Docker image itself rather than mounting them from the deployment level (assuming that they are common to all environments).
 - The following is a sample Dockerfile to build a custom WSO2 APIM image. Depending on your requirements, you may refer to the following and make the necessary additions. The script below will:
-  - Use WSO2 APIM 4.5.0 as the base image
+  - Use WSO2 APIM 4.6.0 as the base image
   - Change UID and GID to 10001 (the default APIM image has 802 as UID and GID)
   - Copy third-party libraries to the `<APIM_HOME>/lib` directory
 
   - Dockerfile for All-in-one
     ```dockerfile
-    FROM docker.wso2.com/wso2am:4.5.0.0
+    FROM docker.wso2.com/wso2am:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -99,11 +99,11 @@ Before you begin, ensure you have the following prerequisites in place:
   
   - Dockerfile for Universal Gateway
     ```dockerfile
-    FROM docker.wso2.com/wso2am-universal-gw:4.5.0.0
+    FROM docker.wso2.com/wso2am-universal-gw:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-universal-gw
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -163,10 +163,10 @@ Deploy API Manager with minimal configuration using the following commands:
 
 ```bash
 # Deploy All-in-One
-helm install apim wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_values.yaml
+helm install apim wso2/wso2am-all-in-one --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_values.yaml
 
 # Deploy Universal Gateway
-helm install apim-gw wso2/wso2am-universal-gw --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+helm install apim-gw wso2/wso2am-universal-gw --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
 ```
 
 !!! important
@@ -375,7 +375,7 @@ kubectl create namespace <namespace>
 
 # Deploy All-in-One using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -504,7 +504,7 @@ After configuring all the necessary parameters, you can deploy the Universal Gat
 ```bash
 # Deploy Universal Gateway using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -76,7 +76,7 @@ Before you begin, ensure you have the following prerequisites in place:
 
   For a production-grade deployment of the desired WSO2 product version, it is highly recommended to use the relevant Docker image which packages WSO2 Updates, available at the [WSO2 Private Docker Registry](https://docker.wso2.com/). To use these images, you need an active [WSO2 Subscription](https://wso2.com/subscription).
 
-- WSO2 API Manager 4.5.0 provides three Docker images:
+- WSO2 API Manager 4.6.0 provides three Docker images:
   - API Control Plane (ACP) - [wso2am-acp](https://hub.docker.com/r/wso2/wso2am-acp)
   - Traffic Manager (TM) - [wso2am-tm](https://hub.docker.com/r/wso2/wso2am-tm)
   - Universal Gateway (GW) - [wso2am-universal-gw](https://hub.docker.com/r/wso2/wso2am-universal-gw)
@@ -87,16 +87,16 @@ Before you begin, ensure you have the following prerequisites in place:
   ```
 - Furthermore, if there are any customizations to the JARs in the product, those can be included in the Docker image itself rather than mounting them from the deployment level (assuming that they are common to all environments).
 - The following is a sample Dockerfile to build a custom WSO2 APIM image. Depending on your requirements, you may refer to the following and make the necessary additions. The script below will do the following:
-  - Use WSO2 APIM 4.5.0 as the base image
+  - Use WSO2 APIM 4.6.0 as the base image
   - Copy third-party libraries to the `<APIM_HOME>/lib` directory
 
   - Dockerfile for API Control Plane
     ```dockerfile
-    FROM docker.wso2.com/wso2am-acp:4.5.0.0
+    FROM docker.wso2.com/wso2am-acp:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-acp
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -106,11 +106,11 @@ Before you begin, ensure you have the following prerequisites in place:
   
   - Dockerfile for Traffic Manager
     ```dockerfile
-    FROM docker.wso2.com/wso2am-tm:4.5.0.0
+    FROM docker.wso2.com/wso2am-tm:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-tm
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -120,11 +120,11 @@ Before you begin, ensure you have the following prerequisites in place:
   
   - Dockerfile for Universal Gateway
     ```dockerfile
-    FROM docker.wso2.com/wso2am-universal-gw:4.5.0.0
+    FROM docker.wso2.com/wso2am-universal-gw:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-universal-gw
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -184,13 +184,13 @@ Deploy API Manager with minimal configuration using the following commands:
 
 ```bash
 # Deploy API Control Plane
-helm install apim-acp wso2/wso2am-acp --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
+helm install apim-acp wso2/wso2am-acp --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml
 
 # Deploy Traffic Manager
-helm install apim-tm wso2/wso2am-tm --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+helm install apim-tm wso2/wso2am-tm --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
 
 # Deploy Universal Gateway
-helm install apim-gw wso2/wso2am-universal-gw --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+helm install apim-gw wso2/wso2am-universal-gw --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
 ```
 
 !!! important
@@ -402,7 +402,7 @@ kubectl create namespace <namespace>
 
 # Deploy API Manager Control Plane using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -442,7 +442,7 @@ After configuring all the necessary parameters, you can deploy the Traffic Manag
 ```bash
 # Deploy Traffic Manager using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -518,7 +518,7 @@ After configuring all the necessary parameters, you can deploy the Universal Gat
 ```bash
 # Deploy Universal Gateway using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -72,7 +72,7 @@ Before you begin, ensure you have the following prerequisites in place:
 
   For a production-grade deployment of the desired WSO2 product version, it is highly recommended to use the relevant Docker image which packages WSO2 Updates, available at the [WSO2 Private Docker Registry](https://docker.wso2.com/). To use these images, you need an active [WSO2 Subscription](https://wso2.com/subscription).
 
-- WSO2 API Manager 4.5.0 provides three Docker images:
+- WSO2 API Manager 4.6.0 provides three Docker images:
   - API Control Plane - [wso2am-acp](https://hub.docker.com/r/wso2/wso2am-acp)
   - Traffic Manager - [wso2am-tm](https://hub.docker.com/r/wso2/wso2am-tm)
   - Universal Gateway - [wso2am-universal-gw](https://hub.docker.com/r/wso2/wso2am-universal-gw)
@@ -86,16 +86,16 @@ Before you begin, ensure you have the following prerequisites in place:
   ```
 - Furthermore, if there are any customizations to the JARs in the product, those can be included in the Docker image itself rather than mounting them from the deployment level (assuming that they are common to all environments).
 - The following is a sample Dockerfile to build a custom WSO2 APIM image. Depending on your requirements, you may refer to the following and make the necessary additions. The script below will do the following:
-  - Use WSO2 APIM 4.5.0 as the base image
+  - Use WSO2 APIM 4.6.0 as the base image
   - Copy third-party libraries to the `<APIM_HOME>/lib` directory
 
   - Dockerfile for API Control Plane
     ```dockerfile
-    FROM docker.wso2.com/wso2am-acp:4.5.0.0
+    FROM docker.wso2.com/wso2am-acp:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-acp
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -105,11 +105,11 @@ Before you begin, ensure you have the following prerequisites in place:
   
   - Dockerfile for Traffic Manager
     ```dockerfile
-    FROM docker.wso2.com/wso2am-tm:4.5.0.0
+    FROM docker.wso2.com/wso2am-tm:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-tm
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -119,11 +119,11 @@ Before you begin, ensure you have the following prerequisites in place:
   
   - Dockerfile for Universal Gateway
     ```dockerfile
-    FROM docker.wso2.com/wso2am-universal-gw:4.5.0.0
+    FROM docker.wso2.com/wso2am-universal-gw:4.6.0.0
 
     ARG USER_HOME=/home/${USER}
     ARG WSO2_SERVER_NAME=wso2am-universal-gw
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -187,16 +187,16 @@ Deploy API Manager with minimal configuration using the following commands:
 
 ```bash
 # 1. Deploy API Control Plane
-helm install apim-acp wso2/wso2am-acp --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
+helm install apim-acp wso2/wso2am-acp --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml
 
 # 2. Deploy Key Manager
-helm install apim-km wso2/wso2am-km --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
+helm install apim-km wso2/wso2am-km --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml
 
 # 3. Deploy Traffic Manager
-helm install apim-tm wso2/wso2am-tm --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+helm install apim-tm wso2/wso2am-tm --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
 
 # 4. Deploy Universal Gateway
-helm install apim-gw wso2/wso2am-universal-gw --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+helm install apim-gw wso2/wso2am-universal-gw --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
 ```
 
 Once the services are up and running, make sure you have the NGINX Ingress Controller deployed by following the steps outlined in the [Add Ingress Controller](#11-add-ingress-controller) section.
@@ -411,7 +411,7 @@ kubectl create namespace <namespace>
 
 # Deploy API Manager Control Plane using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -452,7 +452,7 @@ After configuring all the necessary parameters, you can deploy the Traffic Manag
 ```bash
 # Deploy Traffic Manager using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -528,7 +528,7 @@ After configuring all the necessary parameters, you can deploy the Universal Gat
 ```bash
 # Deploy Universal Gateway using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -561,7 +561,7 @@ After configuring all the necessary parameters, you can deploy the Key Manager u
 ```bash
 # Deploy Key Manager using Helm
 helm install <release-name> <helm-chart-path> \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -101,11 +101,11 @@ If you need to customize the Docker images (e.g., adding JDBC drivers, custom li
 
    **All-in-One** (Control Plane/Key Manager):
    ```dockerfile
-   FROM docker.wso2.com/wso2am:4.5.0.0
+   FROM docker.wso2.com/wso2am:4.6.0.0
 
    ARG USER_HOME=/home/${USER}
    ARG WSO2_SERVER_NAME=wso2am
-   ARG WSO2_SERVER_VERSION=4.5.0
+   ARG WSO2_SERVER_VERSION=4.6.0
    ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
    ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -115,18 +115,18 @@ If you need to customize the Docker images (e.g., adding JDBC drivers, custom li
 
    **Universal Gateway**:
    ```dockerfile
-   FROM docker.wso2.com/wso2am-universal-gw:4.5.0.0
+   FROM docker.wso2.com/wso2am-universal-gw:4.6.0.0
 
    ARG USER_HOME=/home/${USER}
    ARG WSO2_SERVER_NAME=wso2am-universal-gw
-   ARG WSO2_SERVER_VERSION=4.5.0
+   ARG WSO2_SERVER_VERSION=4.6.0
    ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
    ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
    # Copy JDBC MySQL driver
    ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar ${WSO2_SERVER_HOME}/repository/components/lib
    ```
-    ARG WSO2_SERVER_VERSION=4.5.0
+    ARG WSO2_SERVER_VERSION=4.6.0
     ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
     ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 
@@ -188,19 +188,19 @@ If you want to quickly try out WSO2 API Manager on Kubernetes with minimal confi
 
    **Deploy Control Plane (All-in-One)**:
    ```bash
-   helm install apim wso2/wso2am-all-in-one --version 4.5.0-3 \
+   helm install apim wso2/wso2am-all-in-one --version 4.6.0-1 \
      -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml
    ```
 
    **Deploy Key Manager**:
    ```bash
-   helm install km wso2/wso2am-acp --version 4.5.0-3 \
+   helm install km wso2/wso2am-acp --version 4.6.0-1 \
      -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml
    ```
 
    **Deploy Universal Gateway**:
    ```bash
-   helm install gw wso2/wso2am-universal-gw --version 4.5.0-3 \
+   helm install gw wso2/wso2am-universal-gw --version 4.6.0-1 \
      -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
    ```
 
@@ -412,7 +412,7 @@ kubectl create namespace <namespace>
 
 # Install using Helm
 helm install <release-name> wso2/wso2am-all-in-one \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f values.yaml \
@@ -445,7 +445,7 @@ Deploy the Key Manager component with your custom configuration:
 ```bash
 # Install Key Manager component
 helm install <release-name> wso2/wso2am-acp \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f km-values.yaml \
@@ -567,7 +567,7 @@ Deploy the Universal Gateway component with your custom configuration:
 ```bash
 # Install Gateway component
 helm install <release-name> wso2/wso2am-universal-gw \
-  --version 4.5.0-3 \
+  --version 4.6.0-1 \
   --namespace <namespace> \
   --dependency-update \
   -f gw-values.yaml \

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -81,7 +81,7 @@ This section explains how to configure WSO2 Identity Server 7.x as a Key Manager
 
 !!! info
     Before you begin:
-    You need to import the public certificate of the WSO2 Identity Server 7.x to the truststore of the WSO2 API Manager, and vice-versa. For information on importing the certificates, see the [Importing certificates to the truststore](https://apim.docs.wso2.com/en/4.5.0/install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/#step-3-importing-certificates-to-the-truststore) guide.
+    You need to import the public certificate of the WSO2 Identity Server 7.x to the truststore of the WSO2 API Manager, and vice-versa. For information on importing the certificates, see the [Importing certificates to the truststore](https://apim.docs.wso2.com/en/4.6.0/install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/#step-3-importing-certificates-to-the-truststore) guide.
 
 To configure WSO2 Identity Server 7.x to work as a Key Manager with WSO2 API Manager, you need to apply the following configurations:
 
@@ -153,7 +153,7 @@ helm install is wso2/identity-server --version next \
 - Deploy API Manager with minimal configuration using the following command:
 
 ```bash
-helm install apim wso2/wso2am-all-in-one --version 4.5.0-3 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-0-all-in-one/default_values.yaml
+helm install apim wso2/wso2am-all-in-one --version 4.6.0-1 -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-0-all-in-one/default_values.yaml
 ```
 
 Once the service is up and running, make sure you have the NGINX Ingress Controller deployed by following the steps outlined in the [Add Ingress Controller](#11-add-ingress-controller) section.

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
@@ -51,13 +51,13 @@ The official WSO2 Docker images run as a non-root user with a fixed UID. While t
 
 Also 
 
-1. Starting from v4.5.0, each component has a separate Docker image (All-in-one, Control-plane, Gateway, Traffic-manager).
+1. Starting from v4.6.0, each component has a separate Docker image (All-in-one, Control-plane, Gateway, Traffic-manager).
 2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a separate DB.
 3. Download a connector which is compatible with the DB version and copy the connector while building the image
 
 !!! example "Sample Dockerfile for All-in-One Image"
     ```dockerfile
-    FROM wso2/wso2am:4.5.0
+    FROM wso2/wso2am:4.6.0
 
     # Change directory permissions for OpenShift compatibility
     USER root
@@ -260,7 +260,7 @@ The All-in-One deployment is the simplest pattern to deploy WSO2 API Manager on 
    helm install apim wso2/wso2am-all-in-one \
      --namespace wso2 \
      --create-namespace \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      -f openshift-values.yaml
    ```
 
@@ -270,7 +270,7 @@ The All-in-One deployment is the simplest pattern to deploy WSO2 API Manager on 
    helm install apim wso2/wso2am-all-in-one \
      --namespace wso2 \
      --create-namespace \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      --set wso2.subscription.username=<USERNAME> \
      --set wso2.subscription.password=<PASSWORD> \
      -f https://raw.githubusercontent.com/wso2/helm-apim/main/docs/am-pattern-0-all-in-one/default_openshift_values.yaml
@@ -356,7 +356,7 @@ Deploy components in the correct order, typically:
    helm install apim wso2/wso2am-acp \
      --namespace wso2 \
      --create-namespace \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      -f control-plane-openshift-values.yaml
    ```
 
@@ -365,7 +365,7 @@ Deploy components in the correct order, typically:
    helm install tm wso2/wso2am-tm \
      --namespace wso2 \
      --create-namespace \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      -f tm-openshift-values.yaml
    ```
 
@@ -373,7 +373,7 @@ Deploy components in the correct order, typically:
    ```bash
    helm install km wso2/wso2am-km \
      --namespace wso2 \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      -f km-openshift-values.yaml
    ```
 
@@ -381,7 +381,7 @@ Deploy components in the correct order, typically:
    ```bash
    helm install gw wso2/wso2am-universal-gw \
      --namespace wso2 \
-     --version 4.5.0-3 \
+     --version 4.6.0-1 \
      -f gw-openshift-values.yaml
    ```
 

--- a/en/docs/install-and-setup/setup/reference/product-compatibility.md
+++ b/en/docs/install-and-setup/setup/reference/product-compatibility.md
@@ -1,17 +1,17 @@
 # Product Compatibility
 
-Given below are the compatibility details of the WSO2 API Manager (WSO2 API-M) 4.5.0 runtimes.
+Given below are the compatibility details of the WSO2 API Manager (WSO2 API-M) 4.6.0 runtimes.
 
 !!! Note
     Even though the tested operating systems are listed in compatibility sections for each product, ideally WSO2 products relies on the tested versions of the JDK.
 
 ## API-M runtime compatibility
 
-Given below is the tested compatibility of the API-M runtime of WSO2 API Manager 4.5.0.
+Given below is the tested compatibility of the API-M runtime of WSO2 API Manager 4.6.0.
 
 #### Tested Operating Systems
 
-As WSO2 API Manager is a Java application, you can generally run it on most operating systems. Listed below are the operating systems that have been tested with the API-M 4.5.0 runtime.
+As WSO2 API Manager is a Java application, you can generally run it on most operating systems. Listed below are the operating systems that have been tested with the API-M 4.6.0 runtime.
 
 |**Operating System**|**Versions**  |
 |--------------------|--------------|
@@ -46,7 +46,7 @@ The **WSO2 API-M** runtime is tested with the following databases:
 
 #### WSO2 Product Compatibility Matrix
 
-The following is a list of other WSO2 products and components that have been tested with WSO2 API Manager 4.5.0.
+The following is a list of other WSO2 products and components that have been tested with WSO2 API Manager 4.6.0.
 
 {!includes/compatibility-matrix.md!}
 
@@ -64,7 +64,7 @@ The following is a list of other WSO2 products and components that have been tes
 </thead>
 <tbody>
 <tr class="even">
-<td>API-M 4.5.0 GA</td>
+<td>API-M 4.6.0 GA</td>
 <td>
 GA or update for:
 <ul>
@@ -74,7 +74,7 @@ GA or update for:
 </td>
 </tr>
 <tr class="even">
-<td>API-M-4.5.0 update</td>
+<td>API-M-4.6.0 update</td>
 <td>GA or update for:
 <ul>
 <li>WSO2 IS-6.0.0/WSO2 IS-6.1.0</li>

--- a/en/docs/install-and-setup/setup/single-node/deployment-overview.md
+++ b/en/docs/install-and-setup/setup/single-node/deployment-overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-WSO2 API Manager 4.5.0 introduces a modular component architecture with separate distributions for API Control Plane, Universal Gateway, and Traffic Manager. This document provides an overview of various deployment patterns to help you choose the optimal configuration for deployment on virtual machines (VMs) based on your specific requirements.
+WSO2 API Manager 4.6.0 provides a modular component architecture with separate distributions for API Control Plane, Universal Gateway, and Traffic Manager. This document provides an overview of various deployment patterns to help you choose the optimal configuration for deployment on virtual machines (VMs) based on your specific requirements.
 
 ## All-in-One Deployment Patterns
 
@@ -19,7 +19,7 @@ Two all-in-one instances of WSO2 API Manager in active-active configuration prov
 
 ## Distributed Deployment Patterns
 
-WSO2 API Manager 4.5.0 offers separate component distributions:
+WSO2 API Manager 4.6.0 offers separate component distributions:
 
 - **WSO2 API Control Plane (ACP)**: Includes Key Manager, Publisher Portal, and Developer Portal
 - **WSO2 Universal Gateway**: Handles API traffic and security


### PR DESCRIPTION
## Purpose
This pull request updates the documentation for WSO2 API Manager deployments to reference version 4.6.0 instead of 4.5.0. The changes ensure that all sample commands, Docker images, and configuration instructions are aligned with the latest product release across multiple deployment patterns and scenarios.

**Version updates for deployment instructions and Docker images:**

* All references to WSO2 API Manager, its Docker images, and Helm chart versions have been updated from `4.5.0` to `4.6.0` in the documentation for basic, HA, and advanced Kubernetes deployment patterns, including sample commands and Dockerfiles. [[1]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L66-R66) [[2]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L72-R72) [[3]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L79-R79) [[4]](diffhunk://#diff-14ecb70c4670547a740a03e4905b89e0dc02da59db5c9136534ad718846a60feL75-R75)
* Helm install commands for all deployment patterns now use `--version 4.6.0-1` for the charts, ensuring users install the latest release. [[1]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L71-R71) [[2]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L286-R286) [[3]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L138-R141) [[4]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L349-R349) [[5]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L166-R169) [[6]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L378-R378) [[7]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L507-R507) [[8]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L187-R193) [[9]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L405-R405) [[10]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L445-R445) [[11]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L521-R521)
* Sample Dockerfiles for all product components (All-in-One, Universal Gateway, API Control Plane, Traffic Manager) now use the `4.6.0.0` base image and update related ARGs to match the new version. [[1]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L76-R85) [[2]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L82-R92) [[3]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L102-R106) [[4]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L90-R99) [[5]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L109-R113) [[6]](diffhunk://#diff-7e5f5ef6dc6bde36d7d241a9c05a60835d88653db37d30047df02970615e9d79L123-R127) [[7]](diffhunk://#diff-14ecb70c4670547a740a03e4905b89e0dc02da59db5c9136534ad718846a60feL89-R98) [[8]](diffhunk://#diff-14ecb70c4670547a740a03e4905b89e0dc02da59db5c9136534ad718846a60feL108-R112)

**Other documentation updates:**

* The sample response from the `Version` service in health check documentation now reflects `WSO2 API Manager-4.6.0`.