### PR TITLE
docs: add missing multi-DC configuration steps [4.2.0] (Resolves: #10366)

### DIFF
--- a/en/docs/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1.md
+++ b/en/docs/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1.md
@@ -80,6 +80,121 @@ Since the control planes are only connected through the JMS connections, the TCP
 
 Follow the steps below to configure the control plane node(s) in region 1 to communicate with the region 2 control plane. Similarly region 1 configurations should be added to the region 2 control plane.
 
+1. Add the following event publishers to the `<APIM-HOME>/repository/deployment/server/eventpublishers` directory of the control plane.
+
+   **notificationJMSPublisherRegion2.xml**
+
+  ``` 
+    <?xml version="1.0" encoding="UTF-8"?>
+    <eventPublisher name="notificationJMSPublisherRegion2" statistics="disable"
+    trace="disable"
+    xmlns="http://wso2.org/carbon/eventpublisher">
+    <from streamName="org.wso2.apimgt.notification.stream" version="1.0.0"/>
+    <mapping customMapping="disable" type="json"/>
+    <to eventAdapterType="jms">
+    <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+    <property name="java.naming.provider.url">repository/conf/jndi-region2.properties</property>
+    <property name="transport.jms.DestinationType">topic</property>
+    <property name="transport.jms.Destination">notification</property>
+    <property name="transport.jms.ConcurrentPublishers">allow</property>
+    <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+    </to>
+    </eventPublisher>
+  ```
+
+  **tokenRevocationJMSPublisherRegion2.xml**
+
+  ```
+      <?xml version="1.0" encoding="UTF-8"?>
+    <eventPublisher name="tokenRevocationJMSPublisherRegion2" statistics="disable"
+                    trace="disable"
+        xmlns="http://wso2.org/carbon/eventpublisher">
+        <from streamName="org.wso2.apimgt.token.revocation.stream" version="1.0.0"/>
+        <mapping customMapping="disable" type="json"/>
+        <to eventAdapterType="jms">
+            <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+            <property name="java.naming.provider.url">repository/conf/jndi-region2.properties</property>
+            <property name="transport.jms.DestinationType">topic</property>
+            <property name="transport.jms.Destination">tokenRevocation</property>
+            <property name="transport.jms.ConcurrentPublishers">allow</property>
+            <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+        </to>
+    </eventPublisher>
+  ```
+
+  **keymgtEventJMSEventPublisherRegion2.xml**
+
+  ```
+      <?xml version="1.0" encoding="UTF-8"?>
+    <eventPublisher name="keymgtEventJMSEventPublisherRegion2" statistics="disable"
+      trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+      <from streamName="org.wso2.apimgt.keymgt.stream" version="1.0.0"/>
+      <mapping customMapping="disable" type="json"/>
+      <to eventAdapterType="jms">
+        <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+        <property name="java.naming.provider.url">repository/conf/jndi-region2.properties</property>
+        <property name="transport.jms.DestinationType">topic</property>
+        <property name="transport.jms.Destination">keyManager</property>
+        <property name="transport.jms.ConcurrentPublishers">allow</property>
+        <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+      </to>
+    </eventPublisher>
+  ```
+
+  **asyncWebhooksEventPublisherRegion2.xml** (This is optional only if you have webhook streaming APIs in your deployment)
+
+  ```
+        <?xml version="1.0" encoding="UTF-8"?>
+        <eventPublisher name="asyncWebhooksEventPublisher-1.0.0-Region2" statistics="disable" processing="disable"
+        trace="disable"
+        xmlns="http://wso2.org/carbon/eventpublisher">
+        <from streamName="org.wso2.apimgt.webhooks.request.stream" version="1.0.0"/>
+        <mapping customMapping="disable" type="json"/>
+        <to eventAdapterType="jms">
+        <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+        <property name="java.naming.provider.url">repository/conf/jndi2-region2.properties</property>
+        <property name="transport.jms.DestinationType">topic</property>
+        <property name="transport.jms.Destination">asyncWebhooksData</property>
+        <property name="transport.jms.ConcurrentPublishers">allow</property>
+        <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+        </to>
+        </eventPublisher>
+  ```
+
+  **blockingEventJMSPublisherRegion2.xml**
+
+  ```
+    <?xml version="1.0" encoding="UTF-8"?>
+    <eventPublisher name="blockingEventJMSPublisher" statistics="disable"
+      trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+      <from streamName="org.wso2.blocking.request.stream" version="1.0.0"/>
+      <mapping customMapping="disable" type="json"/>
+      <to eventAdapterType="jms">
+        <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+        <property name="java.naming.provider.url">repository/conf/jndi2-region2.properties</property>
+        <property name="transport.jms.DestinationType">topic</property>
+        <property name="transport.jms.Destination">throttleData</property>
+        <property name="transport.jms.ConcurrentPublishers">allow</property>
+        <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+      </to>
+    </eventPublisher>
+  ```
+
+2. Add the following JNDI configuration file to `<APIM-HOME>/repository/conf directory`.
+
+  **jndi-region2.properties**
+
+  ```
+    connectionfactory.TopicConnectionFactory = amqp://admin:admin@clientid/carbon?brokerlist='tcp://<region2-cp-host>:5672'
+    
+    topic.tokenRevocation = tokenRevocation
+    topic.keyManager = keyManager
+    topic.notification = notification
+    topic.asyncWebhooksData = asyncWebhooksData
+    
+  ```
+Replace `<region2-cp-host>` with the host of the control plane of the region where this data is published. In pattern 1, all the event hubs publish data to all the eventhubs. Therefore, all the event hubs (control plane nodes) in all the regions should be configured to publish data to other regions.
+
 ## Optional Step
 If you have secondary user stores, make sure that the userstores directory is shared between the regions.
 


### PR DESCRIPTION
## Purpose
> The documentation page “Configuring Multi-DC Deployment – Pattern 1” in APIM 4.2.0 contains an incomplete section under “Optional Step”, where the required control-plane communication configuration steps are entirely missing.

Resolves: #10366 

## Goals
> To restore the missing configuration steps under the “Optional Step” section by adding the correct event publisher configurations and JNDI file details, ensuring the 4.2.0 Multi-DC documentation is complete, accurate, and aligned with the intended deployment pattern.

## Approach
> The missing configuration block from the latest documentation was reviewed and validated for compatibility with APIM 4.2.0.
The proper configuration instructions including event publisher XML files and the `jndi-region2.properties` JNDI configuration were added beneath the existing “Optional Step” heading.

File modified:
`en/docs/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1.md`

## User stories
> Users deploying API Manager across multiple data centers will now see the correct control-plane communication configurations, eliminating confusion and preventing incomplete multi-DC setups.

## Release note
> Added missing control-plane communication configuration steps to the “Optional Step” section of the Multi-DC Deployment Pattern 1 documentation in APIM 4.2.0.

## Documentation
> This PR updates the APIM 4.2.0 documentation page:
https://apim.docs.wso2.com/en/4.2.0/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1/#optional-step

Reference used to restore missing content:
https://apim.docs.wso2.com/en/latest/install-and-setup/setup/multi-dc-deployment/configuring-multi-dc-deployment-pattern-1/#step-3-configure-the-communication-between-control-plane-nodes-across-regions

## Training
> N/A – no training materials affected.

## Certification
> N/A – no certification content impacted.

## Marketing
> N/A – this is a corrective documentation fix.

## Automation tests
 - Unit tests 
   > N/A – documentation-only change.
 - Integration tests
   > N/A – documentation-only change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A – no samples added or modified.

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Documentation-only change – no runtime or build environment required.
 
## Learning
> Reviewed configurations across multi-DC deployment documentation, cross-checked event publisher compatibility between 4.2.0 and later versions, and verified consistency of JMS/JNDI configuration files.