### PR TITLE
Fix/k8s deployment docs master

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -126,7 +126,7 @@ WSO2 API Manager 4.7.0 uses Envoy Gateway by default for routing and it is the r
     helm install apim wso2/wso2am-all-in-one \
       --version 4.7.0-1 \
       --namespace apim --create-namespace \
-      -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-0-all-in-one/default_values.yaml \
+      -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-0-all-in-one/default_values.yaml \
       --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -241,7 +241,7 @@ Pattern 1 uses a single Helm chart release with two pod replicas forming the act
 1. Download the default values file as a starting point:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-1-all-in-one-HA/default_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-1-all-in-one-HA/default_values.yaml \
       -o values.yaml
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -266,19 +266,21 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 
     Replace `<JDBC_URL_FOR_APIM_DB>` and `<JDBC_URL_FOR_SHARED_DB>` with the JDBC connection URL for your database. For URL formats per database type, see [Setting Up Databases]({{base_path}}/install-and-setup/setup/setting-up-databases/overview/#changing-the-default-databases).
 
-3. Deploy the All-in-One:
+3. Generate the encryption key and deploy the All-in-One:
+
+    !!! warning "Encryption key is mandatory"
+        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key**. Generate it once and keep `$APIM_ENCRYPTION_KEY` set in your shell for the Gateway deploy step that follows.
 
     ```bash
+    export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
     helm install apim wso2/wso2am-all-in-one \
       --version 4.7.0-1 \
       --namespace apim --create-namespace \
       --dependency-update \
       -f values-aio.yaml \
-      --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
-
-    !!! warning "Encryption key is mandatory"
-        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. The command above generates one automatically. For production or shared environments, generate the key separately, store it securely, and set it explicitly in your `values-aio.yaml` under `wso2.apim.configurations.encryption.key`.
 
 4. Wait for the pod to be ready:
 
@@ -297,7 +299,8 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -890,25 +893,27 @@ When enabling HA, also update the EventHub and throttling URLs in `values-gw.yam
 
 ### 6. Deploy with Custom Values { #section-6 }
 
-Once your values files are configured, deploy both components with:
+Once your values files are configured, generate the encryption key once and deploy both components with the same key:
 
 ```bash
-helm install <release-name> <helm-chart-path-aio> \
-  --version 4.7.0-1 \
-  --namespace <namespace> --create-namespace \
-  --dependency-update \
-  -f values-aio.yaml
+export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
 
-helm install <gw-release-name> <helm-chart-path-gw> \
+helm install apim wso2/wso2am-all-in-one \
   --version 4.7.0-1 \
-  --namespace <namespace> \
+  --namespace apim --create-namespace \
   --dependency-update \
-  -f values-gw.yaml
+  -f values-aio.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
+
+helm install apim-gw wso2/wso2am-universal-gw \
+  --version 4.7.0-1 \
+  --namespace apim \
+  --dependency-update \
+  -f values-gw.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! tip "Deployment Parameters"
-    - `<release-name>` — Name for the All-in-One Helm release (e.g. `apim`)
-    - `<gw-release-name>` — Name for the Gateway Helm release (e.g. `apim-gw`)
+    - Release names: `apim`, `apim-gw`
     - `<namespace>` — Kubernetes namespace to deploy into (e.g. `apim`)
-    - `<helm-chart-path-aio>` — Path to the All-in-One Helm chart (`wso2/wso2am-all-in-one` or a local clone)
-    - `<helm-chart-path-gw>` — Path to the Gateway Helm chart (`wso2/wso2am-universal-gw` or a local clone)
+    - Helm chart paths: `wso2/wso2am-all-in-one`, `wso2/wso2am-universal-gw` (or local clones)

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -230,7 +230,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the All-in-One:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-2-all-in-one_GW/default_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-2-all-in-one_GW/default_values.yaml \
       -o values-aio.yaml
     ```
 
@@ -297,13 +297,13 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used a different release name than `apim` for the All-in-One, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-gw.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-2-all-in-one_GW/default_gw_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-2-all-in-one_GW/default_gw_values.yaml \
       -o values-gw.yaml
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -266,19 +266,21 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 
     Replace `<JDBC_URL_FOR_APIM_DB>` and `<JDBC_URL_FOR_SHARED_DB>` with the JDBC connection URL for your database. For URL formats per database type, see [Setting Up Databases]({{base_path}}/install-and-setup/setup/setting-up-databases/overview/#changing-the-default-databases).
 
-3. Deploy the API Control Plane:
+3. Generate the encryption key and deploy the API Control Plane:
+
+    !!! warning "Encryption key is mandatory"
+        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key**. Generate it once and keep `$APIM_ENCRYPTION_KEY` set in your shell for the Traffic Manager and Gateway deploy steps that follow.
 
     ```bash
+    export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
     helm install apim-acp wso2/wso2am-acp \
       --version 4.7.0-1 \
       --namespace apim --create-namespace \
       --dependency-update \
       -f values-acp.yaml \
-      --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
-
-    !!! warning "Encryption key is mandatory"
-        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key** — generate it once, store it securely, and set it explicitly in all values files rather than relying on the auto-generated value above.
 
 4. Wait for the ACP pod to be ready:
 
@@ -297,7 +299,8 @@ helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -316,7 +319,8 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -898,27 +902,31 @@ See [Working with user store properties](https://apim.docs.wso2.com/en/latest/ad
 
 ### 6. Deploy with Custom Values { #section-6 }
 
-Once your values files are configured, deploy all three components with:
+Once your values files are configured, generate the encryption key once and deploy all three components with the same key:
 
 ```bash
+export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
 helm install apim-acp wso2/wso2am-acp \
   --version 4.7.0-1 \
   --namespace apim --create-namespace \
   --dependency-update \
   -f values-acp.yaml \
-  --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-tm.yaml
+  -f values-tm.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-gw.yaml
+  -f values-gw.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! tip "Deployment Parameters"

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -230,7 +230,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the API Control Plane:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-3-ACP_TM_GW/default_acp_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_acp_values.yaml \
       -o values-acp.yaml
     ```
 
@@ -297,13 +297,13 @@ helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used a different release name than `apim-acp` for the ACP, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-tm.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-3-ACP_TM_GW/default_tm_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_tm_values.yaml \
       -o values-tm.yaml
     ```
 
@@ -316,13 +316,13 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used different release names than `apim-acp` and `apim-tm`, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-gw.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-3-ACP_TM_GW/default_gw_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-3-ACP_TM_GW/default_gw_values.yaml \
       -o values-gw.yaml
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -270,19 +270,21 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 
     Replace `<JDBC_URL_FOR_APIM_DB>` and `<JDBC_URL_FOR_SHARED_DB>` with the JDBC connection URL for your database. For URL formats per database type, see [Setting Up Databases]({{base_path}}/install-and-setup/setup/setting-up-databases/overview/#changing-the-default-databases).
 
-3. Deploy the API Control Plane:
+3. Generate the encryption key and deploy the API Control Plane:
+
+    !!! warning "Encryption key is mandatory"
+        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key**. Generate it once and keep `$APIM_ENCRYPTION_KEY` set in your shell for the Key Manager, Traffic Manager, and Gateway deploy steps that follow.
 
     ```bash
+    export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
     helm install apim-acp wso2/wso2am-acp \
       --version 4.7.0-1 \
       --namespace apim --create-namespace \
       --dependency-update \
       -f values-acp.yaml \
-      --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
-
-    !!! warning "Encryption key is mandatory"
-        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key** — generate it once, store it securely, and set it explicitly in all values files rather than relying on the auto-generated value above.
 
 4. Wait for the ACP pod to be ready:
 
@@ -343,7 +345,8 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
       --version 4.7.0-1 \
       --namespace apim \
       --dependency-update \
-      -f values-km.yaml
+      -f values-km.yaml \
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
 
 4. Wait for the Key Manager pod to be ready:
@@ -363,7 +366,8 @@ helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -382,7 +386,8 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -946,33 +951,38 @@ See [Working with user store properties](https://apim.docs.wso2.com/en/latest/ad
 
 ### 6. Deploy with Custom Values { #section-6 }
 
-Once your values files are configured, deploy all four components in order:
+Once your values files are configured, generate the encryption key once and deploy all four components in order with the same key:
 
 ```bash
+export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
 helm install apim-acp wso2/wso2am-acp \
   --version 4.7.0-1 \
   --namespace apim --create-namespace \
   --dependency-update \
   -f values-acp.yaml \
-  --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-km wso2/wso2am-km \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-km.yaml
+  -f values-km.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-tm.yaml
+  -f values-tm.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-gw.yaml
+  -f values-gw.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! tip "Deployment Parameters"

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -234,7 +234,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the API Control Plane:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_acp_values.yaml \
       -o values-acp.yaml
     ```
 
@@ -297,7 +297,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the Key Manager:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_km_values.yaml \
       -o values-km.yaml
     ```
 
@@ -363,13 +363,13 @@ helm install apim-tm wso2/wso2am-tm \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used different release names than `apim-km` and `apim-acp`, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-tm.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_tm_values.yaml \
       -o values-tm.yaml
     ```
 
@@ -382,13 +382,13 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used different release names than `apim-km`, `apim-acp`, and `apim-tm`, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-gw.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-4-ACP_TM_GW_KM/default_gw_values.yaml \
       -o values-gw.yaml
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -248,7 +248,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the All-in-One:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-5-all-in-one_GW_KM/default_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_values.yaml \
       -o values-aio.yaml
     ```
 
@@ -327,7 +327,7 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 1. Download the default values file for the Key Manager:
 
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_km_values.yaml \
       -o values-km.yaml
     ```
 
@@ -393,13 +393,13 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
 ```
 
 !!! note "To customise before deploying"
     If you used different release names than `apim-km` and `apim`, or want to make other changes, download the values file first, edit it, then replace the `-f <url>` above with `-f values-gw.yaml`:
     ```bash
-    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml \
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml \
       -o values-gw.yaml
     ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -300,19 +300,21 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
 
     Replace `<JDBC_URL_FOR_APIM_DB>` and `<JDBC_URL_FOR_SHARED_DB>` with the JDBC connection URL for your database. For URL formats per database type, see [Setting Up Databases]({{base_path}}/install-and-setup/setup/setting-up-databases/overview/#changing-the-default-databases).
 
-3. Deploy the All-in-One:
+3. Generate the encryption key and deploy the All-in-One:
+
+    !!! warning "Encryption key is mandatory"
+        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. In a distributed deployment, **all components must use the same key**. Generate it once and keep `$APIM_ENCRYPTION_KEY` set in your shell for the Key Manager and Gateway deploy steps that follow.
 
     ```bash
+    export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
     helm install apim wso2/wso2am-all-in-one \
       --version 4.7.0-1 \
       --namespace apim --create-namespace \
       --dependency-update \
       -f values-aio.yaml \
-      --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
-
-    !!! warning "Encryption key is mandatory"
-        WSO2 API Manager 4.7.0 requires a 256-bit encryption key before first startup. The command above generates one automatically. For production or shared environments, generate the key separately, store it securely, and set it explicitly in your `values-aio.yaml` under `wso2.apim.configurations.encryption.key`.
 
 4. Wait for the All-in-One pod to be ready:
 
@@ -373,7 +375,8 @@ The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volu
       --version 4.7.0-1 \
       --namespace apim \
       --dependency-update \
-      -f values-km.yaml
+      -f values-km.yaml \
+      --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
     ```
 
 4. Wait for the Key Manager pod to be ready:
@@ -393,7 +396,8 @@ helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-5-all-in-one_GW_KM/default_gw_values.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! note "To customise before deploying"
@@ -968,27 +972,31 @@ When enabling HA, also update the EventHub and throttling URLs in `values-gw.yam
 
 ### 6. Deploy with Custom Values { #section-6 }
 
-Once your values files are configured, deploy all three components in order:
+Once your values files are configured, generate the encryption key once and deploy all three components in order with the same key:
 
 ```bash
+export APIM_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
 helm install apim wso2/wso2am-all-in-one \
   --version 4.7.0-1 \
   --namespace apim --create-namespace \
   --dependency-update \
   -f values-aio.yaml \
-  --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-km wso2/wso2am-km \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-km.yaml
+  -f values-km.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 
 helm install apim-gw wso2/wso2am-universal-gw \
   --version 4.7.0-1 \
   --namespace apim \
   --dependency-update \
-  -f values-gw.yaml
+  -f values-gw.yaml \
+  --set wso2.apim.configurations.encryption.key=$APIM_ENCRYPTION_KEY
 ```
 
 !!! tip "Deployment Parameters"

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -405,7 +405,7 @@ APIM calls IS over HTTPS using the Kubernetes service name `is-identity-server:9
     helm install apim wso2/wso2am-all-in-one \
       --version 4.7.0-1 \
       --namespace apim \
-      -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-0-all-in-one/default_values.yaml \
+      -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-0-all-in-one/default_values.yaml \
       -f values-apim.yaml \
       --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
     ```
@@ -926,7 +926,7 @@ helm install is wso2/identity-server \
 helm install apim wso2/wso2am-all-in-one \
   --version 4.7.0-1 \
   --namespace apim \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-0-all-in-one/default_values.yaml \
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-0-all-in-one/default_values.yaml \
   -f values-apim.yaml \
   --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
 ```

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/kubernetes-quick-start.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/kubernetes-quick-start.md
@@ -81,7 +81,7 @@ kubectl apply \
 helm install apim wso2/wso2am-all-in-one \
   --version 4.7.0-1 \
   --namespace apim --create-namespace \
-  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-0-all-in-one/default_values.yaml \
+  -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-0-all-in-one/default_values.yaml \
   --set wso2.apim.configurations.encryption.key=$(openssl rand -hex 32)
 ```
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
@@ -278,7 +278,7 @@ The All-in-One deployment is the simplest pattern to deploy WSO2 API Manager on 
      --version 4.7.0-1 \
      --set wso2.subscription.username=<USERNAME> \
      --set wso2.subscription.password=<PASSWORD> \
-     -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/docs/am-pattern-0-all-in-one/default_openshift_values.yaml
+     -f https://raw.githubusercontent.com/wso2/helm-apim/4.7.x/resources/am-pattern-0-all-in-one/default_openshift_values.yaml
    ```
 
 ### Step 3 - Verify Deployment


### PR DESCRIPTION
## Purpose
>   - Fix values file URL paths for missed files — All helm-apim/4.7.x/docs/ URLs updated to helm-apim/4.7.x/resources/ following the path change in the helm-apim repository (affects all pattern docs, quick-start, and OpenShift overview)                                                                                                                                              
>  - Fix missing encryption key flags in distributed deployments 