### PR TITLE
Fix JWT configuration property name for 4.1.0

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -961,7 +961,7 @@ claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetrieve
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>enable_claim_retrieval</code> </span>
+                                  <span class="param-name-wrap"> <code>gateway_generator.enable_claim_retrieval</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>


### PR DESCRIPTION
Fixes #10301

Updated JWT claim retrieval property for 4.1.0 branch.

**Changes:**
- Changed `enable_claim_retrieval` to `gateway_generator.enable_claim_retrieval` in config-catalog.md

This is the same fix that was merged in #10579 for master, now applied to 4.1.0.