### PR TITLE
Add detailed instructions for role-based API visibility restriction

### DIFF
--- a/en/docs/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal.md
+++ b/en/docs/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal.md
@@ -7,23 +7,7 @@ By default, the APIs created in the API Publisher Portal are visible to anyone (
 Visibility settings prevent certain user roles from viewing and modifying APIs created by another user role. API visibility can be one of the following options:
 
 - **Public:** The API is visible to all users who are registered and anonymous (who use APIs without signing in to the Developer Portal, for example testing and demonstration), and can be advertised in multiple Developer Portals (central and non-WSO2 stores).
-- **Restricted by roles:** The API is visible to it's tenant domain and only to the user roles that you specify. 
-
-    To restrict by roles:
-    
-    1. Select "Restrict by role(s)" from the Developer Portal Visibility dropdown.
-    2. Click inside the "Roles" text field. You will see the instruction "Enter roles and press Enter" appear in gray text.
-    3. Enter the role name in the format: `<domain>/<rolename>`
-        - The domain and role name must exactly match entries in your Primary or Secondary Userstores.
-        - You must have privileged access to view the available roles in your userstores.
-        - Example: `Internal/creator` or `PRIMARY/subscriber`
-    4. Press Enter after typing each role name.
-    5. Visual feedback:
-        - **Gray background**: The role name is valid and accepted.
-        - **Red text**: The role name is invalid (incorrect format or role doesn't exist).
-    6. You can add multiple roles by repeating steps 3-4.
-    
-    Note: You should provide the roles separated by commas when using the REST API or cURL parameter. 
+- **Restricted by roles:** The API is visible to its tenant domain and only to the user roles that you specify.  
 - **Visible to my domain:** The API is visible to all users who are registered to the API's tenant domain. This option is available only in a multi-tenanted environment. It's not applicable when there is only one active tenant (super tenant) in the system.
 
 Given below is how visibility levels work for users in different roles:
@@ -41,11 +25,20 @@ Given below is how visibility levels work for users in different roles:
      `https://<localhost>:9443/publisher` 
 
 2.  [Create a new API]({{base_path}}/manage-apis/design/create-api/create-rest-api/create-a-rest-api/) or edit an existing API.
-3.  Go to **Portal Configurations** from the left menu and click **Basic Info**. Then under **Developer Portal Visibility** select the desired visibility option.
+3. Go to **Portal Configurations** from the left menu and click **Basic Info**. Then under **Developer Portal Visibility** select the desired visibility option.
         
      [![API visibility Developer Portal dropdown]({{base_path}}/assets/img/learn/api-visibility-devportal-dropdown.png)]({{base_path}}/assets/img/learn/api-visibility-devportal-dropdown.png)
 
-4.  Save the API.
+    !!! note "Restricting by roles"
+        When selecting "Restrict by role(s)":
+        
+        1. Click inside the "Roles" text field. You will see the instruction "Enter roles and press Enter" appear in gray text.
+        2. Enter the role name in the format: `<domain>/<rolename>`
+            - The domain and role name must exactly match entries in your Primary or Secondary Userstores.
+            - Example: `Internal/creator` or `SECONDARY/subscriber`
+        3. Press Enter after typing each role name.
+
+4. Save the API.
 
 ### Control API visibility using the REST API
 You can use the [existing REST API]({{base_path}}/develop/product-apis/restful-apis/) to control the visibility of the API. Add the following element to the request body, including the relevant visibility,


### PR DESCRIPTION
Fixes #7489

Added comprehensive documentation for the "Restrict by role(s)" option that was previously incomplete.

**Changes made:**
- Added step-by-step guide for entering roles in the Developer Portal UI
- Documented role format requirements (`<domain>/<rolename>`)
- Explained visual feedback (gray background for valid roles, red text for invalid)
- Included examples (`Internal/creator`, `PRIMARY/subscriber`)
- Added note about userstore requirements and REST API usage

This addresses the missing information reported by @nrcuster in issue #7489, where users were unable to understand how to properly enter role restrictions after selecting the "Restrict by role(s)" option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded "Restricted by roles" guidance with clear, step‑by‑step UI instructions: enter roles in the dedicated Roles field, use domain/rolename format, press Enter after each role, and note exact matching behavior.
  * Added explicit mapping and examples showing how UI visibility options correspond to REST API visibility values (Public/Restricted/Private).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->