### PR TITLE
Docs: Fix capitalization and minor grammar in Quick Start guide

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -28,7 +28,7 @@ Choose a deployment option to start the WSO2 API Manager All-In-One package. The
     
     5. To start WSO2 API Manager, execute the relevant command:
 
-        === "On MacOS/Linux"
+        === "On macOS/Linux"
             ```bash
             sh api-manager.sh
             ```
@@ -77,7 +77,7 @@ Follow the instructions below to create, deploy and publish an API via the Publi
     | `Charset`               | UTF-8                 |
     | `HTTP Response Body`    | `{"hello": "world"}`  |
 
-    Finally click **Generate My HTTP Response** to save and generate the mock service url.
+    Finally, click **Generate My HTTP Response** to save and generate the mock service URL.
 
     
 4. Select **REST API** from the home screen and then click **Start From Scratch**.


### PR DESCRIPTION
Corrected capitalization of the words "macOS" and "URL" and added a missing comma for readability.

## Purpose
Fix minor documentation issues in the Quick Start guide.

## Goals
Correct capitalization and improve readability.

## Approach
Edited the Quick Start markdown file in the 'en/' folder:
- MacOS → macOS
- url → URL
- Added a missing comma

## User stories
N/A — documentation-only fix.

## Release note
Documentation fix: Corrected minor capitalization and punctuation in the Quick Start guide.

## Documentation
The change **is the documentation**. See Quick Start guide in 'en/docs/get-started/api-manager-quick-start-guide.md'.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
- Followed secure coding standards: N/A
- No secrets committed: Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization and terminology in the API Manager quick-start guide for improved consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->