### PR TITLE
Fix ngrok typo in WebSub tutorial

### DIFF
--- a/en/docs/tutorials/streaming-api/create-and-publish-websub-api.md
+++ b/en/docs/tutorials/streaming-api/create-and-publish-websub-api.md
@@ -153,7 +153,7 @@ A public URL should be forwarded to `localhost:9021`, so that your local server 
           <td>Payload URL</td>
           <td>
           <code>http://3b1*******c9.ngrok.io/repo-watcher/1.0.0/webhooks_events_receiver_resource?topic=/issues</code>
-          <p>This is obtained by replacing <code>https://{GATEWAY_HOST}:9021</code> part of the **/issues** topic's <b>Callback URL</b>, with the forwarding HTTP URL from ngrock (For example, <code>http://3b1*******c9.ngrok.io</code>). </p>
+          <p>This is obtained by replacing <code>https://{GATEWAY_HOST}:9021</code> part of the **/issues** topic's <b>Callback URL</b>, with the forwarding HTTP URL from ngrok (For example, <code>http://3b1*******c9.ngrok.io</code>). </p>
           </td>
           </tr>
           <tr>


### PR DESCRIPTION
Purpose
N/A (doc-only typo fix)

Goals
Fix a typo in the ngrok reference.

Approach
Correct the misspelling of ngrok in the WebSub/WebHook tutorial.

User stories
As a reader, I want accurate tool names so I can follow the tutorial.

Release note
Fix a typo in the WebSub/WebHook tutorial.

Documentation
N/A (this PR is documentation)

Training
N/A

Certification
N/A (doc-only)

Marketing
N/A

Automation tests
Unit tests: Not run (doc-only)
Integration tests: Not run (doc-only)
Security checks
Followed secure coding standards? N/A (doc-only)
Ran FindSecurityBugs? N/A (doc-only)
No secrets committed? Yes

Samples
N/A

Related PRs
N/A

Migrations (if applicable)
N/A

Test environment
N/A (doc-only)

Learning
N/A