### PR TITLE
Add missing PATH export for OS X installation

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -34,6 +34,7 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
              
         On OS X:
         export JAVA_HOME=/System/Library/Java/JavaVirtualMachines/11.0.x.jdk/Contents/Home
+        export PATH=${JAVA_HOME}/bin:${PATH}
         ```
 
     3.  Save the file.


### PR DESCRIPTION
## Description
The installation instructions in Step 2 state to "add the following two lines" but the OS X section only included the JAVA_HOME export, missing the PATH export that was present in the Linux section.

## Changes Made
- Added `export PATH=${JAVA_HOME}/bin:${PATH}` to the OS X installation instructions
- This ensures OS X users have complete setup instructions matching the Linux instructions

## Impact
Without this line, OS X users following the documentation would set JAVA_HOME but not update their PATH, causing Java commands to potentially fail.

Fixes incomplete installation instructions for OS X users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to provide consistent PATH configuration instructions for macOS users, aligning with existing guidance for Linux users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->