### PR TITLE
Add documentation and configuration for SnakeYAML dependency properties

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -373,6 +373,17 @@ A randomly generated string of at least 32 characters is recommended. You can ge
 It is highly recommended to encrypt this secret using the secure vault. See <a href="{{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/">Encrypting Passwords in Configuration Files</a> for instructions.
 </p>
 </td>
+</tr>>
+<tr class="odd">
+<td><p>Override codepoint limit of SnakeYAML Dependency</p>
+<p><br />
+</p></td>
+<td>The default codepoint limit of SnakeYAML Dependency is 3,145,728 (~3MB), which is set to avoid exposing the system to DoS attacks via large malicious files. By default, API-M uses this default limit. However, the <a href="{{base_path}}/reference/config-catalog/#dependency-configurations">dependency configuration</a> of SnakeYAML Dependency can be overridden using the following configuration:
+<pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10 # size in MB
+</code></pre>
+In a production environment, it is strongly recommended to set this value according to your file size requirements and security policies to mitigate potential security risks. You do not need to set this value by default; configure it only if you encounter a SnakeYAML codepoint limit issue.
+</td>
 </tr>
 </tbody>
 </table>

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -17185,3 +17185,60 @@ same_site_cookies = "lax"
     </section>
 </div>
 
+
+
+## Dependency Configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="117" type="checkbox" id="_tab_117">
+                <label class="tab-selector" for="_tab_117"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[dependency_properties]</code>
+                            
+                            <p>
+                                This includes configurations for dependency related properties.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>snakeyaml.max_file_size_limit</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>This sets the maximum file size (in MB) for YAML files processed by SnakeYAML during API definition import/export operations. Overrides the default codepoint limit of 3,145,728 characters (~3MB) to support larger YAML OpenAPI files. The system calculates the actual codepoint limit using the formula: configured_value × 4 × 1024 × 1024 (e.g., 10 MB = 41,943,040 codepoints). Increasing this value may expose the system to DoS attacks via large malicious files - configure based on actual requirements and security policies.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6519,6 +6519,27 @@
                 }
             ],
             "exampleFile": "web_app.cookie_processor.toml"
+        },
+        {
+            "title": "Dependency Configurations",
+            "options": [
+                {
+                    "name": "dependency_properties",
+                    "required": false,
+                    "description": "This includes configurations for dependency related properties.",
+                    "params": [
+                        {
+                            "name": "snakeyaml.max_file_size_limit",
+                            "type": "integer",
+                            "required": false,
+                            "default": "",
+                            "possible": "",
+                            "description": "This sets the maximum file size (in MB) for YAML files processed by SnakeYAML during API definition import/export operations. Overrides the default codepoint limit of 3,145,728 characters (~3MB) to support larger YAML OpenAPI files. The system calculates the actual codepoint limit using the formula: configured_value × 4 × 1024 × 1024 (e.g., 10 MB = 41,943,040 codepoints). Increasing this value may expose the system to DoS attacks via large malicious files - configure based on actual requirements and security policies."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "dependency_properties.toml"
         }
     ]
 }

--- a/en/tools/config-catalog-generator/data/dependency_properties.toml
+++ b/en/tools/config-catalog-generator/data/dependency_properties.toml
@@ -1,0 +1,2 @@
+[dependency_properties]
+'snakeyaml.max_file_size_limit' = 10


### PR DESCRIPTION
### Purpose

This pull request introduces documentation and configuration updates to support overriding the default codepoint limit for the SnakeYAML dependency, which is used for processing YAML files. The changes provide guidance and configuration options for increasing the file size limit when importing/exporting large OpenAPI YAML files, while emphasizing the security implications of such changes.

Key changes include:

**Documentation updates:**

* Added a new section in the deployment security guidelines explaining the default SnakeYAML codepoint limit, how to override it using the `snakeyaml.max_file_size_limit` property, and the associated security considerations.
* Updated the configuration catalog documentation to include a "Dependency Configurations" section, detailing the `snakeyaml.max_file_size_limit` property, its purpose, calculation, and security risks.

**Configuration support:**

* Extended the config catalog generator data (`configs.json`) to document the new `dependency_properties` section and the `snakeyaml.max_file_size_limit` parameter, including its description and usage.
* Added an example TOML configuration file (`dependency_properties.toml`) demonstrating how to set the `snakeyaml.max_file_size_limit` property.

### Related PR
- https://github.com/wso2/docs-apim/pull/11009