### PR TITLE
Fix typo install doc

### DIFF
--- a/en/docs/administer/role-based-access-control.md
+++ b/en/docs/administer/role-based-access-control.md
@@ -21,7 +21,7 @@ below scopes  chart to define scopes.
 1. Sign in to WSO2 the Admin portal ( `https://<Server Host>:9443+<port offset>/admin` ) as the super admin or tenant admin
 2. Click `Scope Assignments` in the left sidebar and click on `Add scope mappings` .
 3. In the `Provide role name` text input give the role name which was previously created in step 1 and then click `next`.
-4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
+4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer to the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
    
     [![Add admin Scope Mapping For Role Based Access Control]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -32,4 +32,4 @@ The APIM APK Agent is a component that connects the WSO2 API Control Plane with 
 
 ## Next Steps
 
-You can refer the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.
+You can refer to the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.


### PR DESCRIPTION
## Purpose
>Fix a minor grammar/clarity issue in the Admin/Install docs: a missing word made one sentence awkward.
Resolves: N/A

## Goals
> Make a single, minimal documentation correction to improve readability without changing meaning.

## Approach
>Edited one sentence in the docs to add the missing word "to". This is a one-line, text-only change and safe for review/merge.

## User stories
> As a reader, I want the documentation to read clearly so I can follow instructions without confusion.

## Release note
> Documentation typo fix in Kubernetes Gateway integration guide.

## Documentation
>Updated: en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
Followed secure coding standards: N/A (documentation-only change)
Ran FindSecurityBugs plugin and verified report: N/A
Confirmed no secrets committed: yes

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> N/A (text-only change)
 
## Learning
> Minor grammar fix; no technical impact or regression risk.