### PR TITLE
Clarify URL-based document heading

### DIFF
--- a/en/docs/api-design-manage/design/api-documentation/add-api-documentation.md
+++ b/en/docs/api-design-manage/design/api-documentation/add-api-documentation.md
@@ -96,7 +96,7 @@ Follow the instructions below to add documentation to an API:
 
         [![Add forum type URL based API documentation]({{base_path}}/assets/img/learn/add-docs-forum-type.png)]({{base_path}}/assets/img/learn/add-docs-forum-type.png)
 
-    #### Add an other type URL based document
+     #### Add another type URL-based document
 
      You can use this if you want to add a document using the **Other** type that points to a link that has a file reference of an external source.
 


### PR DESCRIPTION
Purpose
N/A (doc-only wording improvement)

Goals
Improve clarity in the heading for URL-based documentation.

Approach
Adjust the heading text for readability and consistency.

User stories
As a reader, I want clear headings to quickly find the right steps.

Release note
Clarify a heading in the API documentation guide.

Documentation
N/A (this PR is documentation)

Training
N/A

Certification
N/A (doc-only)

Marketing
N/A

Automation tests
Unit tests: Not run (doc-only)
Integration tests: Not run (doc-only)
Security checks
Followed secure coding standards? N/A (doc-only)
Ran FindSecurityBugs? N/A (doc-only)
No secrets committed? Yes

Samples
N/A

Related PRs
N/A

Migrations (if applicable)
N/A

Test environment
N/A (doc-only)

Learning
N/A
