### PR TITLE
Fix JDK documentation: Change 'Java SE Development Kit' to 'Eclipse Temurin JDK'

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -13,7 +13,7 @@ Choose a deployment option to start the WSO2 API Manager All-In-One package. The
 
     Here's how you can download and run WSO2 API Manager All-In-One package locally on a VM:
 
-    1. Install [Java SE Development Kit (JDK)](https://adoptium.net/temurin/releases/?arch=any&version=21) version **21** and set the `JAVA_HOME` environment variable.
+    1. Install [Eclipse Temurin JDK](https://adoptium.net/temurin/releases/?arch=any&version=21) version **21** and set the `JAVA_HOME` environment variable.
     
         !!! tip
             For more information on setting the `JAVA_HOME` environment variable for different operating systems, see [Setup and Install]({{base_path}}/install-and-setup/install/installing-the-product/installing-api-m-runtime/#setting-up-java_home)


### PR DESCRIPTION
## Description
This PR fixes misleading JDK product name reference in the API Manager Quick Start Guide.

## Problem
The documentation says "Install Java SE Development Kit (JDK)" but the link goes to Eclipse Temurin/Adoptium, which is a different JDK distribution. This creates confusion for users about which JDK to install.

## Solution
- Changed "Java SE Development Kit (JDK)" to "Eclipse Temurin JDK"
- Text now matches the actual link destination (Adoptium website)
- Removes ambiguity between Oracle Java SE and Eclipse Temurin

## Files Changed
- `en/docs/get-started/api-manager-quick-start-guide.md`

## Testing
- Verified the link still points to correct Adoptium download page
- Verified markdown syntax is correct
- No broken links

## Related
Contributes toward WSO2 Customer Success Internship requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API Manager Quick Start Guide to specify Eclipse Temurin JDK 21 as the recommended Java development kit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->