### PR TITLE
Fix: Remove duplicate word in Kubernetes Pattern-0 docs [4.6.0]

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -235,7 +235,7 @@ In addition to the primary, internal keystores and truststore files, you can als
   sh cipher-tool.sh -Dconfigure
   ```
 - Also the apictl can be used to encrypt password as well. Reference can be found in [following](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/api-controller/encrypting-secrets-with-ctl/).
-- Then the encrypted values should be filled in the the relevant fields of values.yaml.
+- Then the encrypted values should be filled in the relevant fields of values.yaml.
 - Since internal keystore password is required to resolve the encrypted value in runtime, we need to store the value in the cloud provider's secret manager. You can use the cloud provider's secret store to store the password of the internal keystore. The following section can be used to add the cloud provider's credentials to fetch the internal keystore password. Configuration for aws can be at as below. 
   ```yaml
   internalKeystorePassword:


### PR DESCRIPTION
### Description
This PR fixes a small typo (duplicate word "the") in the Kubernetes Pattern-0 all-in-one documentation under the "Encrypting Secrets" section.

### Related Issue
Fixes #10656 

### Changes
- Removed the extra "the" in `am-pattern-0-all-in-one.md`.

### Affected Versions
- 4.6.0