### PR TITLE
Update AsyncAPI documentation and new configuration

### DIFF
--- a/en/docs/manage-apis/design/create-api/create-streaming-api/create-a-streaming-api-from-an-asyncapi-definition.md
+++ b/en/docs/manage-apis/design/create-api/create-streaming-api/create-a-streaming-api-from-an-asyncapi-definition.md
@@ -44,6 +44,12 @@ Follow the instructions below to create a Streaming API using an AsyncAPI defini
      <html><div class="admonition note">
       <p class="admonition-title">Note</p>
       <p>The AsynAPI definition of the Streaming API will contain the basic API definition, and <b>will not specify the protocol</b>, such as WebSocket, WebSub, WebHook, SSE, that the API has to use. You need to provide the Streaming API information here.</p>
+        <p>In previous versions of WSO2 API Manager, AsyncAPI definition validation was not very strict. In the latest versions, validation has been improved to align more closely with the AsyncAPI specification. Therefore, you must provide a valid AsyncAPI definition when creating streaming APIs.</p>
+        <p>If you must continue using an older or partially compatible AsyncAPI definition, you can enable the 
+    legacy parser to relax validation. However, this is <b>not recommended</b>, and you should update your AsyncAPI 
+    definition to meet the latest standards whenever possible.</p>
+        <pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>[apim.publisher]
+    use_legacy_async_parser = true</code></pre>
       </div>
      </html>
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -4417,6 +4417,63 @@ mode = "HYBRID"
 
 
 
+## API-M Publisher Portal Configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+
+            <input name="35" type="checkbox" id="_tab_35">
+                <label class="tab-selector" for="_tab_35"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[apim.publisher]
+use_legacy_async_parser=true
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.publisher]</code>
+                            <p>
+                                API-M Publisher Portal configurations
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>use_legacy_async_parser</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable the Legacy Async API Parser.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
 ## API-M CORS configurations
 
 

--- a/en/tools/config-catalog-generator/data/apim.publisher.toml
+++ b/en/tools/config-catalog-generator/data/apim.publisher.toml
@@ -1,0 +1,2 @@
+[apim.publisher]
+use_legacy_async_parser = true

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1660,6 +1660,27 @@
             "exampleFile": "apim.devportal.toml"
         },
         {
+            "title": "API-M Publisher Portal configurations",
+            "options": [
+                {
+                    "name": "apim.publisher",
+                    "required": false,
+                    "description": "Configures the API Publisher Portal",
+                    "params": [
+                        {
+                            "name": "use_legacy_async_parser",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true,false",
+                            "description": "Enable the Legacy Async API Parser."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "apim.publisher.toml"
+        },
+        {
             "title": "API-M CORS configurations",
             "options": [
                 {


### PR DESCRIPTION
## Purpose
> With the recent improvements to the AsyncAPI parser implementation, a new configuration option has been introduced. This allows users to select either the legacy AsyncAPI v2 parser or the new, enhanced AsyncAPI v2 parser when processing AsyncAPI definitions.

## Goals
> This configuration ensures backward compatibility for existing users who rely on the legacy parser, while also enabling new users to take advantage of the updated and improved parser.

## Approach
> To support this feature, we updated the relevant documentation [[1]](https://github.com/wso2/docs-apim/blob/master/en/docs/manage-apis/design/create-api/create-streaming-api/create-a-streaming-api-from-an-asyncapi-definition.md?plain=1)[[2]](https://github.com/wso2/docs-apim/blob/master/en/docs/reference/config-catalog.md)[[3]](https://github.com/wso2/docs-apim/blob/master/en/tools/config-catalog-generator/data/configs.json) and modified the following files accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced AsyncAPI validation guidance and best practices for defining APIs.
  * Added configuration option to enable legacy AsyncAPI parser as fallback for compatibility.
  * New API-M Publisher Portal configuration documentation with setup examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->