### PR TITLE
Add note about delivery semantics for shared topic subscriptions

### DIFF
--- a/en/docs/integrate/examples/jms_examples/shared-topic-subscription.md
+++ b/en/docs/integrate/examples/jms_examples/shared-topic-subscription.md
@@ -7,6 +7,9 @@ With the shared subscription feature in JMS 2.0, you can overcome this restrict
 
 The Micro Integrator can be configured as a shared topic listener that can connect to a shared topic subscription as a message consumer (subscriber) to share workload between other consumers of the subscription.
 
+!!!Note
+    Support for shared topic subscriptions depends on the capabilities of the underlying message broker implementation. Some brokers implement topic subscriptions with different delivery semantics (for example, treating subscriptions as queues with competing consumers). Therefore, it is recommended to check the broker documentation to confirm whether shared subscriptions are supported and how they behave.
+
 To demonstrate the sample scenario, let's configure the JMS inbound endpoint in WSO2 Micro Integrator as a shared topic listener using HornetQ as the message broker.
 
 ## Synapse configurations


### PR DESCRIPTION
## Purpose

Add note about delivery semantics for shared topic subscriptions

<img width="1391" height="648" alt="Screenshot 2026-03-05 at 07 39 59" src="https://github.com/user-attachments/assets/304c34f3-d07f-49d9-8943-10cac2d02461" />
