### PR TITLE
Fix broken Adding Dynamic Endpoints hyperlink

### DIFF
--- a/en/docs/api-design-manage/design/endpoints/endpoint-types.md
+++ b/en/docs/api-design-manage/design/endpoints/endpoint-types.md
@@ -25,7 +25,7 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
-<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="../api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
+<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/api-gateway/policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
 </tr>
 <tr><td>Mock Implementation</td>
 <td>

--- a/en/docs/api-design-manage/design/endpoints/endpoint-types.md
+++ b/en/docs/api-design-manage/design/endpoints/endpoint-types.md
@@ -25,7 +25,7 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
-<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/api-design-manage/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
+<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="../api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
 </tr>
 <tr><td>Mock Implementation</td>
 <td>


### PR DESCRIPTION
Corrected the internal documentation link for the "Adding Dynamic Endpoints" reference in the Endpoint Types page.

## Purpose
The Endpoint Types documentation contained an incorrect internal link to the “Adding Dynamic Endpoints” section.

This could lead users to a broken or invalid navigation path within the API Manager documentation, affecting usability and navigation consistency.

## Goals
Ensure the link correctly navigates to the relevant documentation page.

## Approach
Replaced the incorrect link with a working relative path.

Before:
[[Adding Dynamic Endpoints]({{base_path}}/api-design-manage/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/)](https://apim.docs.wso2.com/en/4.7.0/api-design-manage/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/)

After:
[[Adding Dynamic Endpoints](../api-policies/regular-gateway-policies/adding-dynamic-endpoints/)](https://apim.docs.wso2.com/en/4.2.0/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/)

This ensures correct navigation to the target documentation page.

## User stories
Users can correctly navigate to the "Adding Dynamic Endpoints" documentation without encountering broken links.

## Release note
Fixed an incorrect internal documentation link in the Endpoint Types page for “Adding Dynamic Endpoints”.

## Documentation
N/A – This PR is a documentation correction with no new feature or structural change.

