### PR TITLE
Fix grammar issue in API Manager documentation

### DIFF
--- a/en/docs/administer/role-based-access-control.md
+++ b/en/docs/administer/role-based-access-control.md
@@ -21,7 +21,7 @@ below scopes  chart to define scopes.
 1. Sign in to WSO2 the Admin portal ( `https://<Server Host>:9443+<port offset>/admin` ) as the super admin or tenant admin
 2. Click `Scope Assignments` in the left sidebar and click on `Add scope mappings` .
 3. In the `Provide role name` text input give the role name which was previously created in step 1 and then click `next`.
-4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
+4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer to the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
    
     [![Add admin Scope Mapping For Role Based Access Control]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)
 


### PR DESCRIPTION
## Purpose
> Fix a small grammar/clarity issue in the Admin Portal documentation: a missing word made one sentence awkward.
Resolves: N/A

## Goals
>Make a single, minimal documentation correction so the sentence reads naturally and is clearer to readers.

## Approach
> Edited one sentence in the Admin Portal RBAC doc to add the missing word "to". Change is small, non-functional, and safe for review/merge.

## User stories
> As a reader, I want the docs to read clearly so I can follow scope-assignment steps without confusion.

## Release note
> Documentation typo fix in Admin Portal role-based access control guide.

## Documentation
> Updated: en/docs/administer/role-based-access-control.md — grammar/clarity-only change.

## Training
> N/A

## Certification
> N/A (documentation-only change)

## Marketing
> N/A

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> N/A (text-only change)
 
## Learning
> Minor grammar fix; no technical changes or regression risk.