### PR TITLE
Fix documentation word- API Manager best practices line 21. Previousl…

### DIFF
--- a/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
+++ b/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
@@ -1,4 +1,4 @@
-# Marketplace Assistant Getting Started Guide
+s# Marketplace Assistant Getting Started Guide
 
 The Marketplace Assistant is a powerful tool provided by API Manager, utilizing AI to chat with your APIs and offer recommendations, moving beyond traditional keyword searches. Using this you can access role-restricted APIs in addition to the public APIs defined according to the [developer portal visibility]({{base_path}}/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/#control-api-visibility-in-the-developer-portal).
 

--- a/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
+++ b/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
@@ -125,11 +125,11 @@ This message indicates that the request you made has exceeded the allowed token 
 
 **8. I am getting this error response: Apologies for the inconvenience. `It appears that your token is invalid or expired. Please provide a valid token or upgrade your subscription plan `**
 
-This message suggests that your on-prem key is not valid or it is expired. You can request an extended trial period or you can upgrade your subscription plan so that you can seamlessly use Marketplace Assistant
+This message suggests that your on-prem key is not valid or it is expired. You can request an extended trial period or you can upgrade your subscription plan so that you can seamlessly use Marketplace Assistant.
 
 **9. I am getting this error response: Apologies for the inconvenience. `It seems that something went wrong with the Marketplace Assistant. Please try again later `**
 
-This message signifies that an unexpected error has occurred. It could be due to various reasons such as server issues, network problems, etc. Kindly reach out to the administrator for assistance in resolving the problem,
+This message signifies that an unexpected error has occurred. It could be due to various reasons such as server issues, network problems, etc. Kindly reach out to the administrator for assistance in resolving the problem.
 
 **10. What type of questions I can ask from Marketplace Assistant:**
 

--- a/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
+++ b/en/docs/api-developer-portal/discover-apis/marketplace-assistant.md
@@ -1,4 +1,4 @@
-s# Marketplace Assistant Getting Started Guide
+# Marketplace Assistant Getting Started Guide
 
 The Marketplace Assistant is a powerful tool provided by API Manager, utilizing AI to chat with your APIs and offer recommendations, moving beyond traditional keyword searches. Using this you can access role-restricted APIs in addition to the public APIs defined according to the [developer portal visibility]({{base_path}}/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/#control-api-visibility-in-the-developer-portal).
 

--- a/en/docs/reference/wso2-api-manager-best-practices.md
+++ b/en/docs/reference/wso2-api-manager-best-practices.md
@@ -18,7 +18,7 @@ Here are the guidelines and recommendations to design and deploy APIs using WSO2
 
 #### Proper Naming APIs
 
-It's important to have proper names for services and service paths. For example, if you create an API related to camera-related operations, you can select a name with camera-related terms such a “camera-api”. When you create a resource for the API, you can select names such as “capture-image”, “delete-image”. Resources must be named properly through URIs (Uniform Resource Identifiers). Proper naming of resources is key to increase the understandability of an API to its users.
+It's important to have proper names for services and service paths. For example, if you create an API related to camera-related operations, you can select a name with camera-related terms such as “camera-api”. When you create a resource for the API, you can select names such as “capture-image”, “delete-image”. Resources must be named properly through URIs (Uniform Resource Identifiers). Proper naming of resources is key to increase the understandability of an API to its users.
 
 Following are some of the guidelines for designing proper API/Resource paths and names. Note that these are not mandatory rules but best practices.
 


### PR DESCRIPTION
Commit 1 - Spelling mistake noted in the API Manager Best Practices. Fixed that and locally tested. 

Commit 2 - Standardized punctuation in two FAQ responses in Marketplace Assistant for consistent style and readability.

Commit 3 - Code Rabbit detected a s component in the heading of Marketplace Assistant (probably something I mistakenly added when I did the changes for spelling and grammar) So fixed that. 

