### PR TITLE
[4.3.0] Updating wire log enabling instructions

### DIFF
--- a/en/docs/administer/logging-and-monitoring/logging/configuring-logging.md
+++ b/en/docs/administer/logging-and-monitoring/logging/configuring-logging.md
@@ -189,14 +189,14 @@ The following is a sample Gateway Wire Log for an API request.
 ### Enabling the Gateway Wire Logs
 
 1. Open the `<API-M_HOME>/repository/conf/log4j2.properties` file.
-2. Locate the `synapse-wire` logger, which is already defined in the default `log4j2.properties` file.
+2. To enable Gateway Wire Logs, locate the pre-defined `synapse-wire` logger in the default `log4j2.properties` file and uncomment the following lines:
 
      ``` 
      logger.synapse-wire.name = org.apache.synapse.transport.http.wire
-      logger.synapse-wire.level = DEBUG
-    ```
+     logger.synapse-wire.level = DEBUG
+     ```
 
-     You can use the `synapse-headers` logger to log the request and response headers only.
+     To log only request and response headers, uncomment the `synapse-headers` logger in the default `log4j2.properties` file:
     
      ``` 
      logger.synapse-headers.name = org.apache.synapse.transport.http.headers


### PR DESCRIPTION
## Purpose

This PR updates the gateway wire log enabling instructions following the changes to log4j2.properties file.

## Related issues

- https://github.com/wso2-enterprise/wso2-apim-internal/issues/15304
