### PR TITLE
Fix missing config catalog CSS on 4.7.0

### DIFF
--- a/en/theme/material/assets/css/theme.css
+++ b/en/theme/material/assets/css/theme.css
@@ -926,3 +926,315 @@
         width: 16px;
     }
 }
+
+/* =============================================
+   Config Catalog Styles
+   ============================================= */
+
+.mb-config-catalog {
+    display: table;
+    width: 100%;
+    max-width: 770px;
+}
+
+.hide-toc .mb-config-catalog {
+    display: table;
+    max-width: 1000px;
+}
+
+.mb-config-catalog .superfences-tabs {
+    flex-direction: column;
+}
+
+.mb-config-catalog .superfences-tabs .tab-selector {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: auto;
+    padding: 0.6rem;
+    -webkit-transition: color .125s;
+    transition: color .125s;
+    font-size: .64rem;
+    cursor: pointer;
+    text-align: right;
+}
+
+.mb-config-catalog .superfences-tabs .tab-selector > .icon {
+    margin-right: 5px;
+}
+
+.mb-config-catalog .superfences-content {
+    flex-direction: column;
+    order: 0;
+}
+
+.mb-config-catalog .superfences-tabs > input + label:after {
+    content: "View Sample";
+}
+
+.mb-config-catalog .superfences-tabs > input:checked + label:after {
+    content: "Hide Sample";
+}
+
+.mb-config-catalog .superfences-tabs .doc-wrapper {
+    padding: .525rem;
+}
+
+.mb-config-catalog > section {
+    display: table-row;
+}
+
+.mb-config-catalog > section > .mb-config-options,
+.mb-config-catalog > section > .mb-config-example {
+    display: table-cell;
+    flex-direction: column;
+    max-width: 570px;
+}
+
+.hide-toc .mb-config-catalog > section > .mb-config-options,
+.hide-toc .mb-config-catalog > section > .mb-config-example {
+    display: table-cell;
+    max-width: 1000px;
+}
+
+.mb-config-catalog > section > .mb-config-example > .example-config-wrap {
+    margin-right: 1em;
+}
+
+.mb-config-catalog > section > .mb-config-example > code {
+    font-weight: bold;
+    font-size: 105%;
+}
+
+.mb-config-catalog > section:not(.title) > .mb-config-options {
+    border-bottom: 1px solid var(--md-divider-color);
+    padding-top: 1em;
+}
+
+.mb-config-catalog > section:last-child > .mb-config-options {
+    border-bottom: none;
+}
+
+.mb-config-catalog > section:not(.title) > .mb-config-example {
+    border-top: 1px solid var(--md-divider-color);
+    border-bottom: 1px solid var(--md-divider-color);
+}
+
+.mb-config-catalog > section.title > .mb-config-example {
+    display: none;
+}
+
+.mb-config-catalog .mb-config-example code,
+.mb-config-catalog .mb-config-example pre {
+    margin: 0;
+}
+
+.mb-config-catalog .mb-config-example:hover .md-clipboard:before {
+    color: rgba(0, 0, 0, .54);
+}
+
+.mb-config-catalog > section.title > .mb-config-options > h2 {
+    margin-bottom: 1rem;
+}
+
+.mb-config-catalog > section > .mb-config-example {
+    background: var(--md-default-fg-color--lightest);
+    width: 35%;
+    padding: .5em;
+    vertical-align: top;
+}
+
+.mb-config-catalog > section > .mb-config-example code {
+    background: transparent;
+    box-shadow: none;
+    white-space: pre-line;
+}
+
+.mb-config-catalog .badge-required {
+    margin: 0 .29412em;
+    padding: .07353em .3em;
+    border-radius: .2rem;
+    background-color: var(--md-primary-fg-color);
+    color: #fff;
+    font-size: 75%;
+}
+
+.mb-config-catalog .mb-config > .config-wrap {
+    margin-right: 1em;
+}
+
+.mb-config-catalog .mb-config > .params-wrap {
+    display: table;
+    width: 100%;
+}
+
+.mb-config-catalog .mb-config > .config-wrap > code {
+    font-weight: bold;
+    font-size: 105%;
+}
+
+.mb-config-catalog .mb-config .param {
+    display: table-row;
+}
+
+.mb-config-catalog .mb-config .param > .param-name {
+    display: table-cell;
+    vertical-align: top;
+    border-left: 2px solid var(--md-primary-fg-color);
+    box-sizing: border-box;
+    position: relative;
+    padding: 1.7em 0;
+    line-height: 20px;
+    white-space: nowrap;
+    font-size: .929em;
+    font-weight: 400;
+}
+
+.mb-config-catalog .mb-config .param .param-name-wrap {
+    display: inline-block;
+    padding-right: 25px;
+}
+
+.mb-config-catalog .mb-config .param > .param-name > span::before {
+    content: '';
+    display: inline-block;
+    width: 2px;
+    height: 8px;
+    background-color: var(--md-primary-fg-color);
+    margin: -4px 10px 0;
+    vertical-align: middle;
+}
+
+.mb-config-catalog .mb-config .param > .param-name > span::after {
+    content: '';
+    position: absolute;
+    border-top: 2px solid var(--md-primary-fg-color);
+    width: 10px;
+    left: 0;
+    top: 2.3em;
+}
+
+.mb-config-catalog .mb-config .param:first-of-type > .param-name::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -2px;
+    top: 0;
+    border-left: 3px solid var(--md-default-bg-color);
+    height: 34px;
+}
+
+.mb-config-catalog .mb-config .param:last-of-type > .param-name,
+.mb-config-catalog .mb-config .param.last > .param-name {
+    position: relative;
+}
+
+.mb-config-catalog .mb-config .param:last-of-type > .param-name::after,
+.mb-config-catalog .mb-config .param.last > .param-name::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -2px;
+    border-left: 3px solid var(--md-default-bg-color);
+    top: 36px;
+    background-color: var(--md-default-bg-color);
+    bottom: 0;
+}
+
+.mb-config-catalog .mb-config .param > .param-info {
+    display: table-cell;
+    width: 100%;
+    border-bottom: 1px solid var(--md-divider-color);
+    padding: 10px 10px 10px 0;
+    box-sizing: border-box;
+    word-break: break-word;
+}
+
+.mb-config-catalog .mb-config .param-default {
+    font-size: .95em;
+}
+
+.mb-config-catalog .mb-config .param-type {
+    color: #b5b5b5;
+}
+
+@media only screen and (min-width: 100em) {
+    .mb-config-catalog .mb-config .param > .param-name > span::before {
+        margin: 0 10px;
+    }
+
+    .mb-config-catalog .mb-config .param:first-of-type > .param-name::before {
+        height: 38px;
+    }
+
+    .mb-config-catalog .mb-config .param:last-of-type > .param-name::after,
+    .mb-config-catalog .mb-config .param.last > .param-name::after {
+        top: 40px;
+    }
+}
+
+@media (max-width: 767px) {
+    .mb-config-catalog {
+        margin-bottom: 3rem;
+    }
+
+    .mb-config-catalog,
+    .mb-config-catalog > section,
+    .mb-config-catalog > section > .mb-config-options,
+    .mb-config-catalog > section > .mb-config-example {
+        display: block;
+        width: 100% !important;
+    }
+
+    .mb-config-catalog > section:not(.title) > .mb-config-options {
+        padding-bottom: 1rem;
+    }
+}
+
+/* =============================================
+   Superfences Tabs (used by Config Catalog)
+   ============================================= */
+
+.md-typeset .superfences-tabs > input {
+    display: none;
+}
+
+html .md-typeset .superfences-tabs > label {
+    color: var(--md-primary-fg-color);
+    font-weight: normal;
+}
+
+html .md-typeset .superfences-tabs > label:hover {
+    color: var(--md-primary-fg-color);
+    font-weight: bold;
+}
+
+.md-typeset .superfences-tabs {
+    display: flex;
+    position: relative;
+    flex-wrap: wrap;
+    margin: 1em 0;
+    border: 0.05rem solid rgba(0, 0, 0, .07);
+    border-radius: 0.2em;
+}
+
+.md-typeset .superfences-tabs > input:checked + label {
+    font-weight: 700;
+}
+
+.md-typeset .superfences-tabs > input:checked + label + .superfences-content {
+    display: block;
+}
+
+.md-typeset .superfences-content {
+    display: none;
+    -webkit-box-ordinal-group: 100;
+    order: 99;
+    width: 100%;
+    background-color: var(--md-default-bg-color);
+}
+
+.mb-config-catalog .superfences-content {
+    flex-direction: column;
+    order: 0;
+}

--- a/en/theme/material/assets/css/theme.css
+++ b/en/theme/material/assets/css/theme.css
@@ -1030,7 +1030,7 @@
 }
 
 .mb-config-catalog .mb-config-example:hover .md-clipboard:before {
-    color: rgba(0, 0, 0, .54);
+    color: var(--md-default-fg-color--light);
 }
 
 .mb-config-catalog > section.title > .mb-config-options > h2 {
@@ -1155,7 +1155,7 @@
 }
 
 .mb-config-catalog .mb-config .param-type {
-    color: #b5b5b5;
+    color: var(--md-default-fg-color--light);
 }
 
 @media only screen and (min-width: 100em) {
@@ -1214,7 +1214,7 @@ html .md-typeset .superfences-tabs > label:hover {
     position: relative;
     flex-wrap: wrap;
     margin: 1em 0;
-    border: 0.05rem solid rgba(0, 0, 0, .07);
+    border: 0.05rem solid var(--md-divider-color);
     border-radius: 0.2em;
 }
 
@@ -1232,9 +1232,4 @@ html .md-typeset .superfences-tabs > label:hover {
     order: 99;
     width: 100%;
     background-color: var(--md-default-bg-color);
-}
-
-.mb-config-catalog .superfences-content {
-    flex-direction: column;
-    order: 0;
 }


### PR DESCRIPTION
## Summary
- Adds back ~310 lines of config catalog CSS that were lost during the theme revamp
- Fixes visible raw checkboxes and layout misalignment on the [config catalog page](https://apim.docs.wso2.com/en/latest/reference/config-catalog/)
- Uses CSS variables (`--md-primary-fg-color`, `--md-default-bg-color`, `--md-divider-color`) instead of hardcoded colors for proper light/dark mode support

Same fix as merged for 4.6.0.

## Test plan
- [x] Verify config catalog page renders without visible checkboxes
- [x] Verify "View Sample" / "Hide Sample" toggle works
- [x] Verify parameter layout with orange branch-line decoration displays correctly
- [x] Verify dark mode rendering


🤖 Generated with [Claude Code](https://claude.com/claude-code)