### PR TITLE
Clarify default error response format across APIM versions

### DIFF
--- a/en/docs/troubleshooting/error-handling.md
+++ b/en/docs/troubleshooting/error-handling.md
@@ -1,6 +1,11 @@
 # Error Handling
 
 When errors/exceptions occur in the system, the API Manager throws JSON-based error responses to the client by default. 
+> **Note**
+> The default error response format in WSO2 API Manager depends on the product version.
+> Older versions (such as 4.0.0) return XML-based error responses by default,
+> while newer versions return JSON-based error responses.
+
 
 To change the format of these error responses, you change the relevant XML file in the `<API-M_HOME>/repository/deployment/server/synapse-configs/default/sequences` directory. The directory includes multiple XML files, named after the type of errors that occur. You must select the correct file.
 


### PR DESCRIPTION
This PR clarifies the default error response format behavior in WSO2 API Manager
by adding a version-specific note to the error handling documentation.

Older APIM versions (e.g., 4.0.0) return XML-based error responses by default,
while newer versions return JSON-based responses. This helps avoid confusion
when following the troubleshooting guide.

Fixes #10660

## Purpose
Clarify documentation to avoid confusion about default error response formats across APIM versions.
Resolves #10660.

## Goals
Improve accuracy and clarity of the error handling documentation by adding version-specific information.

## Approach
Added a concise note to the existing error handling documentation indicating version-dependent behavior.

## User stories
As a user following the troubleshooting guide, I want to understand why error responses differ between APIM versions.

## Release note
Documentation update clarifying version-dependent default error response formats.

## Documentation
Updated: Error Handling documentation in docs-apim repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that the default error response format in API Manager varies by product version: XML for older versions and JSON for newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->