### PR TITLE
Update outdated Redocly CDN URLs in API documentation

### DIFF
--- a/en/docs/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17.md
+++ b/en/docs/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/admin-apis/admin-v1/admin-v1.md
+++ b/en/docs/develop/product-apis/admin-apis/admin-v1/admin-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v1/admin-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.md
+++ b/en/docs/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/gateway-apis/gateway-v1/gateway-v1.md
+++ b/en/docs/develop/product-apis/gateway-apis/gateway-v1/gateway-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/gateway-apis/gateway-v1/gateway-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-admin-v0.17.md
+++ b/en/docs/develop/product-apis/getting-started/guide-admin-v0.17.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v0.17/admin-v0.17.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-admin-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-admin-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v1/admin-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-devportal-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-devportal-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-gateway-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-gateway-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/gateway-apis/gateway-v1/gateway-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-publisher-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-publisher-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.md
+++ b/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>


### PR DESCRIPTION
This pull request updates the way Redoc is loaded in several API documentation files, switching the source of the Redoc JavaScript bundle from jsdelivr to the official Redoc CDN. This ensures that documentation pages use the latest version directly from Redoc's maintained source.

Redoc CDN update across API documentation:

* Changed the Redoc script source from `https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js` to `https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js` in all admin, devportal, gateway, and publisher API documentation files and their respective getting started guides. [[1]](diffhunk://#diff-affe11a98e18972ae9194acd3f7aea7480a4ba55dbca90d4d13d43f65d451486L6-R6) [[2]](diffhunk://#diff-fd3ad66b74c1db73e1588babee1181c03249f297ea19b35b02f41ee31e7f3c67L6-R6) [[3]](diffhunk://#diff-638bbe8ec1f95eeb11f1555c03db2ee9d0f92f016acacf3a1c72e894e3328e2eL6-R6) [[4]](diffhunk://#diff-0744df594db5e4bd15e66c2ba65361b1a6faec618593552a924c564ca059b236L6-R6) [[5]](diffhunk://#diff-4bedcd7d59d47fa8e9ecfb25a0e19c28ac92797af391b84a40e8ca0f65a9e753L6-R6)