### PR TITLE
Fix issue 4623-Master: update links from 4.4.x to 4.6.x

### DIFF
--- a/en/docs/install-and-setup/install/installation-options.md
+++ b/en/docs/install-and-setup/install/installation-options.md
@@ -2,18 +2,19 @@
 
 API Manager provides a wide range of installation options for deployments.
 
-1. [Kubernetes(Helm)](#1-kubernetes-helm)
-2. [Docker/Docker Compose](#2-dockerdocker-compose)
-3. [Puppet](#3-puppet)
+- [Installation Options](#installation-options)
+  - [1. Kubernetes (Helm)](#1-kubernetes-helm)
+  - [2. Docker/Docker Compose](#2-dockerdocker-compose)
+  - [3. Puppet](#3-puppet)
 
 ## 1. Kubernetes (Helm)
 
-You can follow the guides available in [https://github.com/wso2/helm-apim](https://github.com/wso2/helm-apim/tree/4.4.x) in order to deploy API Manager Helm artifacts.
+You can follow the guides available in [https://github.com/wso2/helm-apim](https://github.com/wso2/helm-apim/tree/4.6.x) in order to deploy API Manager Helm artifacts.
 
 ## 2. Docker/Docker Compose
 
-You can follow the guides available in [https://github.com/wso2/docker-apim](https://github.com/wso2/docker-apim/tree/4.4.x) in order to deploy API Manager Docker artifacts.
+You can follow the guides available in [https://github.com/wso2/docker-apim](https://github.com/wso2/docker-apim/tree/4.6.x) in order to deploy API Manager Docker artifacts.
 
 ## 3. Puppet
 
-You can follow the guides available in [https://github.com/wso2/puppet-apim](https://github.com/wso2/puppet-apim/tree/4.4.x) in order to deploy API Manager using Puppet artifacts.
+You can follow the guides available in [https://github.com/wso2/puppet-apim](https://github.com/wso2/puppet-apim/tree/4.6.x) in order to deploy API Manager using Puppet artifacts.


### PR DESCRIPTION
## Purpose
> Update documentation links from 4.4.x to 4.6.x.

## Documentation
> https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-options/



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide links to reference the latest stable version (4.6.x) for Kubernetes (Helm), Docker/Docker Compose, and Puppet deployment methods to ensure users follow current instructions.
  * Reorganized the Installation Options section into a dedicated subsection with clearer, indented entries for each deployment method to improve navigation and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->