### PR TITLE
Fix: Add PizzaShack backend note for distributed setup #9872 [4.6.0]

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup.md
@@ -7,6 +7,9 @@ Given below are the API-M nodes you can have in a distributed deployment by defa
 !!! Tip
     To enable high availability, you need a minimum of two nodes running each component distribution.
 
+!!! Note
+    To use the PizzaShack sample API in a distributed deployment, you need to host the sample PizzaShack backend (`pizzashack.war`) on a separate application server or container, as the backend is not included in the API-M component distributions by default. Ensure the backend URL is accessible to the Gateway.
+
 <table>
     <tr>
         <th>


### PR DESCRIPTION
## Purpose
> Resolves #9872. PizzaShack sample fails in distributed setup because backend isn't included.

## Goals
> Instruct users to host the 'pizzashack.war' separately for distributed deployments.

## Approach
> Added an '!!! Note' block in 'deploying-wso2-api-m-in-a-distributed-setup.md'.

## User stories
> As a DevOps engineer, I want to know why PizzaShack isn't working in my distributed cluster.

## Release note
> Fixed documentation issue regarding Resolves #9872. PizzaShack sample fails in distributed setup because backend isn't included..

## Documentation
> Updates 'deploying-wso2-api-m-in-a-distributed-setup.md'.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A (Documentation change only)
 - Integration tests
   > N/A (Documentation change only)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> Parallel PR targeting 'master' branch.

## Migrations (if applicable)
> N/A

## Test environment
> Local MkDocs build. 

## Learning
> Reviewed existing documentation and verified links/commands.