### PR TITLE
Add enable_legacy_api_keys to config list

### DIFF
--- a/en/tools/config-catalog-generator/data/apim.devportal.toml
+++ b/en/tools/config-catalog-generator/data/apim.devportal.toml
@@ -9,4 +9,5 @@ display_deprecated_apis = false
 enable_comments = true
 enable_ratings = true
 enable_forum = true
+enable_legacy_api_keys = true
 mode = "HYBRID"

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1642,6 +1642,14 @@
                             "description": "^"
                         },
                         {
+                            "name": "enable_legacy_api_keys",
+                            "type": "string",
+                            "required": false,
+                            "default": "FALSE",
+                            "possible": "",
+                            "description": "The config to enable application bound legacy API key option."
+                        },
+                        {
                             "name": "application_sharing_claim",
                             "type": "string",
                             "required": false,


### PR DESCRIPTION
This pull request introduces the configuration option to enable support for legacy API keys in the API management developer portal.

Configuration option added:

* Added `enable_legacy_api_keys` setting to `apim.devportal.toml` to allow enabling legacy API key support in the developer portal.
* Documented the `enable_legacy_api_keys` option in `configs.json`, including its type, default value, and description.