### PR TITLE
Fix typo: APi to API

### DIFF
--- a/en/docs/install-and-setup/install-and-setup-overview.md
+++ b/en/docs/install-and-setup/install-and-setup-overview.md
@@ -88,7 +88,7 @@ To set up the API Manager component, see the following topics.
     <th>
         <a>Setting up Proxy Server and the Load Balancer
     <td>
-        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the APi Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
+        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the API Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
         <ul>
             <li>
                 <a href="{{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer">Configuring the Proxy Server and the Load Balancer</a>


### PR DESCRIPTION
Fixed a Typo error under,
API Manager Documentation >> Install and Setup Overview >> Setting up >> Setting up Proxy Server and the Load Balancer.

## Purpose
To correct a spelling error ("APi" -> "API") in the product documentation to maintain professionalism and consistency.

## Goals
- Fix a minor typographical error in the documentation.

## Approach
- Located the typo in the markdown source file for the "Install and Setup Overview" page.
- Changed the incorrect spelling "APi Manager" to the correct "API Manager".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the API Manager component description within the installation and setup guide.
  * Fixed file formatting to ensure proper structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->