### PR TITLE
Docs: Add note recommending WSO2 Identity Server (IS) for user management

### DIFF
--- a/en/docs/install-and-setup/setup/security/user-account-management.md
+++ b/en/docs/install-and-setup/setup/security/user-account-management.md
@@ -1,7 +1,7 @@
 # User Account Management
 
 !!! note "User Management Recommendation"
-    WSO2 API Manager provides basic user account management capabilities. For advanced user management features such as user provisioning, and centralized identity management, it is recommended to use **WSO2 Identity Server (IS)** as the key manager. See [Configuring WSO2 Identity Server as a Key Manager](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager/) for more information.
+    WSO2 API Manager provides basic user account management capabilities. For advanced user management features, it is recommended to use **WSO2 Identity Server (IS)** as the key manager. See [Configuring WSO2 Identity Server as a Key Manager]({{base_path}}/install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager/) for more information.
 
 The following sections explain how to manage Developer Portal, Publisher, and the Admin Portal related user accounts.
 


### PR DESCRIPTION
### Purpose
Resolves #10598 
This PR adds a note to the `user-account-management.md` file. It clarifies that WSO2 API Manager does not support pure user management capabilities out-of-the-box and recommends using WSO2 Identity Server (IS) instead.

### Approach
I addressed the missing architectural guidance by performing the following changes:

* **Admonition Note:** Added a `!!! note` block to the top of `user-account-management.md` to highlight the limitation immediately.
* **Content Update:** Clarified that APIM does not support pure user management natively and explicitly recommended WSO2 Identity Server (IS) for this purpose.
* **Placement:** Inserted the note directly after the introduction to ensure high visibility before users attempt configuration.

### Learning
I learned about **Material for MkDocs** specific syntax, specifically how to use **Admonitions** (`!!! note`). I realized that while these tags look like plain text in the GitHub raw view, they are rendered as colored alert boxes in the final build of the WSO2 documentation site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent "User Management Recommendation" note advising that advanced user management is available via WSO2 Identity Server as the key manager, with a link to configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->