### PR TITLE
Add redirections from the old url to new urls

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -864,7 +864,7 @@ plugins:
               'learn/design-api/create-api/expose-a-soap-service-as-a-rest-api.md': 'tutorials/expose-a-soap-service-as-a-rest-api.md'
               'learn/design-api/create-api/test-a-rest-api.md': 'manage-apis/design/create-api/create-rest-api/test-a-rest-api.md'
               'learn/design-api/publish-api/publish-an-api.md': 'manage-apis/deploy-and-publish/publish-on-dev-portal/publish-an-api.md'
-              # Existing redirects to 4.4.0
+              # Remaining redirects to 4.4.0
               'learn/consume-api/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping.md': 'https://apim.docs.wso2.com/en/4.4.0/reference/customize-product/customizations/customizing-the-developer-portal/customize-api-listing/api-category-based-grouping/'
               'learn/consume-api/customizations/customizing-the-developer-portal/customize-api-listing/change-default-view.md': 'https://apim.docs.wso2.com/en/4.4.0/reference/customize-product/customizations/customizing-the-developer-portal/customize-api-listing/change-default-view/'
               'learn/consume-api/customizations/customizing-the-developer-portal/enabling-or-disabling-api-detail-tabs.md': 'https://apim.docs.wso2.com/en/4.4.0/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-api-detail-tabs/'


### PR DESCRIPTION
## Purpose
Resolves broken documentation links and improves user experience by adding proper URL redirections for the WSO2 API Manager documentation site.

The documentation structure has evolved over different versions (from learn/* to design/* to manage-apis/* paths), causing numerous broken links. Users accessing old bookmarked URLs or following outdated references were encountering 404 errors, leading to poor documentation experience.

## Goals
This PR introduces comprehensive URL redirections in the MkDocs configuration to:

* Redirect old design/* paths to new manage-apis/design/* paths
* Redirect legacy learn/* paths to current documentation structure
* Redirect old deploy-and-publish/* paths to new manage-apis/deploy-and-publish/* paths
* Remove obsolete redirects pointing to external 4.4.0 documentation
* Ensure backward compatibility for all previously published documentation URLs