### PR TITLE
[4.2.0] Add mediator access control configuration guidelines

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -336,7 +336,7 @@ tryItFunctionalityDisabled = true
 <tr class="odd">
 <td><p>Mediator Access Control</p></td>
 <td>
-<p>API/Operation Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/).</p>
+<p>API/Operation policies are designed to extend and customize API gateway behavior. They use Synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/).</p>
 
 <p>To provide better control over mediator usage, a mediator access control configuration has been introduced. This configuration allows administrators to allow or block mediators based on deployment requirements.</p>
 
@@ -345,7 +345,7 @@ tryItFunctionalityDisabled = true
 <br/>
 <br/>
 
-<b>Allowlist Configuration:</b>
+<b>Allow list Configuration:</b>
 
 <br/>
 
@@ -357,7 +357,7 @@ tryItFunctionalityDisabled = true
 
 <br/>
 
-<b>Blocklist Configuration:</b>
+<b>Block list Configuration:</b>
 
 <br/>
 
@@ -383,7 +383,7 @@ The following configuration is the recommended configuration for allowing only t
 
 <br/>
 
-If you use any other mediators, or if you want to enable mediators that are not included in the recommended allowlist, review the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/) to understand their capabilities and use cases before adding them to the configuration.
+If you use any other mediators, or if you want to enable mediators that are not included in the recommended allow list, review the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/) to understand their capabilities and use cases before adding them to the configuration.
 </td>
 </tr>
 </tbody>
@@ -973,7 +973,7 @@ This section provides a list of security guidelines for configuring the network
 <li>In addition to the &quot;/services&quot; and &quot;/carbon&quot; contexts, be sure to expose only the required applications in your product to users beyond the DMZ level in your network.</li>
 </ul>
 <p><strong>Note:</strong> </p>
-<p>It is recommended to use an allowlisting approach when allowing access to resources in your product from the DMZ level.</p>
+<p>It is recommended to use an allow listing approach when allowing access to resources in your product from the DMZ level.</p>
 
 <p>For the API-M Developer Portal, exposing the following paths would be sufficient:</p>
     <ul>

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -336,7 +336,7 @@ tryItFunctionalityDisabled = true
 <tr class="odd">
 <td><p>Mediator Access Control</p></td>
 <td>
-<p>API/Operational Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/).</p>
+<p>API/Operation Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/).</p>
 
 <p>To provide better control over mediator usage, a mediator access control configuration has been introduced. This configuration allows administrators to allow or block mediators based on deployment requirements.</p>
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -333,6 +333,59 @@ tryItFunctionalityDisabled = true
 </code></pre>
 </td>
 </tr>
+<tr class="odd">
+<td><p>Mediator Access Control</p></td>
+<td>
+<p>API/Operational Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the mediator catalog [1].</p>
+
+<p>To provide better control over mediator usage, a mediator access control configuration has been introduced. This configuration allows administrators to allow or block mediators based on deployment requirements.</p>
+
+<p>Add the following configuration to the <code>&lt;APIM_HOME&gt;/repository/conf/deployment.toml</code> file.</p>
+
+<br/>
+<br/>
+
+<b>Allowlist Configuration:</b>
+
+<br/>
+
+<pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>
+[synapse_properties]
+'synapse.mediators.access.control.mode' = “ALLOW_LIST”
+'synapse.mediators.access.control.list' = “&lt;mediator localnames comma separated eg: property, log&gt;”
+</code></pre>
+
+<br/>
+
+<b>Blocklist Configuration:</b>
+
+<br/>
+
+<pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>
+[synapse_properties]
+'synapse.mediators.access.control.mode' = “BLOCK_LIST”
+'synapse.mediators.access.control.list' = “&lt;mediator localnames comma separated eg: property, log&gt;”
+</code></pre>
+
+<br/>
+
+<b>Recommended Configuration:</b>
+
+<br/>
+
+The following configuration is the recommended configuration for allowing only the simple mediators, along with the mediators that are used by default in API Manager for common use cases. 
+
+<pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>
+[synapse_properties]
+'synapse.mediators.access.control.mode' = “ALLOW_LIST”
+'synapse.mediators.access.control.list' = “aggregate,builder,cache,call,class,clone,drop,enrich,filter,foreach,header,in,iterate,log,loopback,makefault,opa,out,payloadfactory,property,propertygroup,respond,rewrite,scatter-gather,script,send,sequence,switch,throwerror,variable”
+</code></pre>
+
+<br/>
+
+If you use any other mediators, or if you want to enable mediators that are not included in the recommended allowlist, review the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/) to understand their capabilities and use cases before adding them to the configuration.
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -336,7 +336,7 @@ tryItFunctionalityDisabled = true
 <tr class="odd">
 <td><p>Mediator Access Control</p></td>
 <td>
-<p>API/Operational Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the mediator catalog [1].</p>
+<p>API/Operational Policies are designed to extend and customize API gateway behavior. They use synapse mediators to support use cases such as message transformation, routing control, backend interaction handling, and organization-specific policy enforcement. These capabilities allow users to adapt gateway behavior based on deployment requirements. For more information, see the [mediator catalog](https://mi.docs.wso2.com/en/latest/reference/mediators/about-mediators/).</p>
 
 <p>To provide better control over mediator usage, a mediator access control configuration has been introduced. This configuration allows administrators to allow or block mediators based on deployment requirements.</p>
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -15027,3 +15027,84 @@ use_username_as_sub_claim = true
         </div>
     </section>
 </div>
+
+
+
+## Synapse Properties
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="100" type="checkbox" id="_tab_100">
+                <label class="tab-selector" for="_tab_100"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[synapse_properties]
+'synapse.mediators.access.control.mode' = "ALLOW_LIST"
+'synapse.mediators.access.control.list' = "aggregate,builder,cache,call,class,clone,drop,enrich,filter,foreach,header,in,iterate,log,loopback,makefault,opa,out,payloadfactory,property,propertygroup,respond,rewrite,scatter-gather,script,send,sequence,switch,throwerror,variable"
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[synapse_properties]</code>
+                            
+                            <p>
+                                This includes configurations for synapse runtime.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>&#39;synapse.mediators.access.control.mode&#39;</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>NONE</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>NONE, ALLOW_LIST, DENY_LIST</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, it is set to ALLOW_LIST, which means only mediators explicitly listed in the allow list will be accessible. Adjust this setting based on your security requirements and the mediators you need to use in your API configurations.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>&#39;synapse.mediators.access.control.list&#39;</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>comma-separated list of mediator local names</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>This property specifies the list of mediators for access control based on the mode defined in &#39;synapse.mediators.access.control.mode&#39;. It should be a comma-separated list of mediator class names. For example, if &#39;synapse.mediators.access.control.mode&#39; is set to ALLOW_LIST, only the mediators listed in this property will be accessible. If the mode is set to DENY_LIST, the mediators listed here will be blocked from access. If the mode is NONE, this property is ignored. Configure this list according to the mediators you want to allow or deny access to in your Synapse runtime environment.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -15076,7 +15076,7 @@ use_username_as_sub_claim = true
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, it is set to ALLOW_LIST, which means only mediators explicitly listed in the allow list will be accessible. Adjust this setting based on your security requirements and the mediators you need to use in your API configurations.</p>
+                                        <p>This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, the access control mode is set to NONE, which means that all mediators are accessible. You can change this mode based on your security requirements and specify the list of mediators for access control using the &#39;synapse.mediators.access.control.list&#39; property.</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -5581,6 +5581,35 @@
                 }
             ],
             "exampleFile": "service_provider.toml"
-        }
+        },
+        {
+          "title": "Synapse Properties",
+          "options": [
+              {
+                  "name": "synapse_properties",
+                  "required": false,
+                  "description": "This includes configurations for synapse runtime.",
+                  "params": [
+                      {
+                          "name": "'synapse.mediators.access.control.mode'",
+                          "type": "string",
+                          "required": false,
+                          "default": "NONE",
+                          "possible": "NONE, ALLOW_LIST, DENY_LIST",
+                          "description": "This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, it is set to ALLOW_LIST, which means only mediators explicitly listed in the allow list will be accessible. Adjust this setting based on your security requirements and the mediators you need to use in your API configurations."
+                      },
+                      {
+                          "name": "'synapse.mediators.access.control.list'",
+                          "type": "string",
+                          "required": false,
+                          "default": "",
+                          "possible": "comma-separated list of mediator local names",
+                          "description": "This property specifies the list of mediators for access control based on the mode defined in 'synapse.mediators.access.control.mode'. It should be a comma-separated list of mediator class names. For example, if 'synapse.mediators.access.control.mode' is set to ALLOW_LIST, only the mediators listed in this property will be accessible. If the mode is set to DENY_LIST, the mediators listed here will be blocked from access. If the mode is NONE, this property is ignored. Configure this list according to the mediators you want to allow or deny access to in your Synapse runtime environment."
+                      }
+                  ]
+              }
+          ],
+          "exampleFile": "synapse_properties.toml"
+      }
     ]
 }

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -5596,7 +5596,7 @@
                           "required": false,
                           "default": "NONE",
                           "possible": "NONE, ALLOW_LIST, DENY_LIST",
-                          "description": "This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, it is set to ALLOW_LIST, which means only mediators explicitly listed in the allow list will be accessible. Adjust this setting based on your security requirements and the mediators you need to use in your API configurations."
+                          "description": "This property controls the access control mode for mediators in the Synapse runtime. It can be set to one of the following values: NONE (no access control), ALLOW_LIST (only mediators in the allow list are accessible), DENY_LIST (mediators in the deny list are not accessible). By default, the access control mode is set to NONE, which means that all mediators are accessible. You can change this mode based on your security requirements and specify the list of mediators for access control using the 'synapse.mediators.access.control.list' property."
                       },
                       {
                           "name": "'synapse.mediators.access.control.list'",

--- a/en/tools/config-catalog-generator/data/synapse_properties.toml
+++ b/en/tools/config-catalog-generator/data/synapse_properties.toml
@@ -1,0 +1,3 @@
+[synapse_properties]
+'synapse.mediators.access.control.mode' = "ALLOW_LIST"
+'synapse.mediators.access.control.list' = "aggregate,builder,cache,call,class,clone,drop,enrich,filter,foreach,header,in,iterate,log,loopback,makefault,opa,out,payloadfactory,property,propertygroup,respond,rewrite,scatter-gather,script,send,sequence,switch,throwerror,variable"


### PR DESCRIPTION
## Purpose

This pull request adds documentation for configuring mediator access control in the API gateway deployment best practices. The new section explains how administrators can use allowlist or blocklist configurations to restrict which synapse mediators are permitted, improving security and customization of API gateway behavior.

**Mediator Access Control Configuration:**

* Added a new section describing how to control access to synapse mediators using either an allowlist or blocklist approach in the `deployment.toml` configuration file, including example configurations for both modes.
* Provided a recommended allowlist configuration that includes only the simple mediators and those required for common API Manager use cases, along with guidance on how to safely enable additional mediators if needed.
* Linked to the official mediator catalog for further reference on mediator capabilities and use cases.