### PR TITLE
Fix invisible properties configuration

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
@@ -214,6 +214,7 @@ This method uses dynamic authentication based on role IDs and secret IDs, allowi
     secretRepositories.vault.properties.authType=APP_ROLE
     secretRepositories.vault.properties.roleId=<role id>
     ```
+    
     !!! note
         In production, you should always use the vault address with TLS enabled.
 


### PR DESCRIPTION
## Purpose
This PR fixes the issue where the properties configuration in [1] step 4 is not visible.

<img width="934" height="140" alt="Screenshot 2026-04-22 at 11 55 38" src="https://github.com/user-attachments/assets/9fc2756a-6906-42d0-9950-c3a10b61a7a9" />


[1] https://apim.docs.wso2.com/en/4.5.0/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension/#step-2-configure-hashicorp-vault-extension_1