### PR TITLE
Revert "Prepare docs for API-M 4.7.0 release"

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -1026,14 +1026,6 @@ html .md-typeset .superfences-tabs>label:hover {
     }
 }
 
-.beta-badge {
-    display: inline-block;
-    background: #ffd600;
-    font-size: 14px;
-    padding: 5px;
-    line-height: 1;
-}
-
 @media only screen and (min-width: 60em) {
     .md-sidebar--secondary {
         margin-left: 96%;

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -19,12 +19,12 @@
 site_name: WSO2 API Manager Documentation
 site_description: Documentation for WSO2 API Manager
 site_author: WSO2
-site_url: https://apim.docs.wso2.com/en/4.7.0/
+site_url: https://apim.docs.wso2.com/en/latest/
 
 # Repository
 repo_name: wso2/docs-apim
 repo_url: https://github.com/wso2/docs-apim
-edit_uri: https://github.com/wso2/docs-apim/edit/4.7.0/en/docs/
+edit_uri: https://github.com/wso2/docs-apim/edit/master/en/docs/
 dev_addr: localhost:8000
 
 # Copyright
@@ -1179,8 +1179,8 @@ extra:
         helm_chart:
             version: 1.2.0-1
             git_tag: v1.2.0.1
-    site_version: 4.7.0
+    site_version: 4.6.0
     # base_path: http://localhost:8000/en/latest
-    base_path: https://apim.docs.wso2.com/en/4.7.0
+    base_path: https://apim.docs.wso2.com/en/latest
     envoy_path: https://www.envoyproxy.io/docs/envoy/v1.24.1
     

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -35,7 +35,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            {{ config.site_name | replace('WSO2', '') }} <span class="beta-badge">This documentation is a work in progress.</span>
+            {{ config.site_name | replace('WSO2', '') }}
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">


### PR DESCRIPTION
Reverts wso2/docs-apim#10714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the beta badge indicator from the documentation header
  * Updated documentation URL structure to serve from the latest version path instead of a specific version
  * Updated version metadata to 4.6.0
  * Modified documentation edit links to reference the master branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->