### PR TITLE
Fix broken links in best practices pages

### DIFF
--- a/en/docs/reference/best-practices-endpoints.md
+++ b/en/docs/reference/best-practices-endpoints.md
@@ -1,6 +1,6 @@
 # Best practices for working with endpoints
 
-- Do not use anonymous endpoints. Always use [named endpoints]({{base_path}}/reference/synapse-properties/endpoint-properties). As anynymous endpoints have auto-generated names in the synapse
+- Do not use anonymous endpoints. Always use [named endpoints](https://mi.docs.wso2.com/en/latest/reference/synapse-properties/endpoint-properties/). As anynymous endpoints have auto-generated names in the synapse
   configuration, it is difficult to identify which endpoint is causing
   the error in case of an error.
 
@@ -34,7 +34,7 @@
   <td><code>[transport.http] 
   socket_timeout = 180000                
   </code></td>
-  <td>The socket timeout of the <a href="{{base_path}}/install-and-setup/setup/mi-setup/transport_configurations/">Passthrough</a> http/https transport sender and listener. You can find the <a href="{{base_path}}/install-and-setup/setup/mi-setup/transport_configurations/">passthru-http.properties</a> file in the <code>&lt;EI_HOME&gt;/conf</code> directory.</td>
+  <td>The socket timeout of the Passthrough http/https transport sender and listener. You can find the passthru-http.properties file in the <code>&lt;EI_HOME&gt;/conf</code> directory.</td>
   <td><code>deployment.toml</code></td>
   <td>180000</td>
   <td>180000</td>
@@ -107,13 +107,13 @@
   perform [endpoint error handling](https://mi.docs.wso2.com/en/latest/reference/synapse-properties/endpoint-properties/#endpoint-error-handling-properties)
   based on the use case.
 
-- Use the [HTTP endpoint]({{base_path}}/install-and-setup/setup/mi-setup/transport_configurations/configuring-transports)
+- Use the [HTTP endpoint](https://mi.docs.wso2.com/en/latest/install-and-setup/setup/transport-configurations/configuring-transports/)
   for RESTful service invocations. The HTTP endpoint is especially
   designed to make RESTful service integration easy. For example, it
   supports `url-templates` , which is an option
   to set the http method.
 
-- For RESTful service integration, use either [REST APIs]({{base_path}}/reference/synapse-properties/rest-api-properties)
+- For RESTful service integration, use either [REST APIs](https://mi.docs.wso2.com/en/latest/reference/synapse-properties/rest-api-properties/)
   or HTTP endpoints. You can use REST APIs to expose an integration
   solution as a RESTful service, and use HTTP endpoints to logically
   represent a RESTful backend service.

--- a/en/docs/reference/wso2-api-manager-best-practices.md
+++ b/en/docs/reference/wso2-api-manager-best-practices.md
@@ -2,43 +2,43 @@
 
 Here are the guidelines and recommendations to design and deploy APIs using WSO2 API Manager:
 
--   [Proper Naming APIs](#WSO2APIManagerBestPractices-ProperNamingAPIs)
-    -   [Naming Resources](#WSO2APIManagerBestPractices-NamingResources)
-    -   [Naming Complex Resources](#WSO2APIManagerBestPractices-NamingComplexResources)
--   [Proper Versioning](#WSO2APIManagerBestPractices-ProperVersioning)
-    -   [Advantages of API Versioning](#WSO2APIManagerBestPractices-AdvantagesofAPIVersioning)
-    -   [Major, Minor, Patch Versions](#WSO2APIManagerBestPractices-Major,Minor,PatchVersions)
+-   [Proper Naming APIs](#proper-naming-apis)
+    -   [Naming Resources](#naming-resources)
+    -   [Naming Complex Resources](#naming-complex-resources)
+-   [Proper Versioning](#proper-versioning)
+    -   [Advantages of API Versioning](#advantages-of-api-versioning)
+    -   [Major, Minor, Patch Versions](#major-minor-patch-versions)
 
-### Best practices for creating an API
+## Best practices for creating an API
 
--   [Create APIs](https://docs.wso2.com/display/AM260/Create+and+Publish+an+API) for dedicated backend services.
--   For each of the resources, decide on the [HTTP methods that are used to perform the required application functions](https://docs.wso2.com/display/AM210/Key+Concepts#KeyConcepts-HTTPmethods) . This includes the use of applicable HTTP headers.
+-   [Create APIs]({{base_path}}/api-design-manage/design/create-api/create-rest-api/create-a-rest-api/) for dedicated backend services.
+-   For each of the resources, decide on the [HTTP methods that are used to perform the required application functions]({{base_path}}/get-started/key-concepts/) . This includes the use of applicable HTTP headers.
 -   Decide on special behaviors required by the application (e.g., concurrency control, long running requests).
--   Identify potential [error-prone situations and define corresponding error messages](_Error_Handling_) .
+-   Identify potential [error-prone situations and define corresponding error messages]({{base_path}}/reference/troubleshooting/error-handling/) .
 
-#### Proper Naming APIs
+### Proper Naming APIs
 
 It's important to have proper names for services and service paths. For example, if you create an API related to camera-related operations, you can select a name with camera-related terms such a “camera-api”. When you create a resource for the API, you can select names such as “capture-image”, “delete-image”. Resources must be named properly through URIs (Uniform Resource Identifiers). Proper naming of resources is key to increase the understandability of an API to its users.
 
 Following are some of the guidelines for designing proper API/Resource paths and names. Note that these are not mandatory rules but best practices.
 
-##### Naming Resources
+#### Naming Resources
 
 Atomic resources, collection resources, and composite resources should be named as nouns because they represent ‘things’; not ‘actions’. Actions lean more towards verbs as names of resources. Processing-function resources and controller resources should be named as verbs because they represent actions. Function resources and controller resources should not be sub-resources of individual resources.
 
-##### Naming Complex Resources
+#### Naming Complex Resources
 
 Use lower case characters only in names. This is because the rules about which URI element names are case sensitive and which are not might cause confusion. If multiple words are used to name a resource, separate the words by dashes (-) or some other separator. Use singular nouns to name atomic resources. Use pluralized names for collections. That is, the name should be the plural noun of the grouped concept (atomic resource or composite resource). Use forward slashes /) to specify hierarchical relations between resources. A forward slash separates the names of the hierarchically structured resources. The parent name precedes the name of its immediate children.
 
-#### Proper Versioning
+### Proper Versioning
 
 The version of an API is part of its URI. It is usually given as a pair of integers (separated by a dot) referred to as the major and the minor number of the version, preceded by the lowercase letter "v". For example, a valid version string in the base path is v2.1, indicating the first minor version of the second major version of the corresponding API.
 
-##### Advantages of API Versioning
+#### Advantages of API Versioning
 
 A proper versioning strategy is helpful for all API users and clients to communicate with APIs easily and effectively. WSO2 API Manager has versioning support. You can copy existing APIs and create new versions of the same APIs. The recommended way to change the functionality of a running API is to create a new version from the existing API. You can then modify the new version, and test the functionalities of the new version before publishing it.
 
-##### Major, Minor, Patch Versions
+#### Major, Minor, Patch Versions
 
 In general, a version number following the semantic versioning concept and have the structure major.minor.patch. The significance, in terms of client impact, increases from left to right. As a best practice, you should support the current major version and at least one previous, major version. In case you release new versions frequently (e.g., every few months), it is recommended to support more previous major versions.
 


### PR DESCRIPTION
## Purpose
This PR fixes the broken links in the following pages.

1. https://apim.docs.wso2.com/en/latest/reference/wso2-api-manager-best-practices/
2. https://apim.docs.wso2.com/en/latest/reference/best-practices-endpoints/