### PR TITLE
[3.2.0] Add multipart message formatter options docs

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -10959,7 +10959,7 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
 
 
 
-## Message Mediation
+## Message Formatter Options
 
 
 <div class="mb-config-catalog">
@@ -10969,6 +10969,87 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
             
             <input name="74" type="checkbox" id="_tab_74">
                 <label class="tab-selector" for="_tab_74"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[message_formatter.options]
+disableSendingMultipartPartCharset = true
+preserveMultipartPartContentTransferEncoding = true
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[message_formatter.options]</code>
+                            
+                            <p>
+                                
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>disableSendingMultipartPartCharset</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Defines whether the charset parameter in the Content-Type header should be preserved in each part of multipart form data.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>preserveMultipartPartContentTransferEncoding</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Defines whether the Content-Transfer-Encoding header should be preserved in each part of multipart form data.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Message Mediation
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="75" type="checkbox" id="_tab_75">
+                <label class="tab-selector" for="_tab_75"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[mediation]
@@ -11305,8 +11386,8 @@ inbound.max_threads = 100</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="75" type="checkbox" id="_tab_75">
-                <label class="tab-selector" for="_tab_75"><i class="icon fa fa-code"></i></label>
+            <input name="76" type="checkbox" id="_tab_76">
+                <label class="tab-selector" for="_tab_76"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">enabled_global_handlers= ["custom_logger"]
@@ -11387,8 +11468,8 @@ custom_logger.class= "com.wso2.apim.log.handler.SynapseLogHandler"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="76" type="checkbox" id="_tab_76">
-                <label class="tab-selector" for="_tab_76"><i class="icon fa fa-code"></i></label>
+            <input name="77" type="checkbox" id="_tab_77">
+                <label class="tab-selector" for="_tab_77"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[governance]
@@ -11445,8 +11526,8 @@ life_cycle_checklist_items_enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="77" type="checkbox" id="_tab_77">
-                <label class="tab-selector" for="_tab_77"><i class="icon fa fa-code"></i></label>
+            <input name="78" type="checkbox" id="_tab_78">
+                <label class="tab-selector" for="_tab_78"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[qpid.heartbeat]
@@ -11521,8 +11602,8 @@ timeout_factor = 3.0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="78" type="checkbox" id="_tab_78">
-                <label class="tab-selector" for="_tab_78"><i class="icon fa fa-code"></i></label>
+            <input name="79" type="checkbox" id="_tab_79">
+                <label class="tab-selector" for="_tab_79"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check]
@@ -11577,8 +11658,8 @@ enable = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="79" type="checkbox" id="_tab_79">
-                <label class="tab-selector" for="_tab_79"><i class="icon fa fa-code"></i></label>
+            <input name="80" type="checkbox" id="_tab_80">
+                <label class="tab-selector" for="_tab_80"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker]
@@ -11653,8 +11734,8 @@ order = "98"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="80" type="checkbox" id="_tab_80">
-                <label class="tab-selector" for="_tab_80"><i class="icon fa fa-code"></i></label>
+            <input name="81" type="checkbox" id="_tab_81">
+                <label class="tab-selector" for="_tab_81"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker.properties]
@@ -11707,8 +11788,8 @@ monitored.user.stores = "primary,sec"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="81" type="checkbox" id="_tab_81">
-                <label class="tab-selector" for="_tab_81"><i class="icon fa fa-code"></i></label>
+            <input name="82" type="checkbox" id="_tab_82">
+                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker]
@@ -11783,8 +11864,8 @@ order = "97"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="82" type="checkbox" id="_tab_82">
-                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
+            <input name="83" type="checkbox" id="_tab_83">
+                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker.properties]
@@ -11857,8 +11938,8 @@ monitored.datasources = "jdbc/WSO2AM_DB,jdbc/SHARED_DB,jdbc/WSO2CarbonDB"</code>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="83" type="checkbox" id="_tab_83">
-                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
+            <input name="84" type="checkbox" id="_tab_84">
+                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[health_checker]
@@ -11954,8 +12035,8 @@ first_property = "value"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="84" type="checkbox" id="_tab_84">
-                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
+            <input name="85" type="checkbox" id="_tab_85">
+                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth]
@@ -12133,8 +12214,8 @@ token_context_dialect_uri = "http://wso2.org/claims"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="85" type="checkbox" id="_tab_85">
-                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
+            <input name="86" type="checkbox" id="_tab_86">
+                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_validation]
@@ -12228,8 +12309,8 @@ refresh_token_validity = "86400"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="86" type="checkbox" id="_tab_86">
-                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
+            <input name="87" type="checkbox" id="_tab_87">
+                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_cleanup]
@@ -12306,8 +12387,8 @@ retain_access_tokens_for_auditing = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="87" type="checkbox" id="_tab_87">
-                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
+            <input name="88" type="checkbox" id="_tab_88">
+                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.oidc.extensions]
@@ -12535,8 +12616,8 @@ enable_unmapped_user_attributes = true
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="88" type="checkbox" id="_tab_88">
-                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
+            <input name="89" type="checkbox" id="_tab_89">
+                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.grant_type.authorization_code]
@@ -13024,8 +13105,8 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="89" type="checkbox" id="_tab_89">
-                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
+            <input name="90" type="checkbox" id="_tab_90">
+                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[session_data.persistence]
@@ -13078,8 +13159,8 @@ persistence_pool_size = 0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="90" type="checkbox" id="_tab_90">
-                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
+            <input name="91" type="checkbox" id="_tab_91">
+                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_generation]
@@ -13134,8 +13215,8 @@ retry_count_on_persistence_failures = 5</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="91" type="checkbox" id="_tab_91">
-                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
+            <input name="92" type="checkbox" id="_tab_92">
+                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[user_store.properties]
@@ -13944,8 +14025,8 @@ UserCoreCacheTimeOut = 5</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="92" type="checkbox" id="_tab_92">
-                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
+            <input name="93" type="checkbox" id="_tab_93">
+                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[custom_keystore.APIKeyKeyStore]
@@ -14080,8 +14161,8 @@ key_password = "wso2carbon"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="93" type="checkbox" id="_tab_93">
-                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
+            <input name="94" type="checkbox" id="_tab_94">
+                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[http_access_log]
@@ -14136,8 +14217,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="94" type="checkbox" id="_tab_94">
-                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
+            <input name="95" type="checkbox" id="_tab_95">
+                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">#### Sample deployment.toml entry
@@ -14484,8 +14565,8 @@ mediaType = "application/vnd.wso2-service+xml"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="95" type="checkbox" id="_tab_95">
-                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
+            <input name="96" type="checkbox" id="_tab_96">
+                <label class="tab-selector" for="_tab_96"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.transport_headers]

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -31,7 +31,7 @@
                             "default": "default",
                             "possible": "default,api-devportal,api-key-manager,api-publisher,gateway-worker,traffic-manager",
                             "description": "The profile name of the API Manager instance."
-                        }, 
+                        },
                         {
                             "name": "enableMTOM",
                             "type": "boolean",
@@ -39,7 +39,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Use this paramater to enable MTOM (Message Transmission Optimization Mechanism) for the product server."
-                        }, 
+                        },
                         {
                             "name": "enableSwA",
                             "type": "boolean",
@@ -47,7 +47,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Use this paramater to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages."
-                        },   
+                        },
                         {
                             "name": "disable_shutdown_from_ui",
                             "type": "boolean",
@@ -55,7 +55,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Use this parameter to disable the shutdown server option from carbon management console UI."
-                        },        
+                        },
                         {
                             "name": "disable_restart_from_ui",
                             "type": "boolean",
@@ -63,12 +63,12 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Use this parameter to disable the restart server option from carbon management console UI."
-                        }                                                                                              
+                        }
                     ]
                 }
             ],
             "exampleFile": "server.toml"
-        },    
+        },
         {
             "title": "Super admin configurations",
             "options": [
@@ -1664,7 +1664,7 @@
                     ]
                 }
             ],
-            "exampleFile": "apim.workflow.toml" 
+            "exampleFile": "apim.workflow.toml"
         },
         {
             "title": "API-M SDK configurations",
@@ -1921,7 +1921,7 @@
                             "possible": "",
                             "description": "If true, it attempts to authenticate the user using the AUTH command. Defaults to false."
                         }
-                        
+
                     ]
                 }
             ],
@@ -2754,7 +2754,7 @@
                             "default": "Not defined",
                             "possible": "",
                             "description": "Provide a number starting from 1. Increase the value by one during each time you need to reindex. Make sure to backup and delete the <API-M_HOME>/solr directory after changing the configuration and before restarting the server. After a server restart, reindexing might take a considerable amount of time depending on the number of APIs you have in the registry."
-                        }                                                                                                  
+                        }
                     ]
                 }
             ],
@@ -4076,6 +4076,35 @@
             "exampleFile": "_message-formatters-custom-blocking.toml"
         },
         {
+            "title": "Message Formatter Options",
+            "options": [
+                {
+                    "name": "message_formatter.options",
+                    "required": false,
+                    "description": "",
+                    "params": [
+                        {
+                            "name": "disableSendingMultipartPartCharset",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true false",
+                            "description": "Defines whether the charset parameter in the Content-Type header should be preserved in each part of multipart form data."
+                        },
+                        {
+                            "name": "preserveMultipartPartContentTransferEncoding",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true false",
+                            "description": "Defines whether the Content-Transfer-Encoding header should be preserved in each part of multipart form data."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "message_formatter.options.toml"
+        },
+        {
             "title": "Message Mediation",
             "options": [
                 {
@@ -4265,7 +4294,7 @@
                             "default": "2.0",
                             "possible": "",
                             "description": "The time duration (in seconds) allowed for a subscriber to respond to a heartbeat request. If this time elapses before the response is received, the channel of communication between the server and the subscriber will end."
-                        }                        
+                        }
                     ]
                 }
             ],
@@ -4286,7 +4315,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Enable carbon health checker."
-                        }                      
+                        }
                     ]
                 }
             ],
@@ -4314,12 +4343,12 @@
                             "default": "98",
                             "possible": "",
                             "description": "The execution order."
-                        }                                                                                           
+                        }
                     ]
                 }
             ],
             "exampleFile": "super_tenant_health_checker.toml"
-        }, 
+        },
         {
             "options": [
                 {
@@ -4334,12 +4363,12 @@
                             "default": "",
                             "possible": "",
                             "description": "An array of domain names of the userstores to monitor health. If not given, health is monitered on all the super tenant secondary user stores."
-                        }                                                                                          
+                        }
                     ]
                 }
             ],
             "exampleFile": "super_tenant_health_checker_properties.toml"
-        },                
+        },
         {
             "options": [
                 {
@@ -4362,12 +4391,12 @@
                             "default": "98",
                             "possible": "",
                             "description": "The execution order."
-                        }                                             
+                        }
                     ]
                 }
             ],
             "exampleFile": "data_source_health_checker.toml"
-        },                                                 
+        },
         {
             "options": [
                 {
@@ -4390,7 +4419,7 @@
                             "default": "",
                             "possible": "",
                             "description": "An array of jndiConfig names of datasources to monitor health. If not given, health is monitered on all the datastores."
-                        }                                                                                                                   
+                        }
                     ]
                 }
             ],
@@ -4410,7 +4439,7 @@
                             "default": "-",
                             "possible": "",
                             "description": "The custom health checker name."
-                        },  
+                        },
                         {
                             "name": "order",
                             "type": "integer",
@@ -4418,7 +4447,7 @@
                             "default": "-",
                             "possible": "",
                             "description": "The custom health checker execution order."
-                        }, 
+                        },
                         {
                             "name": "properties",
                             "type": "integer",
@@ -4426,7 +4455,7 @@
                             "default": "-",
                             "possible": "",
                             "description": "The custom health checker properties. Provide as key value pairs."
-                        }                                                                                                                
+                        }
                     ]
                 }
             ],
@@ -4495,7 +4524,7 @@
                             "default": "http://wso2.org/claims",
                             "possible": "",
                             "description": "Consumer Dialect URI for Authorization Context."
-                        }                                                      
+                        }
 
                     ]
                 }
@@ -4524,7 +4553,7 @@
                             "default": "3600",
                             "possible": "",
                             "description": "Default validity period for user access tokens in seconds."
-                        }, 
+                        },
                         {
                             "name": "refresh_token_validity",
                             "type": "integer",
@@ -4532,7 +4561,7 @@
                             "default": "86400",
                             "possible": "",
                             "description": "Default validity period for refresh tokens in seconds."
-                        }                                                                                                                                                                                                                                                    
+                        }
                     ]
                 }
             ],
@@ -4560,7 +4589,7 @@
                             "default": "true",
                             "possible": "true,false",
                             "description": "Set this to true, to move the old, invalid tokens to the Audit table when token cleaning is enabled. Set this to false, if you do not wish to store old tokens in the Audit table."
-                        }                                                                                                                                                                                                                                                      
+                        }
                     ]
                 }
             ],
@@ -4580,7 +4609,7 @@
                             "default": "org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilder",
                             "possible": "",
                             "description": "IDToken builder implementation class."
-                        },  
+                        },
                         {
                             "name": "extensions.claim_callback_handler",
                             "type": "string",
@@ -4596,7 +4625,7 @@
                             "default": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoUserStoreClaimRetriever",
                             "possible": "",
                             "description": "Defines the class which builds the claims for the User Info Endpoint's response. This class needs to implement the interface UserInfoClaimRetriever."
-                        }, 
+                        },
                         {
                             "name": "user_info.response_type",
                             "type": "string",
@@ -4620,7 +4649,7 @@
                             "default": "${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token (OAuth2 Token Endpoint URL)",
                             "possible": "",
                             "description": "The value of issuer of the IDToken. This should be changed according to the deployment values."
-                        }, 
+                        },
                         {
                             "name": "id_token.redirect_error_page",
                             "type": "boolean",
@@ -4628,8 +4657,8 @@
                             "default": "true",
                             "possible": "true,false",
                             "description": "Send the response to OAuth2 error page."
-                        },                                                                                                 
-                                                                            
+                        },
+
                         {
                             "name": "claims.enable_oidc_dialect",
                             "type": "boolean",
@@ -4645,7 +4674,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Enable adding unmapped user attributes."
-                        }                                             
+                        }
                     ]
                 }
             ],
@@ -4673,7 +4702,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationCodeGrantHandler",
                             "possible": "",
                             "description": "Authorization Code grant implementation class."
-                        }, 
+                        },
                         {
                             "name": "password.enable",
                             "type": "boolean",
@@ -4689,7 +4718,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.token.handlers.grant.PasswordGrantHandler",
                             "possible": "",
                             "description": "Password grant implementation class."
-                        },     
+                        },
                         {
                             "name": "refresh_token.enable",
                             "type": "boolean",
@@ -4705,7 +4734,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
                             "possible": "",
                             "description": "Refresh Token grant implementation class."
-                        },  
+                        },
                         {
                             "name": "client_credentials.enable",
                             "type": "boolean",
@@ -4721,7 +4750,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler",
                             "possible": "",
                             "description": "Client Credentials grant implementation class."
-                        }, 
+                        },
                         {
                             "name": "client_credentials.allow_refresh_tokens",
                             "type": "boolean",
@@ -4729,7 +4758,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Enable to allow refresh tokens for client credentails grant."
-                        },  
+                        },
                         {
                             "name": "client_credentials.allow_id_token",
                             "type": "boolean",
@@ -4737,7 +4766,7 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Enable to allow ID tokens for client credentails grant."
-                        },  
+                        },
                         {
                             "name": "saml_bearer.enable",
                             "type": "boolean",
@@ -4753,7 +4782,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandler",
                             "possible": "",
                             "description": "SAML2 Bearer grant implementation class."
-                        }, 
+                        },
                         {
                             "name": "iwa_ntlm.enable",
                             "type": "boolean",
@@ -4777,7 +4806,7 @@
                             "default": "org.wso2.carbon.identity.oauth.common.NTLMAuthenticationValidator",
                             "possible": "",
                             "description": "NTLM grant validator implementation class."
-                        }, 
+                        },
                         {
                             "name": "jwt_bearer.enable",
                             "type": "boolean",
@@ -4801,7 +4830,7 @@
                             "default": "org.wso2.carbon.identity.oauth2.grant.jwt.JWTGrantValidator",
                             "possible": "",
                             "description": "JWT Bearer grant validator implementation class."
-                        },                                                                            
+                        },
                         {
                             "name": "kerberos.enable",
                             "type": "boolean",
@@ -4825,8 +4854,8 @@
                             "default": "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantValidator",
                             "possible": "",
                             "description": "Kerberos grant validator implementation class."
-                        }                                                                                                                                                                                           
-                                                                                                                                                                                                                                                   
+                        }
+
                     ]
                 }
             ],
@@ -4839,7 +4868,7 @@
                     "name": "session_data.persistence",
                     "required": false,
                     "description": "This includes configuration for session data persistence of tokens.",
-                    "params": [                   
+                    "params": [
                          {
                             "name": "persistence_pool_size",
                             "type": "integer",
@@ -4847,7 +4876,7 @@
                             "default": "0",
                             "possible": "",
                             "description": "This value determines the number of threads in the thread pool that are used to consume the token persisting queue. Set the value 0 to enable synchronous token persistence. Set the value higher than 0 to enable asynchronous token persistence."
-                        }                                                                                                                                                                                                                                                                              
+                        }
                     ]
                 }
             ],
@@ -4859,7 +4888,7 @@
                     "name": "oauth.token_generation",
                     "required": false,
                     "description": "This includes configuration for OAuth2 token persistence.",
-                    "params": [                   
+                    "params": [
                          {
                             "name": "retry_count_on_persistence_failures",
                             "type": "integer",
@@ -4867,7 +4896,7 @@
                             "default": "5",
                             "possible": "",
                             "description": "This indicates how many times to retry in the event of a CONN_APP_KEY violation when storing the access token."
-                        }                                                                                                                                                                                                                                                                              
+                        }
                     ]
                 }
             ],
@@ -5198,7 +5227,7 @@
                     "name": "custom_keystore.APIKeyKeyStore",
                     "required": false,
                     "description": "This includes configuration for custom Keystores in WSO2 API Manager ",
-                    "params": [                   
+                    "params": [
                          {
                             "name": "file_name",
                             "type": "string",
@@ -5238,7 +5267,7 @@
                             "default": "",
                             "possible": "",
                             "description": "The private key password of the Keystore (WSO2 recommends that you maintain the identical Keystore password and key password due to known limitations)."
-                        }                                                                                                                                                                                                                                                                            
+                        }
                     ]
                 }
             ],
@@ -5288,14 +5317,14 @@
                             "default": "",
                             "possible": "",
                             "description": "The class name of the filter which is associated with the Handler (Ex: org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher, org.wso2.carbon.registry.core.jdbc.handlers.filters.URLMatcher)."
-                        }              
+                        }
                     ]
                 },
                 {
                     "name": "registry_handler.properties",
                     "required": false,
                     "description": "Registry Handler custom properties which do not have nested elements. Properties are listed as key, value pairs. These custom properties will be used in Handler processing logic.",
-                    "params": [        
+                    "params": [
                     ]
                 },
                 {
@@ -5326,7 +5355,7 @@
                             "default": "xml",
                             "possible": "xml, null",
                             "description": "The type of the custom parent property."
-                        }              
+                        }
                     ]
                 },
                 {
@@ -5357,14 +5386,14 @@
                             "default": "",
                             "possible": "",
                             "description": "Value of the additional key attribute of the XML element generated for the nested property."
-                        }              
+                        }
                     ]
                 },
                 {
                     "name": "registry_handler.filter_properties",
                     "required": false,
                     "description": "Define registry handler filter element configurations.",
-                    "params": [           
+                    "params": [
                     ]
                 }
             ],
@@ -5426,4 +5455,3 @@
         }
     ]
 }
-

--- a/en/tools/config-catalog-generator/data/message_formatter.options.toml
+++ b/en/tools/config-catalog-generator/data/message_formatter.options.toml
@@ -1,0 +1,3 @@
+[message_formatter.options]
+disableSendingMultipartPartCharset = true
+preserveMultipartPartContentTransferEncoding = true


### PR DESCRIPTION
### Description

This pull request updates the `config-catalog.md` documentation to add a new section for message formatter options and to introduce configuration parameters for multipart form data message formatting. 

The most important changes are:

**New Message Formatter Options Section:**

* Added a new section, `Message Formatter Options`, to the documentation, which details configuration options for message formatting, specifically for multipart form data content type.
* Introduced two new configuration parameters under `[message_formatter.options]`:
  - `disableSendingMultipartPartCharset`: Controls whether the charset parameter is preserved in multipart parts (default: `true`).
  - [`preserveMultipartPartContentTransferEncoding`](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dR10974-R11054): Determines if the Content-Transfer-Encoding header is preserved in multipart parts (default: `true`).
