### PR TITLE
Fix: Add AsyncAPI documentation link #9859 [master]

### DIFF
--- a/en/docs/manage-apis/deploy-and-publish/publish-on-dev-portal/third-party-api-support.md
+++ b/en/docs/manage-apis/deploy-and-publish/publish-on-dev-portal/third-party-api-support.md
@@ -23,6 +23,8 @@ In addition to the streaming APIs supported in API Manager (WebSocket, SSE, and 
     The APIs created using the ‘Other’ option cannot be converted to a regular API. It can be only used as a third-party API.
         [![Create AsyncAPIs using the Other option]({{base_path}}/assets/img/develop/async-api.png)]({{base_path}}/assets/img/develop/async-api.png)
 
+For more information on creating streaming APIs from AsyncAPI definitions, see [Create a Streaming API from an AsyncAPI Definition]({{base_path}}/manage-apis/design/create-api/create-streaming-api/create-a-streaming-api-from-an-asyncapi-definition/).
+
 
 Listed below are the fields available when adding third-party API details to the API Manager.
 


### PR DESCRIPTION
## Purpose
> Resolves #9859. Missing cross-reference to 'Create a Streaming API' from Third-party support page.

## Goals
> Enable users to easily navigate to AsyncAPI creation guide.

## Approach
> Added a markdown link to 'create-async-api.md' in the 'Support for third-party APIs' section.

## User stories
> As a user reading about third-party APIs, I want to know how create streaming APIs.

## Release note
> Fixed documentation issue regarding Resolves #9859. Missing cross-reference to 'Create a Streaming API' from Third-party support page..

## Documentation
> Updates 'third-party-api-support.md'.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A (Documentation change only)
 - Integration tests
   > N/A (Documentation change only)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> Parallel PR targeting '4.6.0' branch.

## Migrations (if applicable)
> N/A

## Test environment
> Local MkDocs build. 

## Learning
> Reviewed existing documentation and verified links/commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a cross-reference in the publish-on-dev-portal guide that links to guidance on creating streaming APIs from AsyncAPI definitions, clarifying next steps for streaming API workflows and improving discoverability of related guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->