### PR TITLE
Fix typo develop api guides

### DIFF
--- a/en/docs/administer/role-based-access-control.md
+++ b/en/docs/administer/role-based-access-control.md
@@ -21,7 +21,7 @@ below scopes  chart to define scopes.
 1. Sign in to WSO2 the Admin portal ( `https://<Server Host>:9443+<port offset>/admin` ) as the super admin or tenant admin
 2. Click `Scope Assignments` in the left sidebar and click on `Add scope mappings` .
 3. In the `Provide role name` text input give the role name which was previously created in step 1 and then click `next`.
-4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
+4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer to the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
    
     [![Add admin Scope Mapping For Role Based Access Control]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -32,4 +32,4 @@ The APIM APK Agent is a component that connects the WSO2 API Control Plane with 
 
 ## Next Steps
 
-You can refer the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.
+You can refer to the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -4,7 +4,7 @@
 
 The Control Plane serves as the central intelligence hub for WSO2 Kubernetes Gateway, orchestrating the entirety of the API ecosystem. It encompasses critical functionalities such as API management, administrative operations, and the API marketplace. Structurally, it comprises four principal components: the Back Office, Dev Portal, Admin Portal, and APIM-APK Agent. These components cater to diverse user roles, ranging from API product managers to consumers and administrative personnel. Within the Control Plane, users configure, oversee, and track the performance of APIs, ensuring seamless management and optimization of the API landscape.
 
-For the Kubernetes Gateway Control Plane, we are going to use same WSO2 API Control Plane. The WSO2 API control plane is a set of components that are responsible for managing and monitoring APIs.
+For the Kubernetes Gateway Control Plane, we are going to use the same WSO2 API Control Plane. The WSO2 API control plane is a set of components that are responsible for managing and monitoring APIs.
 Kubernetes Gateway only supports REST API and GraphQL API creation for now.
 
 ## Architecture


### PR DESCRIPTION
## Purpose
> Fix minor grammar/clarity issues in the Kubernetes Gateway integration documentation.
Resolves: N/A

## Goals
> Improve readability with a minimal, non-functional documentation change so readers follow the instructions without confusion.

## Approach
> Edit a single documentation file to correct two small grammar issues (both are one-word fixes). Change is text-only and safe for review/merge.

## User stories
> As a reader, I want the docs to read clearly so I can follow setup steps without ambiguity.

## Release note
> Documentation: Fixed minor grammar in Kubernetes Gateway integration guide.

## Documentation
> Updated file: en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A

## Marketing
> N/A

## Security checks
Followed secure coding standards: N/A (documentation-only change)
Ran FindSecurityBugs plugin and verified report: N/A
Confirmed no keys, passwords, tokens, usernames, or other secrets committed: yes

## Samples
> N/A

## Related PRs
>N/A

## Migrations (if applicable)
> N/A

## Test environment
>N/A (text-only change)
 
## Learning
> Minor grammar fixes only — no technical impact or regression risk.