### PR TITLE
Add alt text check workflow

### DIFF
--- a/.github/workflows/alt-text-check.yml
+++ b/.github/workflows/alt-text-check.yml
@@ -1,0 +1,25 @@
+name: "Alt text check"
+
+on:
+  pull_request:
+
+jobs:
+  alt-text:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find markdown images with empty alt text
+        run: |
+          set -euo pipefail
+          echo "Checking Markdown image alt text..."
+          # Find markdown images with empty alt: ![](path) or ![  ](path)
+          md_empty_alt=$(git grep -n -E "!\[\s*\]\([^)]*\)" -- 'en/**/*.md' || true)
+          # Find HTML <img> tags missing an alt attribute
+          html_missing_alt=$(git grep -n -P "<img\b(?![^>]*\balt=)[^>]*>" -- 'en/**/*.md' || true)
+          if [ -n "$md_empty_alt" ] || [ -n "$html_missing_alt" ]; then
+            echo "Found images missing alt text:" >&2
+            echo "$md_empty_alt" >&2
+            echo "$html_missing_alt" >&2
+            exit 1
+          fi
+          echo "All images have alt text (as far as this check can detect)."

--- a/en/docs/administer/role-based-access-control.md
+++ b/en/docs/administer/role-based-access-control.md
@@ -21,7 +21,7 @@ below scopes  chart to define scopes.
 1. Sign in to WSO2 the Admin portal ( `https://<Server Host>:9443+<port offset>/admin` ) as the super admin or tenant admin
 2. Click `Scope Assignments` in the left sidebar and click on `Add scope mappings` .
 3. In the `Provide role name` text input give the role name which was previously created in step 1 and then click `next`.
-4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
+4. In the `Select Permissions` menu, select the `Custom scope assignments` option. And select the scopes that you want to assign for the newly created role. You can refer to the following table when assigning the scopes. For example, If the admin wants the newly created user to access the key managers settings in the admin portal he can assign `apim:keymanagers_manage`, `apim:tenantInfo`, and `apim:admin_settings`.
    
     [![Add admin Scope Mapping For Role Based Access Control]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)]({{base_path}}/assets/img/administer/add-admin-scope-mapping-role-based-access.png)
 

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -32,4 +32,4 @@ The APIM APK Agent is a component that connects the WSO2 API Control Plane with 
 
 ## Next Steps
 
-You can refer the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.
+You can refer to the [Quick Start Guide](https://apk.docs.wso2.com/en/latest/get-started/quick-start-guide-with-cp/) with regards to trying out API Control Plane with Kubernetes Gateway using APIM-APK Agent.

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -4,7 +4,7 @@
 
 The Control Plane serves as the central intelligence hub for WSO2 Kubernetes Gateway, orchestrating the entirety of the API ecosystem. It encompasses critical functionalities such as API management, administrative operations, and the API marketplace. Structurally, it comprises four principal components: the Back Office, Dev Portal, Admin Portal, and APIM-APK Agent. These components cater to diverse user roles, ranging from API product managers to consumers and administrative personnel. Within the Control Plane, users configure, oversee, and track the performance of APIs, ensuring seamless management and optimization of the API landscape.
 
-For the Kubernetes Gateway Control Plane, we are going to use same WSO2 API Control Plane. The WSO2 API control plane is a set of components that are responsible for managing and monitoring APIs.
+For the Kubernetes Gateway Control Plane, we are going to use the same WSO2 API Control Plane. The WSO2 API control plane is a set of components that are responsible for managing and monitoring APIs.
 Kubernetes Gateway only supports REST API and GraphQL API creation for now.
 
 ## Architecture


### PR DESCRIPTION
## Purpose
> Problem: PRs sometimes add images without alt text, harming accessibility and SEO.
Files: .github/workflows/alt-text-check.yml
Resolves: N/A

## Goals
>Primary: Automatically detect images in Markdown that lack alt text and fail the PR check so authors fix them before merge.
Secondary: Raise awareness of accessibility best practices among contributors.

## Approach
> Implementation: Add a GitHub Actions workflow that runs on pull requests and performs two checks:
Greps Markdown for empty Markdown image alt text patterns (![](...) / ![ ](...)).
Greps for HTML <img> tags inside Markdown that are missing an alt attribute.
File changed:  .github/workflows/alt-text-check.yml
Behavior: If any matches are found the job prints the locations and exits non‑zero, causing the PR check to fail. No edits to content are made automatically — authors must fix the files.

## User stories
> Doc writer: As a doc author, I want an automated check so I don't forget to add alt text.
Reviewer: As a reviewer, I want CI to surface missing alt text so reviews focus on substance.
Accessibility owner: As an accessibility reviewer, I want a lightweight enforcement point in CI to improve site accessibility.

## Release note
> Docs: Add automated PR check to flag images missing alt text in Markdown.

## Documentation
> Updated config: See  .github/workflows/alt-text-check.yml.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
Type: CI workflow (GitHub Actions) — runs on pull_request.
Unit tests: N/A
Integration tests: N/A

## Security checks
Secure coding guidelines followed: N/A (workflow is configuration-only)
FindSecurityBugs run: N/A
Secrets check: yes — this change commits no keys, passwords, tokens, or credentials.

## Samples
> N/A

## Related PRs
> None (this is an independent CI addition)

## Migrations (if applicable)
> None

## Test environment
> Runner: GitHub Actions ubuntu-latest (workflow runs on pull requests).
 
## Learning
> Notes: Simple grep-based checks are effective for catching common omissions (empty Markdown alt text or missing alt attributes in HTML). This approach is intentionally conservative (reports potential misses rather than attempting automatic fixes). Recommended follow-ups: add a broken-link check and a markdown-lint job to further improve doc quality.