### PR TITLE
Fix: Add Windows commands for Log Analysis #9858 [4.6.0]

### DIFF
--- a/en/docs/monitoring/observability/monitoring-correlation-logs.md
+++ b/en/docs/monitoring/observability/monitoring-correlation-logs.md
@@ -682,7 +682,7 @@ curl -k "Authorization :Bearer <access-token>" -H "activityid:<example-correlati
 2.  Isolate the logs that are correlated.<br/>
     Replace `<correlation_ID>` with the `<example-correlation-ID>` given above.
 
-    === "Linux/Mac OS"
+    === "Linux/macOS"
         ```bash
         cat correlation.log | grep "<correlation_ID>"
         ```
@@ -798,19 +798,19 @@ Follow the following steps to pinpoint the bottleneck,
 
 You can list the times consumed by the code level, using the following command. This will help you to pinpoint method level latencies.
 
-=== "Linux/Mac OS"
+=== "Linux/macOS"
     ```bash
     cat correlation.log | grep "|METHOD|" | cut -d "|" -f4 | sort -n
     ```
 
 === "Windows"
     ```powershell
-    type correlation.log | findstr "|METHOD|" | sort
+    Get-Content correlation.log | Select-String -Pattern "|METHOD|" | ForEach-Object { ($_ -split '\|')[3] } | Sort-Object {[double]$_}
     ```
 
-This will give the time consumed by each method in ascending order. If a method with a high time consumption is identified, then take the 5 most time consuming service and database calls, with the same correlation ID of the method logs, and find out the unusually time consuming call.
+This will give the time consumed by each method in ascending order. If a method with high latency is identified, then take the 5 most time-consuming service and database calls, with the same correlation ID of the method logs, and find out the unusually time-consuming call.
 
-=== "Linux/Mac OS"
+=== "Linux/macOS"
     ```bash
     cat correlation.log | grep "<correlation_ID>" | grep "|HTTP" | cut -d "|" -f4 | sort -n
     cat correlation.log | grep "<correlation_ID>" | grep "|jdbc|" | cut -d "|" -f4 | sort -n
@@ -819,26 +819,27 @@ This will give the time consumed by each method in ascending order. If a method 
 
 === "Windows"
     ```powershell
-    type correlation.log | findstr "<correlation_ID>" | findstr "|HTTP" | sort
-    type correlation.log | findstr "<correlation_ID>" | findstr "|jdbc|" | sort
-    type correlation.log | findstr "<correlation_ID>" | findstr "|ldap|" | sort
+    Get-Content correlation.log | Select-String -Pattern "<correlation_ID>" | Select-String -Pattern "|HTTP" | ForEach-Object { ($_ -split '\|')[3] } | Sort-Object {[double]$_}
+    Get-Content correlation.log | Select-String -Pattern "<correlation_ID>" | Select-String -Pattern "|jdbc|" | ForEach-Object { ($_ -split '\|')[3] } | Sort-Object {[double]$_}
+    Get-Content correlation.log | Select-String -Pattern "<correlation_ID>" | Select-String -Pattern "|ldap|" | ForEach-Object { ($_ -split '\|')[3] } | Sort-Object {[double]$_}
     ```
 
 !!! note
-    If a method with a high time consumption cannot be identified, but still a high latency is observed, the following command can be executed to find the highest time recorded.
+    If a method with high latency cannot be identified, but latency is still observed, the following command can be executed to find the highest duration value recorded.
 
-=== "Linux/Mac OS"
+=== "Linux/macOS"
     ```bash
     cat correlation.log | cut -d "|" -f4 | sort -n
     ```
 
 === "Windows"
     ```powershell
-    type correlation.log | for /f "tokens=4 delims=|" %a in ('more') do @echo %a | sort
+    Get-Content correlation.log | ForEach-Object { ($_ -split '\|')[3] } | Sort-Object {[double]$_}
     ```
-    Then the entry that bears the highest duration can be found by searching the file for this time.
 
-=== "Linux/Mac OS"
+Then the entry that bears the highest duration can be found by searching the file for this time.
+
+=== "Linux/macOS"
     ```bash
     cat correlation.log | grep "<highest_time>"
     ```


### PR DESCRIPTION
## Purpose
> Resolves #9858. Missing Windows/PowerShell commands for log analysis.

## Goals
> Provide Windows equivalents for existing Linux/Mac 'cat/grep' commands.

## Approach
> Added tabbed code blocks for 'Linux/Mac OS' and 'Windows' variants in 'monitoring-correlation-logs.md'.

## User stories
> As a Windows developer, I want copy-pasteable commands for log analysis.

## Release note
> Fixed documentation issue regarding Resolves #9858. Missing Windows/PowerShell commands for log analysis..

## Documentation
> Updates 'monitoring-correlation-logs.md'.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A (Documentation change only)
 - Integration tests
   > N/A (Documentation change only)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> Parallel PR targeting 'master' branch.

## Migrations (if applicable)
> N/A

## Test environment
> Local MkDocs build. 

## Learning
> Reviewed existing documentation and verified links/commands.