### PR TITLE
Fix grammar issue in REST API overview documentation

### DIFF
--- a/en/docs/reference/product-apis/overview.md
+++ b/en/docs/reference/product-apis/overview.md
@@ -1,6 +1,6 @@
 # RESTful APIs
 
-The following topics list the APIs exposed from the API Publisher, Developer Portal, Admin Portal, Gateway, Service Catalog, Devops and Governance which you can use to create and manage APIs. You can consume APIs directly through their UIs or, an external REST client like cURL.
+The following topics list the APIs exposed from the API Publisher, Developer Portal, Admin Portal, Gateway, Service Catalog, Devops and Governance which you can use to create and manage APIs. You can consume APIs directly through their UIs or an external REST client like cURL.
 
 <br>
 <table>


### PR DESCRIPTION
## Description
Fixed a minor grammar issue in the REST API overview documentation.

Changed:
"or, an external REST client."

To:
"or an external REST client."

## Purpose
Improve grammar and readability.