### PR TITLE
Fix TokenExchange sequence example in custom authorization token guide

### DIFF
--- a/en/docs/api-gateway/policies/passing-a-custom-authorization-token-to-the-backend.md
+++ b/en/docs/api-gateway/policies/passing-a-custom-authorization-token-to-the-backend.md
@@ -20,8 +20,8 @@ Here's a summary:
     !!! example
         ```xml
         <sequence xmlns="http://ws.apache.org/ns/synapse" name="TokenExchange">
-            <property name="Custom" expression="get-property('transport', 'Custom')"/>
-            <property name="Authorization" expression="get-property('Custom')" scope="transport"/>
+            <property name="CustomValue" expression="get-property('transport', 'Custom')"/>
+            <property name="Authorization" expression="get-property('CustomValue')" scope="transport"/>
             <property name="Custom" scope="transport" action="remove"/>
         </sequence>
         ```


### PR DESCRIPTION
## Purpose
 Fix the broken `TokenExchange` sequence example in the "Passing a Custom Authorization Token to the Backend" documentation. The intermediate Synapse property and the original transport header both used the name `Custom`, so `get-property('Custom')` resolved to the wrong scope and the example did not exchange the token as described.

 Resolves: wso2/docs-apim#11155

## Goals
 Make the documented example work as written by giving the intermediate property a unique name (`CustomValue`), so readers who copy the snippet get the behavior the surrounding text describes.

## Approach
 Rename the intermediate property in the `TokenExchange` sequence from `Custom` to `CustomValue` in `en/docs/api-gateway/policies/passing-a-custom-authorization-token-to-the-backend.md`. This matches the fix proposed in the issue. Text-only documentation change, no behavioral or build impact.

## User stories
 As a reader following this guide, I want the sequence example to work when I copy it into `tokenExchange.j2`, so that the `Custom` header value is correctly promoted to the `Authorization` header before the request reaches the backend.

## Release note
 Documentation: Fixed the `TokenExchange` sequence example in "Passing a Custom Authorization Token to the Backend" to use a distinct intermediate property name.

## Documentation
 Updated file: `en/docs/api-gateway/policies/passing-a-custom-authorization-token-to-the-backend.md`

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests
   > N/A (documentation-only change)
 - Integration tests
   > N/A (documentation-only change)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (documentation-only change)
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A (text-only change)

## Learning
 Re-read the Synapse `get-property` semantics: when the second argument is omitted it looks up the default scope, so reusing the transport header name `Custom` for an intermediate property masked the intended value. Renaming the intermediate property to `CustomValue` removes the collision.
