### PR TITLE
[master] Fix broken links

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -88,7 +88,7 @@ The helm charts for the API Manager deployment are available in the [WSO2 Helm C
     <RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>
     ```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows.
 
@@ -116,7 +116,7 @@ The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.g
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore into the docker image, you can mount them using a Kubernetes secret. Following steps shows how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -132,7 +132,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 > For advanced details with regards to managing custom Java keystores and truststores in a container based WSO2 product deployment
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -159,7 +159,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -188,7 +188,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the docker image created previously in the helm chart.
     
@@ -234,7 +234,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 !!! info "SSL Configuration Best Practices"
     For WSO2 recommended best practices in configuring SSL when exposing internal services to outside of the Kubernetes cluster, refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
@@ -246,7 +246,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
 This section covers the specific configurations relevant to the All-in-One deployment pattern.
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load that comes in, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -280,7 +280,7 @@ gateway:
       websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties as described in this [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/):
 
@@ -298,7 +298,7 @@ You can configure user store properties as described in this [documentation](htt
 
 For a complete list of available user store properties and their descriptions, refer to the [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/).
 
-#### 2.4 Configure JWKS URL
+### 2.4 Configure JWKS URL
 By default, for the super tenant, the Resident Key Manager's JWKS URL is set to `https://<HOSTNAME>:9443/oauth2/jwks`. If you are using a virtual host like `am.wso2.com` that is not globally routable, this URL will be incorrect. You can configure the correct JWKS URL for the super tenant using the Helm chart as shown below:
 
 ```yaml
@@ -309,7 +309,7 @@ wso2:
         oauth2JWKSUrl: "https://localhost:9443/oauth2/jwks"
 ```
 
-#### 2.5 Deploy All-in-One
+### 2.5 Deploy All-in-One
 
 After configuring all the necessary parameters, you can deploy the All-in-One pattern using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -152,7 +152,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
 - The Helm naming convention for APIM follows a simple pattern. The following format is used for naming the resources:
 ```<RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 It is recommended to use the [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows:
 
@@ -180,7 +180,7 @@ It is recommended to use the [**NGINX Ingress Controller**](https://kubernetes.g
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore in the Docker image, you can mount them using a Kubernetes secret. The following steps show how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -196,7 +196,7 @@ It is recommended to use the [**NGINX Ingress Controller**](https://kubernetes.g
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -223,7 +223,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -252,7 +252,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the Docker image created previously in the Helm chart:
     
@@ -301,14 +301,14 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 For WSO2 recommended best practices in configuring SSL when exposing the internal product services outside of the Kubernetes cluster,
 please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
 
 ### 2. All-in-One Configurations
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -342,7 +342,7 @@ If you need to distribute the Gateway load, you can configure multiple API Gatew
           websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties as described in this [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/):
 
@@ -358,7 +358,7 @@ You can configure user store properties as described in this [documentation](htt
 !!! warning Important
     If you do not want to configure any of the above properties, you must remove the `properties` block from the YAML file.
 
-#### 2.4 Configure JWKS URL
+### 2.4 Configure JWKS URL
 
 By default, for the super tenant, the Resident Key Manager's JWKS URL is set to `https://<HOSTNAME>:9443/oauth2/jwks`. If you are using a virtual host like `am.wso2.com` that is not globally routable, this URL will be incorrect. You can configure the correct JWKS URL for the super tenant using the Helm chart as shown below:
 
@@ -374,7 +374,7 @@ wso2:
     Use Key Manager's service name instead of `localhost` if you are using a different hostname for the Key Manager.
 
 
-#### 2.5 Deploy All-in-One
+### 2.5 Deploy All-in-One
 
 Now deploy the Helm chart using the following command after creating a namespace for the deployment. Replace `<release-name>` and `<namespace>` with appropriate values. Replace `<helm-chart-path>` with the path to the Helm deployment.
   
@@ -383,7 +383,7 @@ Now deploy the Helm chart using the following command after creating a namespace
   helm install <release-name> <helm-chart-path> --version 4.7.0-1 --namespace <namespace> --dependency-update -f values.yaml --create-namespace
   ```
 
-#### 2.6 Enable High Availability
+### 2.6 Enable High Availability
 To enable high availability, you can scale the deployment by increasing the number of replicas for the API Manager runtime. This can be done by modifying the `highAvailability` in the `values.yaml` file:
 
 ```yaml

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -185,7 +185,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
 - The Helm naming convention for APIM follows a simple pattern. The following format is used for naming the resources:
 ```<RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use the [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows:
 
@@ -213,7 +213,7 @@ The recommendation is to use the [**NGINX Ingress Controller**](https://kubernet
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore in the Docker image, you can mount them using a Kubernetes secret. The following steps show how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -229,7 +229,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -256,7 +256,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -285,7 +285,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the Docker image created previously in the Helm chart.
     
@@ -334,14 +334,14 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 * For WSO2 recommended best practices in configuring SSL when exposing the internal product services outside of the Kubernetes cluster,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
 
 ### 2. All-in-One Configurations
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -375,7 +375,7 @@ If you need to distribute the Gateway load, you can configure multiple API Gatew
           websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties as described in this [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/):
 
@@ -392,7 +392,7 @@ You can configure user store properties as described in this [documentation](htt
     If you do not want to configure any of the above properties, you must remove the `properties` block from the YAML file.
 
 
-#### 2.4 Configure JWKS URL
+### 2.4 Configure JWKS URL
 
 By default, for the super tenant, the Resident Key Manager's JWKS URL is set to `https://<HOSTNAME>:9443/oauth2/jwks`. If you are using a virtual host like `am.wso2.com` that is not globally routable, this URL will be incorrect. You can configure the correct JWKS URL for the super tenant using the Helm chart as shown below:
 
@@ -403,7 +403,7 @@ wso2:
       oauth_config:
         oauth2JWKSUrl: "https://<ALL-IN-ONE_SERVICE_NAME>:9443/oauth2/jwks"
 ```
-#### 2.5 Deploy All-in-One
+### 2.5 Deploy All-in-One
 
 After configuring all the necessary parameters, you can deploy the All-in-One using Helm:
 
@@ -429,7 +429,7 @@ helm install <release-name> <helm-chart-path> \
     - `<helm-chart-path>`: Path to the Helm chart (e.g., `./all-in-one` or use the repository URL)
 
 
-#### 2.6 Enable High Availability
+### 2.6 Enable High Availability
 To enable high availability, you can scale the deployment by increasing the number of replicas for the API Manager runtime. This can be done by modifying the `highAvailability` in the `values.yaml` file:
 
 ```yaml
@@ -440,7 +440,7 @@ wso2:
 
 ### 3. Universal Gateway Configuration
 
-#### 3.1 Configure Key Manager, Eventhub and Throttling
+### 3.1 Configure Key Manager, Eventhub and Throttling
 
 The following configurations are needed to connect the Universal Gateway to the All-in-One:
 
@@ -521,7 +521,7 @@ The following configurations are needed to connect the Universal Gateway to the 
       queryParamBasedThrottling: false
     ```
 
-#### 3.2 Enable Replicas
+### 3.2 Enable Replicas
 
 To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
 
@@ -538,7 +538,7 @@ wso2:
     - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
     - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
 
-#### 3.3 Deploy Universal Gateway
+### 3.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -211,7 +211,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
 - The Helm naming convention for APIM follows a simple pattern. The following format is used for naming the resources:
 ```<RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use the [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows:
 
@@ -239,7 +239,7 @@ The recommendation is to use the [**NGINX Ingress Controller**](https://kubernet
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore in the Docker image, you can mount them using a Kubernetes secret. The following steps show how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -255,7 +255,7 @@ The recommendation is to use the [**NGINX Ingress Controller**](https://kubernet
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -282,7 +282,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -311,7 +311,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the Docker image created previously in the Helm chart.
     
@@ -361,14 +361,14 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 * For WSO2 recommended best practices in configuring SSL when exposing the internal product services outside of the Kubernetes cluster,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
 
 ### 2. API Control Plane Configurations
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load that comes in, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -402,7 +402,7 @@ If you need to distribute the Gateway load that comes in, you can configure mult
           websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties as described in this [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/):
 
@@ -420,7 +420,7 @@ You can configure user store properties as described in this [documentation](htt
 
 For a complete list of available user store properties and their descriptions, refer to the [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/).
 
-#### 2.4 Configure JWKS URL
+### 2.4 Configure JWKS URL
 By default, for the super tenant, the Resident Key Manager's JWKS URL is set to `https://<HOSTNAME>:9443/oauth2/jwks`. If you are using a virtual host like `am.wso2.com` that is not globally routable, this URL will be incorrect. You can configure the correct JWKS URL for the super tenant using the Helm chart as shown below:
 
 ```yaml
@@ -430,7 +430,7 @@ wso2:
       oauth_config:
         oauth2JWKSUrl: "https://<CONTROL_PLANE_SERVICE_NAME>:9443/oauth2/jwks"
 ```
-#### 2.5 Deploy Control Plane
+### 2.5 Deploy Control Plane
 
 After configuring all the necessary parameters, you can deploy the Control Plane using Helm:
 
@@ -457,7 +457,7 @@ helm install <release-name> <helm-chart-path> \
 
 ### 3. Traffic Manager Configurations
 
-#### 3.1 Configure Key Manager and Eventhub
+### 3.1 Configure Key Manager and Eventhub
 
 - In this pattern, the Control Plane is used as the Key Manager. Therefore, you need to specify the Control Plane service URL as the Key Manager service URL.
   ```yaml
@@ -476,7 +476,7 @@ helm install <release-name> <helm-chart-path> \
       - "<CONTROL_PLANE_2_SERVICE_NAME>"
   ```
 
-#### 3.2 Deploy Traffic Manager
+### 3.2 Deploy Traffic Manager
 
 After configuring all the necessary parameters, you can deploy the Traffic Manager using Helm:
 
@@ -497,7 +497,7 @@ helm install <release-name> <helm-chart-path> \
 
 ### 4. Universal Gateway Configuration
 
-#### 4.1 Configure Key Manager, Eventhub and Throttling
+### 4.1 Configure Key Manager, Eventhub and Throttling
 - Configure Control Plane as the Key Manager
   ```yaml
     km:
@@ -535,7 +535,7 @@ helm install <release-name> <helm-chart-path> \
     queryParamBasedThrottling: false
   ```
 
-#### 4.2 Enable Replicas
+### 4.2 Enable Replicas
 
 To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
 
@@ -552,7 +552,7 @@ wso2:
     - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
     - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
 
-#### 4.3 Deploy Universal Gateway
+### 4.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -217,7 +217,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
     <RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>
     ```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows.
 
@@ -245,7 +245,7 @@ The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.g
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore in the Docker image, you can mount them using a Kubernetes secret. The following steps show how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -261,7 +261,7 @@ The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.g
 > For advanced details with regards to managing custom Java keystores and truststores in a container-based WSO2 product deployment
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -288,7 +288,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -317,7 +317,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the docker image created previously in the helm chart.
     
@@ -367,7 +367,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 * For WSO2 recommended best practices in configuring SSL when exposing the internal product services to outside of the Kubernetes cluster,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
@@ -375,7 +375,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
 ### 2. API Control Plane Configurations
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load that comes in, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -409,7 +409,7 @@ If you need to distribute the Gateway load that comes in, you can configure mult
           websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties as described in this [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/):
 
@@ -427,7 +427,7 @@ You can configure user store properties as described in this [documentation](htt
 
 For a complete list of available user store properties and their descriptions, refer to the [documentation](https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/working-with-properties-of-user-stores/).
 
-#### 2.3 Configure JWKS URL
+### 2.3 Configure JWKS URL
 By default, for the super tenant, the Resident Key Manager's JWKS URL is set to `https://<HOSTNAME>:9443/oauth2/jwks`. If you are using a virtual host like `am.wso2.com` that is not globally routable, this URL will be incorrect. You can configure the correct JWKS URL for the super tenant using the Helm chart as shown below:
 
 ```yaml
@@ -437,7 +437,7 @@ wso2:
       oauth_config:
         oauth2JWKSUrl: "https://<CONTROL_PLANE_SERVICE_NAME>:9443/oauth2/jwks"
 ```
-#### 2.4 Deploy Control Plane
+### 2.4 Deploy Control Plane
 
 After configuring all the necessary parameters, you can deploy the Control Plane using Helm:
 
@@ -465,7 +465,7 @@ helm install <release-name> <helm-chart-path> \
 
 ### 3. Traffic Manager Configurations
 
-#### 3.1 Configure Key Manager and Eventhub
+### 3.1 Configure Key Manager and Eventhub
 
 - In this pattern, the Control Plane is used as the Key Manager. Therefore, you need to specify the Control Plane service URL as the Key Manager service URL.
   ```yaml
@@ -484,7 +484,7 @@ helm install <release-name> <helm-chart-path> \
       - "<CONTROL_PLANE_2_SERVICE_NAME>"
   ```
 
-#### 3.2 Deploy Traffic Manager
+### 3.2 Deploy Traffic Manager
 
 After configuring all the necessary parameters, you can deploy the Traffic Manager using Helm:
 
@@ -505,7 +505,7 @@ helm install <release-name> <helm-chart-path> \
 
 ### 4. Universal Gateway Configuration
 
-#### 4.1 Configure Key Manager, Eventhub and Throttling
+### 4.1 Configure Key Manager, Eventhub and Throttling
 - Configure Control Plane as the Key Manager
   ```yaml
     km:
@@ -543,7 +543,7 @@ helm install <release-name> <helm-chart-path> \
     queryParamBasedThrottling: false
   ```
 
-#### 4.2 Enable Replicas
+### 4.2 Enable Replicas
 
 To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
 
@@ -560,7 +560,7 @@ wso2:
     - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
     - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
 
-#### 4.3 Deploy Universal Gateway
+### 4.3 Deploy Universal Gateway
 
 After configuring all the necessary parameters, you can deploy the Universal Gateway using Helm:
 
@@ -581,7 +581,7 @@ helm install <release-name> <helm-chart-path> \
 
 ### 5. Key Manager Configuration
 
-#### 5.1 Configure Eventhub
+### 5.1 Configure Eventhub
 - Configure eventhub
   ```yaml
   eventhub:
@@ -593,7 +593,7 @@ helm install <release-name> <helm-chart-path> \
       - "<CONTROL_PLANE_2_SERVICE_NAME>"
   ```
 
-#### 5.2 Deploy Key Manager
+### 5.2 Deploy Key Manager
 
 After configuring all the necessary parameters, you can deploy the Key Manager using Helm:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -87,7 +87,7 @@ For this pattern, you will need:
 !!! note "Key Manager Image"
     There is no separate Docker image for the Key Manager component. The All-in-One image should be used for the Key Manager component.
 
-#### Building Custom Docker Images
+### Building Custom Docker Images
 
 If you need to customize the Docker images (e.g., adding JDBC drivers, custom libraries):
 
@@ -219,7 +219,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
 - The Helm naming convention for APIM follows a simple pattern. The following format is used for naming the resources:
 ```<RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use the [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows:
 
@@ -247,7 +247,7 @@ The recommendation is to use the [**NGINX Ingress Controller**](https://kubernet
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore in the Docker image, you can mount them using a Kubernetes secret. The following steps show how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -263,7 +263,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 > For advanced details regarding managing custom Java keystores and truststores in a container-based WSO2 product deployment,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -290,7 +290,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -319,7 +319,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the Docker image created previously in the Helm chart.
     
@@ -368,14 +368,14 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 * For WSO2 recommended best practices in configuring SSL when exposing the internal product services outside of the Kubernetes cluster,
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).
 
 ### 2. All-in-one Configurations
 
-#### 2.1 Configure Multiple Gateways
+### 2.1 Configure Multiple Gateways
 
 If you need to distribute the Gateway load, you can configure multiple API Gateway environments in WSO2 API Manager to publish to a single Developer Portal. [See more...](https://apim.docs.wso2.com/en/latest/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-through-multiple-api-gateways/)
 ```yaml
@@ -409,7 +409,7 @@ If you need to distribute the Gateway load, you can configure multiple API Gatew
           websubHostname: "websub.wso2.com"
 ```
 
-#### 2.2 Configure User Store Properties
+### 2.2 Configure User Store Properties
 
 You can configure user store properties to customize authentication and user management according to your requirements:
 
@@ -428,7 +428,7 @@ userStore:
 !!! warning "Important"
     If you don't need to configure any user store properties, you must remove the `properties` block from the YAML file to avoid configuration errors.
 
-#### 2.3 Configure JWKS URL
+### 2.3 Configure JWKS URL
 
 For the super tenant, the Resident Key Manager's default JWKS URL is `https://<HOSTNAME>:9443/oauth2/jwks`. When using virtual hosts like `am.wso2.com`, you need to configure the correct JWKS URL:
 
@@ -443,7 +443,7 @@ wso2:
 !!! tip
     Using a properly configured JWKS URL ensures that token validation works correctly between components.
 
-#### 2.4 Deploy All-in-One
+### 2.4 Deploy All-in-One
 
 Deploy the Control Plane (All-in-One) component with your custom configuration:
 
@@ -462,7 +462,7 @@ helm install <release-name> wso2/wso2am-all-in-one \
 
 ### 3. Key Manager Configuration
 
-#### 3.1 Configure Eventhub
+### 3.1 Configure Eventhub
 
 The Key Manager component needs to connect to the Control Plane's event hub for synchronizing data:
 
@@ -479,7 +479,7 @@ eventhub:
 !!! info "Event Hub"
     The Event Hub enables communication between API Manager components. Configure the service URLs to point to your Control Plane instances.
 
-#### 3.2 Deploy Key Manager
+### 3.2 Deploy Key Manager
 
 Deploy the Key Manager component with your custom configuration:
 
@@ -498,7 +498,7 @@ helm install <release-name> wso2/wso2am-acp \
 
 ### 4. Universal Gateway Configuration
 
-#### 4.1 Configure Key Manager, Eventhub, and Throttling
+### 4.1 Configure Key Manager, Eventhub, and Throttling
 
 The Universal Gateway needs to connect to several components to function properly:
 
@@ -584,7 +584,7 @@ km:
 
 Choose the configuration that matches your deployment pattern. For high availability, specify all Control Plane service URLs under `urls` for both `eventhub` and `throttling` sections.
 
-#### 4.2 Enable Replicas
+### 4.2 Enable Replicas
 
 To ensure high availability and scalability of the Universal Gateway, you can configure the number of replicas in the `wso2.deployment` section of your `values.yaml` file.
 
@@ -601,7 +601,7 @@ wso2:
     - `minReplicas`: The minimum number of pods that should always be running (e.g., 1).
     - `maxReplicas`: The maximum number of pods that can be scaled up to (e.g., 3).
 
-#### 4.3 Deploy Universal Gateway
+### 4.3 Deploy Universal Gateway
 
 Deploy the Universal Gateway component with your custom configuration:
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -187,7 +187,7 @@ The Helm charts for the API Manager deployment are available in the [WSO2 Helm C
     <RELEASE_NAME>-<CHART_NAME>-<RESOURCE_NAME>
     ```
 
-#### 1.1 Add Ingress Controller
+### 1.1 Add Ingress Controller
 
 The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.github.io/ingress-nginx/deploy/) suitable for your cloud environment or local deployment. Some sample annotations that could be used with the ingress resources are as follows.
 
@@ -215,7 +215,7 @@ The recommendation is to use [**NGINX Ingress Controller**](https://kubernetes.g
     kubectl create secret tls my-tls-secret --key <private key filename> --cert <certificate filename>
     ```
 
-#### 1.2 Mount Keystore and Truststore
+### 1.2 Mount Keystore and Truststore
 
 - If you are not including the keystore and truststore into the docker image, you can mount them using a Kubernetes secret. Following steps shows how to mount the keystore and truststore using a Kubernetes secret.
 - Create a Kubernetes secret with the keystore and truststore files. The secret should contain the primary keystore file, secondary keystore file, internal keystore file, and the truststore file. Note that the secret should be created in the same namespace in which you will be setting up the deployment.
@@ -231,7 +231,7 @@ In addition to the primary, internal keystores and truststore files, you can als
 > For advanced details with regards to managing custom Java keystores and truststores in a container based WSO2 product deployment
   please refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/deploy/Managing_Keystores_And_Truststores.md).
 
-#### 1.3 Configure Internal Encryption Key (Mandatory)
+### 1.3 Configure Internal Encryption Key (Mandatory)
 
 This section is for the internal encryption key (`wso2.apim.configurations.encryption.key`), which is mandatory and used by API Manager to encrypt and decrypt internal/shared data.
 
@@ -258,7 +258,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 
     In a distributed or high-availability deployment, all API Manager instances must use the exact same internal encryption key (`wso2.apim.configurations.encryption.key`). Each instance encrypts and decrypts shared registry resources using this key, so a mismatch will cause decryption failures across the cluster. Configure the shared key on every node before the first startup.
 
-#### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
+### 1.4 Encrypting Secrets (Cipher Tool and Secure Vault)
 
 - If you need to use the cipher tool to encrypt the passwords in the secret, first you need to encrypt the passwords using the cipher tool. The cipher tool can be found in the `bin` directory of the product pack. The following command can be used to encrypt the password:
   ```bash
@@ -287,7 +287,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
 !!! note
     These are two different keys serving distinct purposes. The internal encryption key (`wso2.apim.configurations.encryption.key`) defined in section 1.3 is **mandatory** and is used by API Manager for internal encryption of data such as registry resources and shared configuration. The secret encryption key (`secretEncryptionKey` under AWS/Azure/GCP) is a separate key used **only** when secure vault is enabled, allowing the runtime to fetch and decrypt secrets stored in a cloud provider's secret manager (which may itself include an encrypted copy of the internal encryption key).
 
-#### 1.5 Configure Docker Image and Databases
+### 1.5 Configure Docker Image and Databases
 
   - Add the following configurations to reflect the docker image created previously in the helm chart.
     
@@ -333,7 +333,7 @@ This section is for the internal encryption key (`wso2.apim.configurations.encry
       adminPassword: ""
     ```
   
-#### 1.6 Configure SSL in Service Exposure
+### 1.6 Configure SSL in Service Exposure
 
 !!! info "SSL Configuration Best Practices"
     For WSO2 recommended best practices in configuring SSL when exposing internal services to outside of the Kubernetes cluster, refer to the [official WSO2 container guide](https://github.com/wso2/container-guide/blob/master/route/Routing.md#configuring-ssl).


### PR DESCRIPTION
This pull request updates the Kubernetes deployment documentation for WSO2 API Manager across multiple "All-in-One" deployment patterns. The main change is the standardization of section headings from `####` to `###` for better consistency and improved readability. No technical content has been altered.

**Documentation formatting improvements:**

* Changed all section headings under setup steps from `####` to `###` in the following files to ensure consistent heading levels and clearer structure:  
  * `am-pattern-0-all-in-one.md` [[1]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L91-R91) [[2]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L119-R119) [[3]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L135-R135) [[4]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L162-R162) [[5]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L191-R191) [[6]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L237-R237) [[7]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L249-R249) [[8]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L283-R283) [[9]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L301-R301) [[10]](diffhunk://#diff-2238f0afd2da0736c295507d0f202a0777eaef32d4678e72afc73aa9d3badb46L312-R312)
  * `am-pattern-1-all-in-one-ha.md` [[1]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L155-R155) [[2]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L183-R183) [[3]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L199-R199) [[4]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L226-R226) [[5]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L255-R255) [[6]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L304-R311) [[7]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L345-R345) [[8]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L361-R361) [[9]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L377-R377) [[10]](diffhunk://#diff-51cdbcea19d8560b042deddd64796960d6590cebd13e6423b1010d9bfcd2ff43L386-R386)
  * `am-pattern-2-all-in-one-gw.md` [[1]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L188-R188) [[2]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L216-R216) [[3]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L232-R232) [[4]](diffhunk://#diff-d0b338c4e1f04585a806c1e146a05afac8ad140cd4e9e00d9ac05ec98eee9a31L259-R259)

No changes were made to code or deployment logic—this is a documentation-only update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Kubernetes deployment documentation with improved heading hierarchy for better navigation and clearer table of contents organization across multiple deployment pattern guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->