### PR TITLE
Align JDK guidance with supported versions

### DIFF
--- a/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
+++ b/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
@@ -45,8 +45,8 @@ To prevent these types of security attacks, it is encouraged to disable the weak
 
 !!! tip
 
-    - To use AES-256, the Java JCE Unlimited Strength Jurisdiction Policy files need to be installed. Download them from [http://www.oracle.com/technetwork/java/javase/downloads/index.html](http://www.oracle.com/technetwork/java/javase/downloads/index.html), if your Java installation does not have it installed.
-    -   From Java 7, you must set the `jdk.certpath.disabledAlgorithms` property in the `<JAVA_HOME>/jre/lib/security/java.security` file to `jdk.certpath.disabledAlgorithms=MD2, DSA, RSA keySize < 2048` . It rejects all algorithms that have key sizes less than 2048 for MD2, DSA and RSA.
+    - For JDK 8u161+ and all newer JDKs (including JDK 21), unlimited strength crypto is enabled by default, so no additional policy files are required.
+    - For JDK 9+ (including JDK 21), set the `jdk.certpath.disabledAlgorithms` property in the `<JAVA_HOME>/conf/security/java.security` file to `jdk.certpath.disabledAlgorithms=MD2, DSA, RSA keySize < 2048`. It rejects all algorithms that have key sizes less than 2048 for MD2, DSA and RSA.
 
 #### Configuring PassThrough transport-level ciphers and TLS versions
 

--- a/en/docs/reference/customize-product/extending-api-manager/extending-gateway/writing-custom-handlers.md
+++ b/en/docs/reference/customize-product/extending-api-manager/extending-gateway/writing-custom-handlers.md
@@ -129,7 +129,7 @@ is <a href="{{base_path}}/assets/attachments/learn/api-authentication-handler.ja
 support any custom authentication mechanism by writing your own authentication handler class.
 
 Given below is an example implementation. Please find the complete project archive [here]({{base_path}}/assets/attachments/reference/org.wso2.carbon.test.authenticator.zip). 
-You can download, unzip and build the project using maven and Java 7 or 8.
+You can download, unzip and build the project using Maven and a supported JDK (for API-M 4.7, JDK 21).
 
 ``` java
 package org.wso2.carbon.test;


### PR DESCRIPTION
Purpose
Doc guidance still referenced legacy Java 7/8 behavior and file paths, which conflicts with the product’s JDK 21 baseline.

Goals
Align security configuration notes with JDK 21 behavior.
Remove outdated Java 7/8 build guidance for custom handlers.
Approach
Update JDK guidance to reflect modern defaults and correct java.security location, and update the custom handler build requirement to use a supported JDK.

User stories
As an APIM admin, I want docs that match the supported JDK so I can configure security correctly.

Release note
Align JDK guidance in security and custom handler docs with the supported JDK version.

Documentation
N/A (this PR is documentation)

Training
N/A

Certification
N/A (doc-only)

Marketing
N/A

Automation tests
Unit tests: Not run (doc-only)
Integration tests: Not run (doc-only)
Security checks
Followed secure coding standards? N/A (doc-only)
Ran FindSecurityBugs? N/A (doc-only)
No secrets committed? Yes
Samples
N/A

Related PRs
N/A

Migrations (if applicable)
N/A

Test environment
N/A (doc-only)

Learning
N/A
