### PR TITLE
Docs: Update Oracle NLS_DATE_FORMAT configuration to prevent ORA-01830 errors

### DIFF
--- a/en/docs/use-cases/streaming-usecase/summarizing-data.md
+++ b/en/docs/use-cases/streaming-usecase/summarizing-data.md
@@ -78,8 +78,14 @@ Observe the following in the above Siddhi application:
     Also when using persisted aggregation with Oracle, add below configuration in the datasource configuration,
 
     ```
-    connectionInitSql: alter session set NLS_DATE_FORMAT='RRRR/fmMM/fmDD'
-       
+    connectionInitSql: alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'
+
+    ```
+    !!! note
+    If you encounter the error `ORA-01830: date format picture ends before converting entire input string`, use the following configuration instead:
+    `connectionInitSql: alter session set NLS_DATE_FORMAT='RRRR/fmMM/fmDD'`
+
+    ```
     eg:
        
      - name: APIM_ANALYTICS_DB
@@ -96,9 +102,10 @@ Observe the following in the above Siddhi application:
              maxPoolSize: 50
              idleTimeout: 60000
              connectionTestQuery: SELECT 1 FROM DUAL
-             connectionInitSql: alter session set NLS_DATE_FORMAT='RRRR/fmMM/fmDD'
+             connectionInitSql: alter session set NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'
              validationTimeout: 30000
              isAutoCommit: false
+    ```
                
     ```
     For an example please refer to the following query which will be executed on the database to update the table for below sample Aggregation ,


### PR DESCRIPTION
### Purpose
Resolves #9023 
The current `NLS_DATE_FORMAT` configuration (`YYYY-MM-DD HH24:MI:SS`) causes `ORA-01830` errors ("date format picture ends before converting entire input string") on certain Oracle database versions during aggregation.

### Changes
* Updated `connectionInitSql` in `summarizing-data.md` to use `alter session set NLS_DATE_FORMAT='RRRR/fmMM/fmDD'`.
* This format is more robust for persisted aggregations and prevents data mismatches.

### Learning
I learned that Oracle's `ORA-01830` error ("date format picture ends before converting entire input string") often occurs when the input data contains more precision or characters than the defined format mask expects.

Specifically, I discovered that switching to `'RRRR/fmMM/fmDD'` is more robust because:
* `RRRR` handles 2-digit years more intelligently (pivoting around the year 2000) compared to `YYYY`.
* The `fm` (Fill Mode) modifier suppresses leading zeros and padding blanks, preventing mismatches when the input string doesn't perfectly align with a fixed-width format like `MM` or `DD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Oracle persistence date format configuration for improved compatibility and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->