### PR TITLE
Add Display Name to API Product documentation

### DIFF
--- a/en/docs/manage-apis/design/create-api-product/create-api-product.md
+++ b/en/docs/manage-apis/design/create-api-product/create-api-product.md
@@ -71,6 +71,14 @@ the attached OpenAPI definition (a.k.a Swagger definition) files]({{base_path}}/
      </tr>
      <tr>
      <td>
+     Display Name
+     </td>
+     <td>
+     Customer Leasing
+     </td>
+     </tr>
+     <tr>
+     <td>
      Context
      </td>
      <td>


### PR DESCRIPTION
Fixes #10253

Added the missing Display Name field to the API Product creation documentation.

**Changes:**
- Added Display Name row to the API Product details table in Step 4
- Example value: "Customer Leasing"

This addresses the issue where the Display Name field was not documented in the API Product creation guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API Product creation documentation to reflect a new Display Name field in the form configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->