### PR TITLE
Add AWS Lambda connection pooling related configurations

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -17456,3 +17456,120 @@ queue_capacity = 50</code></pre>
     </section>
 </div>
 
+
+
+## API-M AWS Lambda Configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+
+            <input name="114" type="checkbox" id="_tab_114">
+                <label class="tab-selector" for="_tab_114"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[apim.aws_lambda.http_client]
+max_connections = 50
+connection_timeout = 10
+socket_timeout = 30
+connection_acquisition_timeout = 60
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.aws_lambda.http_client]</code>
+                            
+                            <p>
+                                 Configurations to tune the underlying HTTP connection pool settings used by each AWS Lambda client instance, to improve performance under high load.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>max_connections</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>100</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The maximum number of concurrent HTTP connections allowed per API resource. Increase this value if you expect high concurrent throughput to Lambda functions.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>connection_timeout</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>2</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The maximum time (in seconds) to wait when establishing a new TCP connection to AWS.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>socket_timeout</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>30</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The maximum time (in seconds) to wait for data to be transferred after a connection is established.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>connection_acquisition_timeout</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>30</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The maximum time (in seconds) to wait for a connection to become available from the pool if max_connections has been reached.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+

--- a/en/docs/tutorials/create-and-publish-awslambda-api.md
+++ b/en/docs/tutorials/create-and-publish-awslambda-api.md
@@ -146,3 +146,71 @@ When using AWS Lambda, you can execute your code without having to manage or pro
 2. Go to **Lifecycle** page and click on **PUBLISH** to publish the API to Developer Portal.
 
 You have successfully published the AWS Lambda API. Try invoking the Lambda API in the Developer Portal.
+
+## Configure Connection Pooling 
+
+You can fine-tune the underlying HTTP connection pool used by the **AWS Lambda client** to optimize performance under high load. 
+
+To configure the connection pooling, add the following configuration to the <code>&lt;API-M_HOME&gt;/repository/conf/deployment.toml</code> file.  For more information, see  [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+
+
+```toml
+[apim.aws_lambda.http_client]
+max_connections = 50
+connection_timeout = 10
+socket_timeout = 30
+connection_acquisition_timeout = 60
+```
+
+The elements in the above configuration are described below. If these values are not configured, the system will use the default settings.
+
+<table>
+  <thead>
+    <tr>
+      <th>Setting</th>
+      <th>Key</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><strong>Max Connections</strong></td>
+      <td><code>max_connections</code></td>
+      <td>
+        The maximum number of concurrent HTTP connections allowed in the pool.
+        Increase this value if you expect high concurrent throughput to Lambda functions.
+      </td>
+      <td>100</td>
+    </tr>
+
+    <tr>
+      <td><strong>Connection Timeout</strong></td>
+      <td><code>connection_timeout</code></td>
+      <td>The maximum time (in seconds) to wait when establishing a new TCP connection to AWS.</td>
+      <td>2 seconds</td>
+    </tr>
+
+    <tr>
+      <td><strong>Socket Timeout</strong></td>
+      <td><code>socket_timeout</code></td>
+      <td>The maximum time (in seconds) to wait for data to be transferred after a connection is established.</td>
+      <td>30 seconds</td>
+    </tr>
+
+    <tr>
+      <td><strong>Connection Acquisition Timeout</strong></td>
+      <td><code>connection_acquisition_timeout</code></td>
+      <td>
+        The maximum time (in seconds) to wait for a connection to become available from the pool
+        if <strong>Max Connections</strong> has been reached.
+      </td>
+      <td>30 seconds</td>
+    </tr>
+  </tbody>
+</table>
+
+!!! Note 
+    These configurations serve as the global settings for all AWS Lambda endpoints in the Gateway. However, please note that each API resource initializes its own independent **AWS Lambda client**. Therefore, the values defined here (such as <code>max_connections</code>) are applied per API resource, not as a server-wide aggregate limit.

--- a/en/tools/config-catalog-generator/data/apim.aws_lambda.http_client.toml
+++ b/en/tools/config-catalog-generator/data/apim.aws_lambda.http_client.toml
@@ -1,0 +1,5 @@
+[apim.aws_lambda.http_client]
+max_connections = 50
+connection_timeout = 10
+socket_timeout = 30
+connection_acquisition_timeout = 60

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6512,7 +6512,52 @@
             }
         ],
         "exampleFile": "synapse_artifact_generator_pool.toml"
-        }                                                                       
+        },
+        {
+        "title": "API-M AWS Lambda Configurations",
+        "options": [
+          {
+            "name": "apim.aws_lambda.http_client",
+            "required": false,
+            "description": " Configurations to tune the underlying HTTP connection pool settings used by each AWS Lambda client instance, to improve performance under high load.",
+            "params": [
+              {
+                "name": "max_connections",
+                "type": "integer",
+                "required": false,
+                "default": "100",
+                "possible": "",
+                "description": "The maximum number of concurrent HTTP connections allowed per AWS Lambda client instance. Increase this value if you expect high concurrent throughput to Lambda functions."
+              },
+              {
+                "name": "connection_timeout",
+                "type": "integer",
+                "required": false,
+                "default": "2",
+                "possible": "",
+                "description": "The maximum time (in seconds) to wait when establishing a new TCP connection to AWS."
+              },
+              {
+                "name": "socket_timeout",
+                "type": "integer",
+                "required": false,
+                "default": "30",
+                "possible": "",
+                "description": "The maximum time (in seconds) to wait for data to be transferred after a connection is established."
+              },
+              {
+                "name": "connection_acquisition_timeout",
+                "type": "integer",
+                "required": false,
+                "default": "30",
+                "possible": "",
+                "description": "The maximum time (in seconds) to wait for a connection to become available from the pool if max_connections has been reached."
+              }
+            ]
+          }
+        ],
+        "exampleFile": "apim.aws_lambda.http_client.toml"
+        }
     ]
 }
 


### PR DESCRIPTION
## Purpose

- This update documents the new Connection Pooling configuration support for the AWS Lambda mediator introduced via https://github.com/wso2/carbon-apimgt/pull/13561.  With these configurations users can fine-tune the underlying HTTP client via deployment.toml.

Changes included:
- Updated `Create and Publish an AWS Lambda API` guide with a new step for configuring connection pooling.
- Added `API-M AWS Lambda configurations` section to the `Configuration Catalog`  referencing the new `[apim.aws_lambda.http_client]` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Lambda HTTP client connection pool settings (max connections and timeouts) to allow tuning for high-load scenarios.

* **Documentation**
  * Added guidance and example configuration for the new connection-pooling options, including defaults and explanations for each setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->