### PR TITLE
Fix typo in contribution guide

### DIFF
--- a/en/CONTRIBUTE.md
+++ b/en/CONTRIBUTE.md
@@ -1,6 +1,6 @@
 # Contributing to WSO2 API Manager Documentation
 
-WSO2 API Manager (API-M) documentation is a relavitely new project that involves hosting source documentation on GitHub. This documentation is rendered using [mkdocs](https://www.mkdocs.org/), which is a static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.
+WSO2 API Manager (API-M) documentation is a relatively new project that involves hosting source documentation on GitHub. This documentation is rendered using [mkdocs](https://www.mkdocs.org/), which is a static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.
 
 We are an open-source project registered under Apache license.
 


### PR DESCRIPTION
Purpose
N/A (doc-only typo fix)

Goals
Correct a spelling error in the contribution guide.

Approach
Update the typo to the correct word; no behavior changes.

User stories
As a contributor, I want clear contribution guidelines without spelling errors.

Release note
Fix a typo in the contribution guide.

Documentation
N/A (this PR is documentation)

Training
N/A

Certification
N/A (doc-only)

Marketing
N/A

Automation tests
Unit tests: Not run (doc-only)
Integration tests: Not run (doc-only)
Security checks
Followed secure coding standards? N/A (doc-only)
Ran FindSecurityBugs? N/A (doc-only)
No secrets committed? Yes
Samples
N/A

Related PRs
N/A

Migrations (if applicable)
N/A

Test environment
N/A (doc-only)

Learning
N/A

