### PR TITLE
Fix minor typo and unify Markdown table formatting

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -1,6 +1,6 @@
 # About this Release
 
-WSO2 API Manager is a complete platform for building, integrating, and exposing your digital services as managed APIs in the cloud, on-premise, and hybrid architectures to drive your digital transformation strategy. It comes with a cloud-native, standards-based messaging engine, and an integration framework for integrating APIs, services, data, SaaS, proprietary, and legacy systems and it can also serve streaming-based integrations. The product comes with command-line and developer tools that enable easy design, development, and testing.
+WSO2 API Manager is a complete platform for building, integrating, and exposing your digital services as managed APIs in the cloud, on-premise, and hybrid architectures to drive your digital transformation strategy. It comes with a cloud-native, standards-based messaging engine, and an integration framework for integrating APIs, services, data, SaaS, proprietary, and legacy systems. It can also serve streaming-based integrations. The product comes with command-line and developer tools that enable easy design, development, and testing.
 
 **WSO2 API Manager 4.6.0** is the latest **WSO2 API Manager release** and is the successor of **WSO2 API Manager 4.5.0**.
 
@@ -52,7 +52,7 @@ For more information on WSO2 API Manager, see the [overview]({{base_path}}/get-s
 
 ??? note "API Discovery support for Federated Gateways"
 
-    WSO2 API Manager 4.6.0 release introduces the API discovery support for Federated Gateways. The allows organizations to manage APIs deployed in multiple third-party gateways through a unified control plane. Gateways supported in this release include:
+    WSO2 API Manager 4.6.0 release introduces the API discovery support for Federated Gateways. This allows organizations to manage APIs deployed in multiple third-party gateways through a unified control plane. Gateways supported in this release include:
 
     - [AWS API Gateway]({{base_path}}/manage-apis/deploy-and-publish/federated-gateways/aws/discover-apis-on-aws-api-gateway/)
     - [Azure API Gateway]({{base_path}}/deploy-and-publish/federated-gateways/azure/discover-apis-on-azure-api-gateway/)

--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -76,7 +76,7 @@ Follow the instructions below to create, deploy and publish an API via the Publi
     | `Charset`               | UTF-8                 |
     | `HTTP Response Body`    | `{"hello": "world"}`  |
 
-    Finally click **Generate My HTTP Response** to save and generate the mock service url.
+    Finally, click **Generate My HTTP Response** to save and generate the mock service URL.
 
     
 4. Select **REST API** from the home screen and then click **Start From Scratch**.
@@ -86,42 +86,14 @@ Follow the instructions below to create, deploy and publish an API via the Publi
 
 5. Enter the API details.
 
-    <table>
-    <tr> 
-     <th>
-     Name
-     </th>
-     <td>
-     HelloWorld
-     </td>
-     </tr>
-     <tr>
-     <th>
-     Display Name
-     </th>
-     <td>
-     Hello World
-     </td>
-     </tr>
-     <tr> 
-     <th>Context
-     </th>
-     <td><code>/hello</code>
-     </td>
-     </tr>
-     <tr> 
-     <th>Version
-     </th>
-     <td>1.0.0
-     </td>
-     </tr>
-     <tr> 
-     <th>Endpoint
-     </th>
-     <td><code>https://run.mocky.io/v3/e42a76f0-95f3-4759-b658-dcc2b0c8bacd</code>
-     </td>
-     </tr>
-     </table>
+    | Field        | Value                                                                 |
+    | ------------ | --------------------------------------------------------------------- |
+    | Name         | HelloWorld                                                             |
+    | Display Name | Hello World                                                            |
+    | Context      | `/hello`                                                               |
+    | Version      | 1.0.0                                                                  |
+    | Endpoint     | `https://run.mocky.io/v3/e42a76f0-95f3-4759-b658-dcc2b0c8bacd`         |
+
      
 6. Click **Create & Publish**.
 
@@ -145,7 +117,7 @@ Follow the instructions below to subscribe to the API via the Developer Portal o
 
 2. Click **Sign-In** and enter **`admin/admin`** as your credentials to sign in to the Developer Portal.
 
-3. Once you click on the HelloWorld API, you will be redirected to  the API overview page. Then, go ahead and click on the **TRY OUT** button.
+3. Once you click on the HelloWorld API, you will be redirected to the API overview page. Then, go ahead and click on the **TRY OUT** button.
 
      [![API try out]({{base_path}}/assets/img/get_started/try-out.png)]({{base_path}}/assets/img/get_started/try-out.png)
 

--- a/en/docs/get-started/apim-architecture.md
+++ b/en/docs/get-started/apim-architecture.md
@@ -1,6 +1,6 @@
 # Architecture and Key Components
 
-The diagram below is a high-level snapshot of WSO2 API Manager and the various components that it can work together with. 
+The diagram below is a high-level snapshot of WSO2 API Manager and the various components that it can works with. 
 
 [![Basic Architecture]({{base_path}}/assets/img/get_started/architecture/apim-architecture-final.png)]({{base_path}}/assets/img/get_started/architecture/apim-architecture-final.png)
 
@@ -8,7 +8,7 @@ The diagram below is a high-level snapshot of WSO2 API Manager and the various c
 
 ## API Control Plane
 
-The API Control Plane is where API creation and API management takes place. It consists of portals (Publisher, Developer Portal and Service Catalog) for users to create and manage APIs, implement rate limiting policies, monitor, and monetize etc. The API Control Plane consists of a Key manager component for API security validation and API key generation. It also provides a set of APIs to interact with external tools like API Controller. The API Control Plane includes API Analytics dashboards, displaying various business insights.
+The API Control Plane is where API creation and API management takes place. It consists of portals (Publisher, Developer Portal and Service Catalog) for users to create and manage APIs, implement rate limiting policies, monitor, and monetize. The API Control Plane consists of a Key Manager component for API security validation and API key generation. It also provides a set of APIs to interact with external tools like API Controller. The API Control Plane includes API Analytics dashboards, displaying various business insights.
 
 #### API Publisher
 
@@ -36,11 +36,11 @@ These integration services can be created using WSO2 Integration Studio and a va
 
 The Key Manager is the identity provider for WSO2 API Control Plane and acts as the Secure Token Service (STS). WSO2 API Control Plane supports OAuth 2.0, Basic Auth, Mutual SSL as well as API-Key based authentication mechanisms. 
  
-In WSO2 API Control Plane, tokens are generated for an application. The Key manager provides a token API to generate access tokens. These tokens can be used by clients to invoke APIs exposed by WSO2 API Control Plane. The Key Manager also exposes a revoke token API that clients can use to revoke an access token. A client can generate an OAuth 2.0 access token by invoking the token API directly or via the Developer Portal UI. Alternatively, an API Key can be generated through the Developer Portal without calling the Key Manager. The API Key is a self-signed JWT token. When a client invokes an API with an OAuth 2.0 access token or an API Key, the Gateway validates the token by validating its signature and subscription.
+In WSO2 API Control Plane, tokens are generated for an application. The Key Manager provides a token API to generate access tokens. These tokens can be used by clients to invoke APIs exposed by WSO2 API Control Plane. The Key Manager also exposes a revoke token API that clients can use to revoke an access token. A client can generate an OAuth 2.0 access token by invoking the token API directly or via the Developer Portal UI. Alternatively, an API Key can be generated through the Developer Portal without calling the Key Manager. The API Key is a self-signed JWT token. When a client invokes an API with an OAuth 2.0 access token or an API Key, the Gateway validates the token by validating its signature and subscription.
  
 The Key Manager performs scope validation as well. It could also generate JWT tokens to pass end-user attributes to the backend, if configured. 
  
-In addition to using the built-in Key Manager as the IDP, WSO2 API Control Plane also supports integrating with third-party identity providers such as Okta, Auth0, KeyCloak, etc., for OAuth 2.0 based security for APIs.
+In addition to using the built-in Key Manager as the IDP, WSO2 API Control Plane also supports integrating with third-party identity providers such as Okta, Auth0, Keycloak, etc., for OAuth 2.0 based security for APIs.
 
 #### API Analytics
 
@@ -50,7 +50,7 @@ In addition to using the built-in Key Manager as the IDP, WSO2 API Control Plane
 
 ## Data Plane
 
-The Data Plane is where the created API is exposed to the public consumers and acts as the proxy for API calls. This also provides additional capabilities such as enforcing security, rate limiting etc. 
+The Data Plane is where the created API is exposed to the public consumers and acts as the proxy for API calls. This also provides additional capabilities such as enforcing security, rate limiting, etc. 
 
 #### Universal Gateway
 
@@ -64,15 +64,15 @@ Once the token is validated, the Universal Gateway acts upon the API request bef
 
 #### Kubernetes Gateway
 
-WSO2 Kubernetes Gateway is WSO2's cloud native API management platform. It is designed to help you build, deploy, and manage APIs in a cloud environment. This is built on top of a microservices architecture and uses containerization technologies to ensure scalability and flexibility. With features like automatic failover and load balancing, this platform is designed to be highly available and able to handle large numbers of API requests without performance degradation. There is added support for continuous delivery and deployment, so you can quickly and easily push updates to your API services. 
+WSO2 Kubernetes Gateway is WSO2's cloud-native API management platform. It is designed to help you build, deploy, and manage APIs in a cloud environment. This is built on top of a microservices architecture and uses containerization technologies to ensure scalability and flexibility. With features like automatic failover and load balancing, this platform is designed to be highly available and able to handle large numbers of API requests without performance degradation. There is added support for continuous delivery and deployment, so you can quickly and easily push updates to your API services. 
 
-Please refer the WSO2 Kubernetes Gateway [Quick Start Guide](https://apk.docs.wso2.com/en/1.3.0/get-started/quick-start-guide/) for trying out the product.
+Please refer to the WSO2 Kubernetes Gateway [Quick Start Guide](https://apk.docs.wso2.com/en/1.3.0/get-started/quick-start-guide/) for trying out the product.
 
 #### Immutable Gateway
 
 Being an API Gateway for micro services, which is cloud-native, decentralized and developer centric, the WSO2 Immutable Gateway is a lightweight message processor for APIs. The Immutable Gateway is used for message security, transport security, routing, and other common API Management related quality of services.
 
-Please refer the WSO2 Immutable Gateway [documentation](https://mg.docs.wso2.com/en/latest/) for more details.
+Please refer to the WSO2 Immutable Gateway [documentation](https://mg.docs.wso2.com/en/latest/) for more details.
  
 ## Traffic Manager
  

--- a/en/docs/get-started/deployment-patterns.md
+++ b/en/docs/get-started/deployment-patterns.md
@@ -1,6 +1,6 @@
 # Deployment Patterns
 
-A deployment pattern refers to the architecture you use to run WSO2 API Manager's components. The pattern you choose determines how the system handles load, scales, and ensures high availability. These patterns are independent of the underlying platform; you can use any of them on both Virtual Machines and Kubernetes.
+A deployment pattern refers to the architecture used to run WSO2 API Manager components. The pattern you choose determines how the system handles load, scales, and ensures high availability. These patterns are independent of the underlying platform; you can use any of them on both Virtual Machines and Kubernetes.
 
 The patterns can be grouped into three main categories: **All-in-One**, **Distributed**, and **Multi-Datacenter**.
 
@@ -43,13 +43,13 @@ Distributed patterns separate WSO2 API Manager into distinct component distribut
 The main component distributions are:
 
 *   **WSO2 API Control Plane (ACP)**: Includes the Key Manager, Publisher Portal, and Developer Portal for API creation, management, and governance.
-*   **WSO2 Universal Gateway**: The proxy that handles API traffic, enforces security policies, and gathers statistics. Only starts the components related to the API Gateway.
+*   **WSO2 Universal Gateway**: The proxy that handles API traffic, enforces security policies, and gathers statistics. Starts only the components related to the API Gateway.
 *   **WSO2 Traffic Manager**: Manages rate limiting and traffic policies for the gateways. Only starts the Traffic Manager component. 
 
 
 ### Databases used by API-M Component Distributions
 
-When you run the different distributions of API-M, databases are used as shown below.
+When you run the different API-M distributions, the databases used are shown below.
 
 <table>
 <thead>
@@ -91,7 +91,7 @@ database</strong></p>
 
 ### API-M Components
 
-Listed below are the five main components in the API-M server. When you run the recommended API-M component distributions, the components (from the below list) that are required for operating the functionalities related to each distribution are used.
+Listed below are the five main components of the API-M server. When you run the recommended API-M component distributions, the components (from the below list) that are required for operating the functionalities related to each distribution are used.
 
 <table>
     <tr>
@@ -144,7 +144,7 @@ Listed below are the five main components in the API-M server. When you run the 
     </tr>
 </table>
 
-In a typical distributed deployment, you only have the WSO2 API Control Plane, WSO2 Universal Gateway and WSO2 Traffic Manager distributions running as separate nodes. However, you have the option of separating the Key Manager from the WSO2 API Control Plane. With this, there are few patterns under which we can configure a distributed deployment for API-M. They are as follows.
+In a typical distributed deployment, you only have the WSO2 API Control Plane, WSO2 Universal Gateway, and WSO2 Traffic Manager distributions running as separate nodes. However, you have the option of separating the Key Manager from the WSO2 API Control Plane. In this case, there are a few patterns under which you can configure a distributed deployment for API-M. They are as follows.
 
 ---
 ### Pattern 2: Simple Scalable Deployment
@@ -203,7 +203,7 @@ This is a variation of Pattern 2 where the Gateway and Key Manager are separated
 ### Pattern 6: API-M Deployment with IS as Key Manager
 
 *   **Description**: Deployment with WSO2 Identity Server (IS) as the Key Manager
-*   **Use Case**: Using WSO2 Identity Server as third-party Key Manager for API Manager
+*   **Use Case**: Using WSO2 Identity Server as a third-party Key Manager for API Manager
 *   **Components**: All-in-one, WSO2 Identity Server
 
 > **View the Configuration Guides for Pattern 6:** [Deploy on VMs]({{base_path}}/api-security/key-management/third-party-key-managers/configure-wso2is7-connector) or [Deploy on Kubernetes]({{base_path}}/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km)


### PR DESCRIPTION
This PR addresses a couple of minor issues in the Quick Start Guide Markdown file:

1. Corrected a small typo for clarity.
2. Updated the API details table to use consistent Markdown formatting, matching the existing mock service table style.

These changes improve readability and ensure the Markdown renders consistently across different platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded supported Federated Gateways list to include Kong Gateway (Kubernetes & Standalone) and Envoy Gateway.
  * Reformatted the API quick start guide with a compact, consistent table for API details and corrected "mock service URL" wording.
  * Reworded introductory text and fixed grammar, punctuation, and whitespace inconsistencies across get-started docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->