### PR TITLE
[4.3.0] Add SnakeYAML dependency configuration and update security guidelines

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -325,6 +325,17 @@ Java methods/native objects having names equal to any of the values given under 
 Likewise, when <code>limit_java_native_object_access_in_scripts.list_type</code> is <code>ALLOW_LIST</code>, classes with matching names will be selectively allowed.
 </td>
 </tr>
+<tr class="even">
+<td><p>Override codepoint limit of SnakeYAML Dependency</p>
+<p><br />
+</p></td>
+<td>The default codepoint limit of SnakeYAML Dependency is 3,145,728 (~3MB), which is set to avoid exposing the system to DoS attacks via large malicious files. By default, API-M uses this default limit. However, the <a href="{{base_path}}/reference/config-catalog/#dependency-configurations">dependency configuration</a> of SnakeYAML Dependency can be overriden using the following configuration:
+<pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10
+</code></pre>
+In a production environment, it is strongly recommended to set this value according to your file size requirements and security policies to mitigate potential security risks.
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -15501,3 +15501,60 @@ use_username_as_sub_claim = true
     </section>
 </div>
 
+
+
+## Dependency Configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="103" type="checkbox" id="_tab_103">
+                <label class="tab-selector" for="_tab_103"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[dependency_properties]</code>
+                            
+                            <p>
+                                This includes configurations for dependency related properties.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>snakeyaml.max_file_size_limit</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>This sets the maximum file size (in MB) for YAML files processed by SnakeYAML during API definition import/export operations. Overrides the default codepoint limit of 3,145,728 characters (~3MB) to support larger YAML OpenAPI files. The system calculates the actual codepoint limit using the formula: configured_value × 4 × 1024 × 1024 (e.g., 10 MB = 41,943,040 codepoints). Increasing this value may expose the system to DoS attacks via large malicious files - configure based on actual requirements and security policies. Note that this configuration is only available from update level 93 onwards.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -5759,6 +5759,27 @@
                 }
             ],
             "exampleFile": "service_provider.toml"
+        },
+        {
+            "title": "Dependency Configurations",
+            "options": [
+                {
+                    "name": "dependency_properties",
+                    "required": false,
+                    "description": "This includes configurations for dependency related properties.",
+                    "params": [
+                        {
+                            "name": "snakeyaml.max_file_size_limit",
+                            "type": "integer",
+                            "required": false,
+                            "default": "",
+                            "possible": "",
+                            "description": "This sets the maximum file size (in MB) for YAML files processed by SnakeYAML during API definition import/export operations. Overrides the default codepoint limit of 3,145,728 characters (~3MB) to support larger YAML OpenAPI files. The system calculates the actual codepoint limit using the formula: configured_value × 4 × 1024 × 1024 (e.g., 10 MB = 41,943,040 codepoints). Increasing this value may expose the system to DoS attacks via large malicious files - configure based on actual requirements and security policies. Note that this configuration is only available from update level 93 onwards."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "dependency_properties.toml"
         }
     ]
 }

--- a/en/tools/config-catalog-generator/data/dependency_properties.toml
+++ b/en/tools/config-catalog-generator/data/dependency_properties.toml
@@ -1,0 +1,2 @@
+[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10


### PR DESCRIPTION
This pull request introduces a new configuration option to allow overriding the default file size limit for YAML files processed by the SnakeYAML dependency, enabling support for larger OpenAPI files during API definition import/export. The changes add documentation, configuration catalog entries, and an example configuration file for this new option, with clear security guidance.

**New configuration for SnakeYAML file size limit:**

* Added a new `[dependency_properties]` section to the configuration catalog, introducing the `snakeyaml.max_file_size_limit` property. This allows administrators to set the maximum file size (in MB) for YAML files processed by SnakeYAML, overriding the default codepoint limit of 3,145,728 (~3MB). [[1]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dR15504-R15560) [[2]](diffhunk://#diff-b26b7e1f01c1d71338a9ec1ace25b50f8019b2aebe8e3d075fe1772f192e2626R5762-R5782)
* Provided a detailed description and security warning for the new property, including the calculation formula and the recommendation to adjust the limit based on security policies. [[1]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dR15504-R15560) [[2]](diffhunk://#diff-b26b7e1f01c1d71338a9ec1ace25b50f8019b2aebe8e3d075fe1772f192e2626R5762-R5782) [[3]](diffhunk://#diff-d51bb3cddfac04d53bf13e0d244ff19517ac876752ffe7cb5b3fbb89c02fb69bR328-R338)
* Updated the security guidelines documentation to reference the new configuration and explain its impact on mitigating DoS risks from large YAML files.
* Added an example configuration file `dependency_properties.toml` demonstrating how to set the new property.