### PR TITLE
Fix: Enable image lightbox to prevent users from navigating away from documentation pages [Resolves #10924]

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -813,6 +813,7 @@ plugins:
         lang: ['en']
         prebuild_index: true
         ngram_length: 3
+    - glightbox
     - markdownextradata: {}
     - exclude:
           glob:


### PR DESCRIPTION
## Purpose
Resolves #10924

Currently, clicking on an image in the documentation opens the raw image file directly in the browser tab. This creates a poor user experience, as users are forced to use the browser's "Back" button to return to the guide, which breaks their reading flow and often causes them to lose their scroll position.

## Goals
Improve the documentation user experience by enabling a native lightbox overlay for all images so that users can view images in an enlarged format without leaving the documentation page.

## Approach
The `mkdocs-glightbox` package is already included in the project's `requirements.txt`.  
This change enables the `glightbox` plugin in the `mkdocs.yml` configuration file.

With this configuration, clicking an image now opens it in a full-screen modal lightbox. The overlay can be closed by clicking outside the image or pressing the **Esc** key, allowing users to continue reading without losing their position.

## User stories
As a documentation reader, I want to click on images and diagrams to view them in a larger overlay format so that I can clearly see the details without losing my place in the documentation.

## Release note
Improved documentation user experience by enabling a lightbox overlay for images.

## Documentation
N/A – This change updates the documentation site configuration and does not introduce new product functionality.

## Training
N/A

## Certification
N/A – No impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests  
  N/A

- Integration tests  
  N/A

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**  
- Ran FindSecurityBugs plugin and verified report? **N/A**  
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested locally using `mkdocs serve` to verify that images open in the lightbox overlay correctly and that the documentation builds without warnings.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration with the glightbox plugin to enhance image handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->