### PR TITLE
docs: add warning banner to /en/latest/ landing page about using versioned docsUpdate index.md

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -1,3 +1,7 @@
+::: warning
+**Note:** You are viewing the **latest** documentation. Content on this page may change as the docs evolve.  
+If you are using a specific released version of WSO2 API Manager in production, choose your version from the [versions page](/en/versions/) or use a versioned URL (for example `/en/4.5.0/`) to ensure instructions match your installed version.
+:::
 ---
 template: templates/single-column.html
 ---


### PR DESCRIPTION
Add warning banner to landing page
Problem:
When users select "WSO2 API Manager" from the dropdown, they are directed to /en/latest/. "latest" can change over time and may contain content that differs from a user's installed release. This can mislead users who need stable, release-specific instructions.

Fix:
Add a short, prominent warning banner at the top of the /en/latest/ landing page instructing users to select a version from /en/versions/ for stable documentation.

Notes:
- This is a non-functional documentation-only change.
- The banner is intentionally short and links to the versions page.

