### PR TITLE
Fix JWT configuration property name in documentation

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -942,7 +942,7 @@ claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetrieve
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>enable_claim_retrieval</code> </span>
+                                  <span class="param-name-wrap"> <code>gateway_generator.enable_claim_retrieval</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>


### PR DESCRIPTION
Fixes #10301

Updated the JWT claim retrieval configuration property to match the actual implementation.

**Changes:**
- Changed `enable_claim_retrieval` to `gateway_generator.enable_claim_retrieval` in config-catalog.md
- This reflects the actual property used in api-manager.xml.j2 template

**Versions affected:** 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed JWT configuration parameter `enable_claim_retrieval` to `gateway_generator.enable_claim_retrieval`. Update existing configurations accordingly.

* **Documentation**
  * Updated configuration documentation to clarify that this parameter controls whether user claims are included in backend JWT tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->