### PR TITLE
Fix missing spaces in HTTP headers in invoke-api-with-jwt.md

### DIFF
--- a/en/docs/includes/invoke-api-with-jwt.md
+++ b/en/docs/includes/invoke-api-with-jwt.md
@@ -1,12 +1,11 @@
 Execute the following cURL command to Invoke the API using the access token.
 
 === "Format"
-    ``` bash
-    curl -X GET "https://<CHOREO-CONNECT_ROUTER_HOST>:<CHOREO-CONNECT_ROUTER_PORT>/<API-context>/<API-resource>" -H "accept:application/xml" -H "Authorization:Bearer $TOKEN" -k
-    ```
+``` bash
+    curl -X GET "https://<CHOREO-CONNECT_ROUTER_HOST>:<CHOREO-CONNECT_ROUTER_PORT>/<API-context>/<API-resource>" -H "accept: application/xml" -H "Authorization: Bearer $TOKEN" -k
+```
  
 === "Example"
-    ``` bash
-    curl -X GET "https://localhost:9095/v2/pet/findByStatus?status=available" -H "accept: application/xml" -H "Authorization:Bearer $TOKEN" -k
-    ```
-
+``` bash
+    curl -X GET "https://localhost:9095/v2/pet/findByStatus?status=available" -H "accept: application/xml" -H "Authorization: Bearer $TOKEN" -k
+```


### PR DESCRIPTION
## Summary
Fixed incorrect HTTP header formatting in the `invoke-api-with-jwt.md` include file.

## Problem
The curl examples were missing required spaces in two HTTP headers:

1. `"accept:application/xml"` → missing space after colon
2. `"Authorization:Bearer $TOKEN"` → missing space after colon (in both Format and Example tabs)

This violates RFC 7230 HTTP header formatting standards.

## Impact
- Strict HTTP clients may reject malformed headers
- Copy-paste users may receive 401 Unauthorized errors
- Authentication may silently fail in production environments

## Fix
- `"accept: application/xml"` ✅
- `"Authorization: Bearer $TOKEN"` ✅ (fixed in both Format and Example tabs)

## References
- RFC 7230 Section 3.2 — HTTP/1.1 Header Fields
- Affected page: https://apim.docs.wso2.com/en/4.2.0/includes/invoke-api-with-jwt/