### PR TITLE
Add links for API platform docs

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -21,6 +21,8 @@ For more information on WSO2 API Manager, see the [overview]({{base_path}}/get-s
     - **APIM as control plane**: Manage gateway registration, configuration, API deployments, and policies directly from API Manager.
     - **Unified gateway model**: Use a single gateway implementation across cloud and on-prem environments.
 
+    **[Learn more]({{base_path}}/api-gateway/universal-gateway/getting-started)**
+
 ??? note "API-Bound API Keys with Enhanced Security and Access Control"
 
     WSO2 API Manager introduces enhanced API key capabilities with improved visibility, security, and lifecycle control, enabling more fine-grained and secure API access management.


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Learn more" hyperlink in the API Platform Gateway Integration release note section, directing users to the universal gateway getting-started documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->