### PR TITLE
Update outdated Redocly CDN URLs in API documentation

### DIFF
--- a/en/docs/develop/product-apis/admin-apis/admin-v0.16/admin-v0.16.md
+++ b/en/docs/develop/product-apis/admin-apis/admin-v0.16/admin-v0.16.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v0.16/admin-v0.16.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.md
+++ b/en/docs/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-admin-v0.16.md
+++ b/en/docs/develop/product-apis/getting-started/guide-admin-v0.16.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/admin-apis/admin-v0.16/admin-v0.16.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-devportal-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-devportal-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/devportal-apis/devportal-v1/devportal-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/getting-started/guide-publisher-v1.md
+++ b/en/docs/develop/product-apis/getting-started/guide-publisher-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>

--- a/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.md
+++ b/en/docs/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.md
@@ -3,4 +3,4 @@ template: templates/redoc.html
 ---
 
 <redoc spec-url='{{base_path}}/develop/product-apis/publisher-apis/publisher-v1/publisher-v1.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>


### PR DESCRIPTION
This pull request updates the Redoc documentation viewer across multiple API documentation files to use a new CDN source for the Redoc JavaScript bundle. The change ensures that all references now point to the official Redoc CDN, which may provide improved reliability and access to the latest version.

Redoc CDN source update:

* Updated the Redoc script source from `cdn.jsdelivr.net` to `cdn.redoc.ly` in the following documentation files:  
  - `admin-v0.16.md` and `guide-admin-v0.16.md`
  - `devportal-v1.md` and `guide-devportal-v1.md`
  - `publisher-v1.md` and `guide-publisher-v1.md`