### PR TITLE
Fix typo in 'on-premise' to 'on-premises'

### DIFF
--- a/en/docs/get-started/about-this-release.md
+++ b/en/docs/get-started/about-this-release.md
@@ -1,6 +1,6 @@
 # About this Release
 
-WSO2 API Manager is a complete platform for building, integrating, and exposing your digital services as managed APIs in the cloud, on-premise, and hybrid architectures to drive your digital transformation strategy. It comes with a cloud-native, standards-based messaging engine, and an integration framework for integrating APIs, services, data, SaaS, proprietary, and legacy systems and it can also serve streaming-based integrations. The product comes with command-line and developer tools that enable easy design, development, and testing.
+WSO2 API Manager is a complete platform for building, integrating, and exposing your digital services as managed APIs in the cloud, on-premises, and hybrid architectures to drive your digital transformation strategy. It comes with a cloud-native, standards-based messaging engine, and an integration framework for integrating APIs, services, data, SaaS, proprietary, and legacy systems and it can also serve streaming-based integrations. The product comes with command-line and developer tools that enable easy design, development, and testing.
 
 **WSO2 API Manager 4.7.0** is the latest **WSO2 API Manager release** and is the successor of **WSO2 API Manager 4.6.0**.
 


### PR DESCRIPTION
## Purpose
Fix minor grammar inconsistency in documentation by correcting "on-premise" to "on-premises" for better consistency and readability.

## Goals
Improve documentation consistency by using correct terminology "on-premises" across the document.

## Approach
Updated the documentation by replacing incorrect usage of "on-premise" with the correct term "on-premises".

## User stories
As a reader, I want consistent terminology in documentation so that it is easier to understand.

## Release note
Fixed minor grammar inconsistency in documentation by correcting terminology usage.

## Documentation
N/A – This is a minor grammar correction with no functional impact.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: N/A
- Integration tests: N/A

## Security checks
- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed no secrets are committed? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
This fix was made by identifying a minor grammar inconsistency in the documentation and correcting the terminology for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected terminology in the release documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->