### PR TITLE
Add note regarding removal the mandatory dot extension in WSO2 IS 7.2.0

### DIFF
--- a/en/docs/administer/multitenancy/tenant-sharing-with-wso2is7.md
+++ b/en/docs/administer/multitenancy/tenant-sharing-with-wso2is7.md
@@ -54,7 +54,7 @@ allowed_username = ["*"]
 ## Tenant Synchronization from WSO2 IS 7.x to WSO2 API Manager
 
 !!! note 
-    Starting from WSO2 Identity Server 7.2.0, it is possible to create tenant domains without a mandatory dot extension (e.g., abc instead of abc.com). If you intend to support tenant domains in this format, please add the following configuration to the `<Product-Home>/repository/conf/deployment.toml` file of API Manager to avoid errors during tenant synchronization: : 
+    Starting from WSO2 Identity Server 7.2.0, it is possible to create tenant domains without a mandatory dot extension (e.g., abc instead of abc.com). If you intend to support tenant domains in this format, please add the following configuration to the `<Product-Home>/repository/conf/deployment.toml` file of API Manager to avoid errors during tenant synchronization :  
     ```toml
     [multi_tenancy]
     stratos.public_cloud_setup = false


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified tenant domain creation behavior in WSO2 Identity Server 7.2.0+ (dot extension no longer mandatory).
  * Added guidance to disable public-cloud setup to prevent tenant creation errors.
  * Documented how to enable tenant create/update/enable/disable event synchronization from WSO2 Identity Server to API Manager.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->