### PR TITLE
Fix: Typo in correlation logs documentation [4.6.0]

### DIFF
--- a/en/docs/monitoring/observability/monitoring-correlation-logs.md
+++ b/en/docs/monitoring/observability/monitoring-correlation-logs.md
@@ -415,7 +415,7 @@ In contrast to the information provided by the Synapse global handler level, the
         The following are the two possible call types:
         <ul>
         <li><strong>HTTP</strong> - This call type identifies logs that correspond to either back-end latency or round-trip latency states. Thereby, in the case of an individual request, one log will be recorded to identify back-end latency, and another log for the round-trip latency. These logs are categorized using the HTTP call type because these logs relate to HTTP calls between WSO2 API-M and external clients.</li>
-        <li><strong>HTTP State Transition</strong> - This call type idenfities logs that correspond to the state transition in the HTTP transport related to a particular message.</li>
+        <li><strong>HTTP State Transition</strong> - This call type identifies logs that correspond to the state transition in the HTTP transport related to a particular message.</li>
         </ul>
     </td>
     </tr>


### PR DESCRIPTION
## Purpose
> Fixes typo: 'idenfities' -> 'identifies'.

## Goals
> Correct spelling error in documentation.

## Approach
> Replaced 'idenfities' with 'identifies' in 'monitoring-correlation-logs.md'.

## User stories
> As a reader, I want professional and typo-free documentation.

## Release note
> Fixed documentation issue regarding Fixes typo: 'idenfities' -> 'identifies'..

## Documentation
> Updates 'monitoring-correlation-logs.md'.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A (Documentation change only)
 - Integration tests
   > N/A (Documentation change only)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> Parallel PR targeting 'master' branch.

## Migrations (if applicable)
> N/A

## Test environment
> Local MkDocs build. 

## Learning
> Reviewed existing documentation and verified links/commands.