### PR TITLE
[4.7.0] Update Database Change Documentation to Enforce Case Sensitivity and give informations about UTF8 handling

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -104,8 +104,8 @@ Before you begin, ensure you have the following prerequisites in place:
 
 - An example for MySQL is provided below:
   ```sql
-  CREATE DATABASE apim_db CHARACTER SET latin1;
-  CREATE DATABASE shared_db CHARACTER SET latin1;
+  CREATE DATABASE apim_db CHARACTER SET latin1 COLLATE latin1_bin;
+  CREATE DATABASE shared_db CHARACTER SET latin1 COLLATE latin1_bin;
   ```
   ```bash
   mysql -h <DB_HOST> -P 3306 -u sharedadmin -p -Dshared_db < './dbscripts/mysql.sql'
@@ -416,4 +416,3 @@ hostnames and the external IP in the `/etc/hosts` file on the client side.
 - API Manager DevPortal: `https://<kubernetes.ingress.management.hostname>/devportal`
 - API Manager Carbon Console: `https://<kubernetes.ingress.management.hostname>/carbon`
 - Universal Gateway: `https://<kubernetes.ingress.gateway.hostname>`
-

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -127,8 +127,8 @@ Before you begin, ensure you have the following prerequisites in place:
 
 - An example for MySQL is provided below:
   ```sql
-  CREATE DATABASE apim_db CHARACTER SET latin1;
-  CREATE DATABASE shared_db CHARACTER SET latin1;
+  CREATE DATABASE apim_db CHARACTER SET latin1 COLLATE latin1_bin;
+  CREATE DATABASE shared_db CHARACTER SET latin1 COLLATE latin1_bin;
 
   GRANT ALL ON apim_db.* TO 'apimadmin'@'%';
 
@@ -583,4 +583,3 @@ hostnames and the external IP in the `/etc/hosts` file on the client side:
 - API Manager Carbon Console: `https://<kubernetes.ingress.management.hostname>/carbon`
 
 - Universal Gateway: `https://<kubernetes.ingress.gateway.hostname>`
-

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -148,8 +148,8 @@ Before you begin, ensure you have the following prerequisites in place:
 
 - An example for MySQL is provided below.
   ```sql
-  CREATE DATABASE apim_db CHARACTER SET latin1;
-  CREATE DATABASE shared_db CHARACTER SET latin1;
+  CREATE DATABASE apim_db CHARACTER SET latin1 COLLATE latin1_bin;
+  CREATE DATABASE shared_db CHARACTER SET latin1 COLLATE latin1_bin;
 
   GRANT ALL ON apim_db.* TO 'apimadmin'@'%';
 
@@ -599,4 +599,3 @@ If the defined hostnames are not backed by a DNS service, for the purpose of eva
 - API Manager Carbon Console: `https://<kubernetes.ingress.management.hostname>/carbon`
 
 - Universal Gateway: `https://<kubernetes.ingress.gateway.hostname>`
-

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -147,8 +147,8 @@ Before you begin, ensure you have the following prerequisites in place:
 
 - An example for MySQL is provided below.
   ```sql
-  CREATE DATABASE apim_db CHARACTER SET latin1;
-  CREATE DATABASE shared_db CHARACTER SET latin1;
+  CREATE DATABASE apim_db CHARACTER SET latin1 COLLATE latin1_bin;
+  CREATE DATABASE shared_db CHARACTER SET latin1 COLLATE latin1_bin;
 
   GRANT ALL ON apim_db.* TO 'apimadmin'@'%';
 
@@ -638,4 +638,3 @@ If the defined hostnames are not backed by a DNS service, for the purpose of eva
 - API Manager Carbon Console: `https://<kubernetes.ingress.management.hostname>/carbon`
 
 - Universal Gateway: `https://<kubernetes.ingress.gateway.hostname>`
-

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -150,8 +150,8 @@ If you need to customize the Docker images (e.g., adding JDBC drivers, custom li
 
 - An example for MySQL is provided below:
   ```sql
-  CREATE DATABASE apim_db CHARACTER SET latin1;
-  CREATE DATABASE shared_db CHARACTER SET latin1;
+  CREATE DATABASE apim_db CHARACTER SET latin1 COLLATE latin1_bin;
+  CREATE DATABASE shared_db CHARACTER SET latin1 COLLATE latin1_bin;
 
   GRANT ALL ON apim_db.* TO 'apimadmin'@'%';
 
@@ -657,4 +657,3 @@ After completing the deployment and DNS configuration, you can access the manage
 
 !!! tip "Default Credentials"
     The default username is `admin` with password `admin`. For production environments, change these credentials immediately after first login.
-

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-ibm-db2.md
@@ -14,6 +14,9 @@ The following sections describe how to set up a IBM DB2 database to replace the 
 
 Follow the instructions below to set up a IBM DB2 database:
 
+!!! important "Character Set and Collation"
+    IBM DB2 uses **UTF-8 encoding** and **case-sensitive comparison** by default. It is **required** to maintain your DB2 database with case-sensitive comparison to preserve product behaviors.
+
 1. Create the database using the following command:
    ```sh
    db2 CREATE DATABASE <DATABASE_NAME>

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mssql.md
@@ -33,6 +33,19 @@ Follow the steps below to set up the Microsoft SQL database and users.
 
 1.  Open the Microsoft SQL Management Studio to create a database and user.
 1.  Click **New Database** from the **Database** menu and specify all the options to create a new database.
+
+    !!! important "Case-Sensitive Collation Requirement"
+        WSO2 API Manager **requires** a case-sensitive database collation for correct operation. When creating the database, ensure you select a **case-sensitive (CS) collation**. The default MSSQL collation (`SQL_Latin1_General_CP1_CI_AS`) is case insensitive and **must not** be used.
+
+        For fresh setups, set the collation to a case-sensitive one such as `Latin1_General_CS_AS`:
+
+        ```sql
+        CREATE DATABASE <DATABASE_NAME> COLLATE Latin1_General_CS_AS;
+        ```
+
+    !!! note
+        UTF-8 encoding is **not supported** for MSSQL databases used with WSO2 API Manager.
+
 1.  Click **New Login** from the **Logins** menu, and specify all the necessary options.
 
 ### Eliminate concurrency issues in tables

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -44,29 +44,19 @@ Follow the  instructions below to set up a MySQL database:
 
 1.  When prompted, specify the password that will be used to access the databases with the username you specified.
 
-1.  In the MySQL command prompt, create the database.
+1.  In the MySQL command prompt, create the database using a **case-sensitive collation**.
 
-    ``` java
-    CREATE DATABASE <DATABASE_NAME>;
+    !!! important "Case-Sensitive Collation Requirement"
+        WSO2 API Manager **requires** a case-sensitive database collation. The default collation in MySQL 8.0+ is `utf8mb4_0900_ai_ci`, which is **case insensitive** and **must not** be used. Using a case-insensitive collation can lead to data integrity issues.
+
+    For **fresh setups**, it is mandatory to use a **case-sensitive collation** such as `utf8mb4_bin` or `latin1_bin`:
+
+    ``` sql
+    CREATE DATABASE <DATABASE_NAME> CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
     ```
-        
-    !!! warning
-        When creating the database related to apim_db with MySQL 8.0, add **character set latin1** to avoid the MySQL Linux ERROR 1071 (42000).
-        ```sh
-        CREATE DATABASE <APIM_DATABASE_NAME> character set latin1;
-        ```
 
-    !!! info
-        Character Sets and Collations in MySQL
-    
-        - For users of Microsoft Windows, when creating the database in MySQL, it is important to specify the character set as latin1. Failure to do this may result in an error (error code: 1709) when starting your cluster. This error occurs in certain versions of MySQL (5.6.x) and is related to the UTF-8 encoding. MySQL originally used the latin1 character set by default, which stored characters in a 2-byte sequence. However, in recent versions, MySQL defaults to UTF-8 to be friendlier to international users. Hence, you must use latin1 as the character set as indicated below in the database creation commands to avoid this problem. Note that this may result in issues with non-latin characters (like Hebrew, Japanese, etc.). The following is how your database creation command should look.
-          ```sh
-          CREATE DATABASE <DATABASE_NAME> character set latin1;
-          ```
-
-        - If you are using MySQL to configure your datasource, we recommend that you use a case sensitive database collation. For more information, see the [MySQL Official Manual](https://dev.mysql.com/doc/refman/5.7/en/charset-mysql.html). The default database collation, which is `latin1_swedish_ci`, is case insensitive. However, you need to maintain case sensitivity for database collation, because when the database or table has a case-insensitive collation in MySQL 5.6 or 5.7, if a user creates an API with letters using mixed case, deletes the API, and then creates another API with the same name, but in lower case letters, then the later created API loses its permission information because when deleting the API, it keeps the Registry collection left behind.
-        
-        - This issue could be avoided if you use a case sensitive collation for database and tables. In that case, when creating the second API (which has the same name, but is entirely in lowercase letters), it will create a new record with the lowercase name in the `UM_PERMISSION` table.
+    !!! tip "UTF-8 Support"
+        WSO2 API Manager supports UTF-8 with MySQL. If you require full Unicode support (e.g., for multilingual API names, descriptions, or user data), use the `utf8mb4` character set with a case-sensitive collation such as `utf8mb4_bin` as shown above.
     
 
 1.  Provide authorization to the user that you use to access the databases. 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle-rac.md
@@ -14,7 +14,10 @@ Oracle Real Application Clusters (RAC) is an option that facilitates clustering 
 
 ### Setting up the database and users
 
-Follow the instructions below to set up an Oracle RAC database:
+Follow the instructions below to set up an Oracle RAC database:
+
+!!! important "Case Sensitivity"
+    Oracle databases use **case-sensitive comparison** by default. It is **required** to maintain your Oracle RAC database with case-sensitive comparison to preserve product behaviors.
 
 1.  As SYSDBA, create a database user and grant privileges to the user as shown below:
 

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-oracle.md
@@ -14,6 +14,9 @@ The following sections describe how to set up Oracle database to replace the def
 
 Follow the instructions below to set up an Oracle database.
 
+!!! important "Case Sensitivity"
+    Oracle databases use **case-sensitive comparison** by default. It is **required** to maintain your Oracle database with case-sensitive comparison to preserve product behaviors.
+
 1. As SYSDBA, create a database user and grant privileges to the user as shown below:
 
     ```sh

--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-postgresql.md
@@ -14,6 +14,9 @@ The following sections describe how to set up PostgreSQL database to replace the
 
 Follow the  instructions below to set up the PostgreSQL database and users.
 
+!!! important "Case Sensitivity"
+    PostgreSQL databases use **case-sensitive comparison** by default. It is **required** to maintain your PostgreSQL database with case-sensitive comparison to preserve product behaviors.
+
 1. Login to PostgreSQL using a client (e.g. `psql`). Enter the following command in a command prompt, where `USER_NAME` is the username that you will use to access the databases and `POSTGRE_HOST_IP` is the IP of the host of PostgreSQL server.
   
    ```sh

--- a/en/docs/reference/product-compatibility.md
+++ b/en/docs/reference/product-compatibility.md
@@ -39,12 +39,6 @@ The **WSO2 API-M** runtime is tested with the following databases:
 |Microsoft SQL Server| 2019, 2022        |
 |PostgreSQL            | 16.2, 17       |
 
-!!! warning
-    When creating the database related to apim_db with MySQL 8.0, add **character set latin1** to avoid the MySQL Linux ERROR 1071 (42000).
-    ```sh
-    CREATE DATABASE <APIM_DATABASE_NAME> character set latin1;
-    ```
-
 #### WSO2 Product Compatibility Matrix
 
 The following is a list of other WSO2 products and components that have been tested with WSO2 API Manager 4.7.0.


### PR DESCRIPTION
### Description
This pull request updates the database setup documentation for several supported database engines to clarify and enforce requirements for character set encoding and, most importantly, case-sensitive collation. These changes are critical to ensure correct operation of WSO2 API Manager and to prevent data integrity issues that can arise from using case-insensitive collations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified database defaults and required case-sensitive collations for IBM DB2, Oracle, Oracle RAC, and PostgreSQL.
  * MSSQL guidance now mandates a case-sensitive collation, adds a fresh-setup example, and notes UTF-8 is not supported.
  * MySQL guidance now mandates a case-sensitive collation, adds a utf8mb4+case-sensitive example, and removes the prior MySQL 8.0 latin1 warning.
  * Kubernetes examples updated to specify case-sensitive MySQL collations.
  * Removed an obsolete MySQL 8.0 compatibility warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->