### PR TITLE
Fix capitalization: Standardize 'Secure Vault' feature name

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -116,7 +116,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
 If you need to set additional system properties when the server starts, you can take the following approaches:
 
 -   **Set the properties from a script:** Setting your system properties in the startup script is ideal because it ensures that you set the properties every time you start the server. To avoid modifying the script each time you upgrade, the best approach is to create your startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
--   **Set the properties from an external registry:** If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [secure vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
+-   **Set the properties from an external registry:** If you want to access properties from an external registry, you could create Java code that reads the properties at runtime from that registry. Be sure to store sensitive data such as username and password to connect to the registry in a property file instead of in the Java code and secure the properties file with the [Secure Vault](https://docs.wso2.com/display/ADMIN44x/Carbon+Secure+Vault+Implementation).
 
 !!! info
 


### PR DESCRIPTION
## Description
This PR fixes inconsistent capitalization of the "Secure Vault" feature name in the installation documentation.

## Problem
The term appears as "secure vault" (lowercase) in the system properties section, while it appears capitalized as "Secure Vault" in 2 other locations in the documentation. Product feature names should be capitalized consistently.

## Solution
- Changed "secure vault" to "Secure Vault" (capitalize both words)
- Maintains consistency with other documentation instances
- Current: "...secure the properties file with the secure vault."
- Fixed: "...secure the properties file with the Secure Vault."

## Files Changed
- `en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md`

## Evidence
- Found via search showing 2 capitalized instances elsewhere
- This fix standardizes all instances to match established pattern

## Related
Contributes toward WSO2 Customer Success Internship requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated capitalization of terminology in API M Runtime installation documentation for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->