### PR TITLE
Fix: Clarify API Product behavior on resource update #10398 [master]

### DIFF
--- a/en/docs/manage-apis/design/create-api-product/create-api-product.md
+++ b/en/docs/manage-apis/design/create-api-product/create-api-product.md
@@ -45,6 +45,10 @@ the attached OpenAPI definition (a.k.a Swagger definition) files]({{base_path}}/
       </p></li>
 
       <li><p>
+      If you update the resources of an API that is part of an API Product, the API Product does not automatically reflect these changes. To apply the resource-level changes, navigate to <b>Manage Resources</b> in the API Product's edit view and click <b>Save</b> or <b>Save and Deploy</b>. Simply redeploying the API Product without this action will not refresh inherited policies or resource configurations.
+      </p></li>
+
+      <li><p>
       If you have not already signed in to the Publisher Portal as a user who has <code>Internal/publisher</code> permissions (e.g., <code>admin</code>), you need to sign out and sign in with this permission in order to be able to carry out the following instructions. </p></li>
      
       </ul>


### PR DESCRIPTION
## Purpose
> Resolves #10398. Users are often confused that API Product resources don't auto-update.

## Goals
> Explicitly warn users that changes to underlying APIs are not automatically propagated to API Products.

## Approach
> Added a 'Note' list item in 'create-api-product.md' clarifying manual update requirement.

## User stories
> As an API Publisher, I want to know if my API Product updates automatically.

## Release note
> Fixed documentation issue regarding Resolves #10398. Users are often confused that API Product resources don't auto-update..

## Documentation
> Updates 'create-api-product.md'.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A (Documentation change only)
 - Integration tests
   > N/A (Documentation change only)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> Parallel PR targeting '4.6.0' branch.

## Migrations (if applicable)
> N/A

## Test environment
> Local MkDocs build. 

## Learning
> Reviewed existing documentation and verified links/commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that updating an API included in an API Product does not automatically apply resource or inherited policy changes. To refresh those updates, open the API Product's edit view, use Manage Resources and click Save or Save and Deploy — redeploying alone will not update inherited resource configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->