### PR TITLE
Add missing step for publishing API in the Developer Portal

### DIFF
--- a/en/docs/includes/design/create-publish-api.md
+++ b/en/docs/includes/design/create-publish-api.md
@@ -12,3 +12,5 @@
      [![Configure API key authentication](../../../../assets/img/learn/api-key-option.png)](../../../../assets/img/learn/api-key-option.png)
      
 5. Click **Save and Deploy** to save the changes made within the **Runtime Configurations** page. Upon redirection to the **Deployments** page, select the relevant Gateway and click on **Deploy**.
+
+6. Publish the API to make it available in the Developer Portal. Navigate to the **Lifecycle** section and click **Publish** to publish the API. Once published, the API will be visible to subscribers in the Developer Portal.


### PR DESCRIPTION
## Purpose
> Adds the missing API publishing step in the reusable include file (`create-publish-api.md`) that is referenced across multiple API authentication and security documentation pages. This resolves a critical workflow gap where users complete the deployment steps but cannot see their API in the Developer Portal because the publishing step is not documented in this foundational sub-step template.

## Goals
> Complete the foundational API creation workflow in the shared include file by adding the API publishing step, which will automatically improve documentation consistency across all pages that reference this template. Ensure that users following any API authentication tutorial (API keys, OAuth2, mutual SSL, etc.) understand that both deployment and publishing are required steps before an API becomes available in the Developer Portal for subscription and testing.

## Approach
> **Issue Identified:**
> While reviewing the "Secure APIs with API Keys" documentation, I discovered that only documented the deployment steps but omitted the critical publishing step in the lifecycle management. For new users unfamiliar with WSO2 APIM workflows, this creates confusion:
> 
> 1. Users follow the steps to create, configure API key security, and deploy the API to the gateway
> 2. Users then try to find the API in the Developer Portal to test subscription and key generation
> 3. The API doesn't appear because it hasn't been published to the Developer Portal yet
> 4. Users are left wondering where the API is or what step they missed
> 
> **Solution Implemented:**
> Added Step 6 to the `create-publish-api.md` include file with clear instructions about publishing the API:
> - Explicitly states that the API must be published to the Developer Portal
> - Directs users to the Lifecycle section in the Publisher
> - Explains that publishing makes the API visible to subscribers
> - Bridges the gap between deployment and Developer Portal visibility

## User stories
> - As a new APIM user following the API key authentication tutorial, I want to understand all required steps to make my API available for subscription so that I can successfully test API key generation and invocation
> - As a developer deploying my first API with API-bound keys, I need clear guidance on the complete workflow so that I don't miss critical steps between deployment and testing in the Developer Portal

## Release note
> Enhanced "Create publish api" documentation to include explicit instructions for publishing the API to the Developer Portal after deployment, clarifying the complete workflow and preventing user confusion when APIs don't appear in the Developer Portal.

## Documentation
> Modified: `/en/docs/includes/design/create-publish-api.md`
> 
> The include file is referenced in:
> - `/en/docs/api-security/runtime/api-authentication/secure-apis-using-api-keys.md` (Step 1)
> 
> This change will automatically propagate to all documentation pages that reference this include file, ensuring consistent guidance across the documentation.

## Training
> N/A - This is a documentation clarification that aligns with existing training content

## Certification
> N/A - This change does not introduce new features or alter existing functionality; it clarifies existing processes in the documentation.

## Marketing
> N/A - This is an internal documentation improvement for user guidance

## Automation tests
 - Unit tests 
   > N/A - Documentation change only
 - Integration tests
   > N/A - Documentation change only

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (Documentation)
 - Ran FindSecurityBugs plugin and verified report? N/A (Documentation)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
> N/A - No code samples added; documentation clarification only

## Related PRs
> None

## Migrations (if applicable)
> N/A - No migration steps required

## Test environment
> Documentation review and validation across all browsers and devices. Content verified for accuracy against WSO2 API Manager 4.7.0+ behavior.

## Learning
> During the documentation review process, I identified a common onboarding friction point where new users were confused about why their newly created and deployed API wasn't visible in the Developer Portal. Through research of user feedback and APIM workflow documentation, I determined that the missing explicit publishing step in the include file was the root cause. The solution adds a clear, concise step that bridges the deployment and Developer Portal visibility gap, improving the overall user experience for API Manager newcomers.
