### PR TITLE
Fix issue 4623-4.6.0: update 4.4.x to 4.6.x links in installation options

### DIFF
--- a/en/docs/install-and-setup/install/installation-options.md
+++ b/en/docs/install-and-setup/install/installation-options.md
@@ -2,18 +2,19 @@
 
 API Manager provides a wide range of installation options for deployments.
 
-1. [Kubernetes(Helm)](#1-kubernetes-helm)
-2. [Docker/Docker Compose](#2-dockerdocker-compose)
-3. [Puppet](#3-puppet)
+- [Installation Options](#installation-options)
+  - [1. Kubernetes (Helm)](#1-kubernetes-helm)
+  - [2. Docker/Docker Compose](#2-dockerdocker-compose)
+  - [3. Puppet](#3-puppet)
 
 ## 1. Kubernetes (Helm)
 
-You can follow the guides available in [https://github.com/wso2/helm-apim](https://github.com/wso2/helm-apim/tree/4.4.x) in order to deploy API Manager Helm artifacts.
+You can follow the guides available in [https://github.com/wso2/helm-apim](https://github.com/wso2/helm-apim/tree/4.6.x) in order to deploy API Manager Helm artifacts.
 
 ## 2. Docker/Docker Compose
 
-You can follow the guides available in [https://github.com/wso2/docker-apim](https://github.com/wso2/docker-apim/tree/4.4.x) in order to deploy API Manager Docker artifacts.
+You can follow the guides available in [https://github.com/wso2/docker-apim](https://github.com/wso2/docker-apim/tree/4.6.x) in order to deploy API Manager Docker artifacts.
 
 ## 3. Puppet
 
-You can follow the guides available in [https://github.com/wso2/puppet-apim](https://github.com/wso2/puppet-apim/tree/4.4.x) in order to deploy API Manager using Puppet artifacts.
+You can follow the guides available in [https://github.com/wso2/puppet-apim](https://github.com/wso2/puppet-apim/tree/4.6.x) in order to deploy API Manager using Puppet artifacts.


### PR DESCRIPTION
## Purpose
> Update 4.6.0 documentation links from 4.4.x to 4.5.x.

## Documentation
> https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-options/
