### PR TITLE
Rewrite OpenShift deployment guide for WSO2 API Manager 4.6.0 

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/openshift/openshift-deployment-overview.md
@@ -1,488 +1,536 @@
 # Deploy WSO2 API Manager on OpenShift
 
-This guide provides comprehensive instructions for deploying WSO2 API Manager on OpenShift Container Platform using Helm charts. OpenShift environments have unique security requirements that differ from standard Kubernetes clusters, requiring specific configuration adjustments for successful deployment.
+OpenShift is a Kubernetes distribution with stricter security defaults. The core deployment approach — Helm charts, the same patterns (P0–P5) — is identical to standard Kubernetes. The key difference is that OpenShift ignores the UID defined in the Docker image and injects a random UID at runtime, which requires additional file permission configuration in the image and specific security context settings in the Helm values.
 
-!!! info "OpenShift-Specific Configuration"
-    This guide covers the following OpenShift-specific requirements:
-    
-    - [Preparing Docker images for OpenShift compatibility](#step-1---preparing-the-docker-images)
-    - [Configuring security context settings in `values.yaml`](#step-4---configure-openshift-specific-settings-in-valuesyaml)
-    - [Applying proper permissions for container execution](#step-1---preparing-the-docker-images)
+For routing, WSO2 API Manager 4.6.0 uses standard Kubernetes Ingress. An **NGINX Ingress Controller** must be installed on your OpenShift cluster before deploying.
 
-For an all-in-one deployment, following this guide is sufficient. If you need a distributed deployment, please refer to the [Deployment Patterns guide](../kubernetes/kubernetes-overview.md) and apply the additional configurations mentioned in this document on top of the provided `default_values.yaml` files.
+!!! warning "OpenShift deployment requires the following before deploying:"
 
-## Contents
+    1. **A custom Docker image** — with GID 0 group-write permissions and the JDBC driver for your database. Standard WSO2 images will fail to start on OpenShift.
+    2. **An external database** — required for distributed deployments (P1–P5). The All-in-One pattern (P0) can use the embedded H2 database for evaluation purposes.
+    3. **Database schema initialised** — if using an external database, run the WSO2 schema scripts against both databases before the pods start.
+    4. **NGINX Ingress Controller** — must be installed on the OpenShift cluster before the Helm chart is deployed.
 
-- [WSO2 API Manager: Deployment on OpenShift](#wso2-api-manager-deployment-on-openshift)
-  - [Contents](#contents)
-  - [Prerequisites](#prerequisites)
-  - [Deployment Steps](#deployment-steps)
-    - [Step 1 - Preparing the Docker Images](#step-1---preparing-the-docker-images)
-    - [Step 2 - Login to the OpenShift Cluster](#step-2---login-to-the-openshift-cluster)
-    - [Step 3 - Create Secrets and Clone Helm Charts](#step-3---create-secrets-and-clone-helm-charts)
-    - [Step 4 - Configure OpenShift-Specific Settings in values.yaml](#step-4---configure-openshift-specific-settings-in-valuesyaml)
-  - [All-in-One Deployment](#all-in-one-deployment)
-  - [Distributed Deployment](#distributed-deployment)
+---
 
-## Prerequisites
+## Quick Start
 
-Before you begin, ensure you have met the following requirements:
+### Step 1 — Install Required Tools { #step-1 }
 
-!!! info "Prerequisites"
-    - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-    - [Helm](https://helm.sh/docs/intro/install/) (version 3 or newer)
-    - [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
-    - [Kubernetes client (kubectl)](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-    - Access to an operational OpenShift cluster
-    - [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (compatible with Git release nginx-0.22.0)
-    - Access to a container registry accessible from your OpenShift cluster
-    - Database server (MySQL, MSSQL, PostgreSQL, etc.) accessible from the OpenShift cluster
+1. Ensure the following tools are installed on your machine:
 
-## Deployment Steps
+    | Tool | Purpose | Install Guide |
+    | ---- | ------- | ------------- |
+    | `oc` | OpenShift CLI for managing cluster resources | [Install](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) |
+    | `kubectl` | Kubernetes CLI (used alongside `oc`) | [Install](https://kubernetes.io/docs/tasks/tools/) |
+    | `helm` (v3) | Package manager for deploying WSO2 Helm charts | [Install](https://helm.sh/docs/intro/install/) |
+    | `docker` | Required to build and push custom WSO2 images | [Install](https://docs.docker.com/get-docker/) |
 
-### Step 1 - Preparing the Docker Images
+2. Verify all tools are installed:
 
-To fully comply with OpenShift’s security model especially its use of arbitrary user IDs, user has to create a custom Docker image tailored for OpenShift environments. Following are the steps required for modifying the image to ensure compatibility, including how to set group ownership to the root group (GID 0), which allows access when OpenShift assigns a random UID at runtime.
-
-The official WSO2 Docker images run as a non-root user with a fixed UID. While that works on standard Kubernetes clusters, OpenShift often injects a random UID and restricts container privileges. To prevent permission issues, update the image to:
-
-1. Allow group write access to required directories
-2. Assign root group ownership (GID 0)
-
-Also 
-
-1. Starting from v4.6.0, each component has a separate Docker image (All-in-one, Control-plane, Gateway, Traffic-manager).
-2. These Docker images do not contain any database connectors; therefore, we need to build custom Docker images based on each Docker image in order to make the deployment work with a separate DB.
-3. Download a connector which is compatible with the DB version and copy the connector while building the image
-
-!!! example "Sample Dockerfile for All-in-One Image"
-    ```dockerfile
-    FROM wso2/wso2am:4.6.0
-
-    # Change directory permissions for OpenShift compatibility
-    USER root
-    RUN chgrp -R 0 ${USER_HOME} && chmod -R g=u ${USER_HOME} \
-        && chgrp -R 0 ${WSO2_SERVER_HOME} && chmod -R g=u ${WSO2_SERVER_HOME} \
-        && chgrp -R 0 ${USER_HOME}/solr && chmod -R g=u ${USER_HOME}/solr
-    USER wso2carbon
-
-    # Copy JDBC MySQL driver
-    COPY mysql-connector.jar ${WSO2_SERVER_HOME}/repository/components/lib
+    ```bash
+    oc version
+    helm version
+    docker info
     ```
 
-!!! info "Note"
-    Changing the group is mandatory to allow OpenShift to assign arbitrary UIDs. 
-    Ref: [a-guide-to-openshift-and-uids](https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids), [group_ownership_and_file_permission](https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform#group_ownership_and_file_permission)
+### Step 2 — Log in to OpenShift { #step-2 }
 
-After creating your Dockerfile:
+1. Authenticate with the OpenShift CLI:
 
-1. Build the custom image:
-   ```bash
-   docker build -t <REGISTRY_URL>/<REPOSITORY>/<IMAGE_NAME>:<TAG> .
-   ```
+    === "Username / Password"
 
-2. Push the image to your registry:
-   ```bash
-   docker push <REGISTRY_URL>/<REPOSITORY>/<IMAGE_NAME>:<TAG>
-   ```
+        ```bash
+        oc login <API_SERVER_URL> -u <USERNAME> -p <PASSWORD>
+        ```
 
-!!! warning "Important"
-    Make sure to update the Helm chart configurations to use these modified images when deploying to OpenShift.
+    === "Token"
 
+        ```bash
+        oc login <API_SERVER_URL> --token=<TOKEN>
+        ```
 
-### Step 2 - Login to the OpenShift Cluster
+2. Verify your connection and create the namespace:
 
-First, authenticate to your OpenShift cluster using the OpenShift CLI:
+    ```bash
+    oc whoami
+    oc create namespace apim
+    ```
 
-!!! info "Authentication with OpenShift CLI"
-    You can authenticate using one of the following methods:
-    
-    - **Username/Password Authentication**:
-      ```bash
-      oc login <API_SERVER_URL> -u <USERNAME> -p <PASSWORD>
-      ```
-      
-    - **Token-Based Authentication**:
-      ```bash
-      oc login <API_SERVER_URL> --token=<TOKEN>
-      ```
-
-Once authenticated, verify your connection and check your currently selected project:
+### Step 3 — Add the WSO2 Helm Repository { #step-3 }
 
 ```bash
-# Verify connection
-oc whoami
-
-# Check current project
-oc project
+helm repo add wso2 https://helm.wso2.com && helm repo update
 ```
 
-### Step 3 - Create Secrets and Clone Helm Charts
+### Step 4 — Install NGINX Ingress Controller { #step-4 }
 
-1. **Create Keystore Secret**:
+WSO2 API Manager 4.6.0 uses Kubernetes Ingress for external access. Install the NGINX Ingress Controller on your OpenShift cluster:
 
-   Before deploying the Helm chart, create a Kubernetes secret containing the keystores and truststore:
+```bash
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --set controller.service.type=LoadBalancer \
+  --set controller.admissionWebhooks.enabled=false
+```
 
-   ```bash
-   # Create a secret with default WSO2 keystores and truststores
-   kubectl create secret generic apim-keystore-secret \
-     --from-file=wso2carbon.jks \
-     --from-file=client-truststore.jks
-   ```
+OpenShift's default Security Context Constraints (SCCs) block the NGINX controller pod from starting. Grant the `privileged` SCC to its service account and restart the deployment:
 
-   !!! tip
-       You can find the default keystore and truststore files in the `repository/resources/security/` directory of any WSO2 API-M distribution.
+```bash
+oc adm policy add-scc-to-user privileged system:serviceaccount:ingress-nginx:ingress-nginx
+kubectl rollout restart deployment ingress-nginx-controller -n ingress-nginx
+```
 
-2. **Clone WSO2 Helm Charts Repository**:
+Wait for the controller pod to be ready:
 
-   ```bash
-   git clone https://github.com/wso2/helm-apim.git
-   cd helm-apim
-   ```
+```bash
+kubectl get pods -n ingress-nginx -w
+```
 
-### Step 4 - Configure OpenShift-Specific Settings in values.yaml
+The pod should show `1/1 Running` before proceeding.
 
-In each `values.yaml` file for your deployment, make the following OpenShift-specific changes:
+### Step 5 — Build an OpenShift-Compatible Docker Image { #step-5 }
 
-!!! info "Security Context Configuration"
-    The following settings need to be applied to make your deployment compatible with OpenShift's security model:
+Standard WSO2 images run as a fixed UID (`wso2carbon`, UID 802). OpenShift injects a random UID at runtime, so any directories the server writes to must have **group-write permissions with root group (GID 0) ownership**.
 
-1. **Update Security Context Settings**:
+!!! note "Why GID 0?"
+    OpenShift assigns a random UID to the container process but always uses GID 0 (root group). By granting group-write access to the root group, the container can write to its directories regardless of which UID OpenShift assigns. See [Red Hat's guide to OpenShift and UIDs](https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids) and [group ownership and file permission](https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform#group_ownership_and_file_permission) for more detail.
 
-   | Setting | Description |
-   |---------|-------------|
-   | `runAsUser: null` | Allows OpenShift to assign arbitrary UIDs |
-   | `seLinux.enabled: true/false` | Enables/disables SELinux support |
-   | `enableAppArmor: false` | Disables AppArmor profiles |
-   | `configMaps.scripts.defaultMode: "0457"` | Sets execute permissions for ConfigMaps |
-   | `seccompProfile.type` | Controls which seccomp profile to apply |
+1. Create a `Dockerfile` for the All-in-One image:
 
-   **Example Configuration**:
+    === "Evaluation (H2 database)"
 
-   ```yaml
-   securityContext:
-     # -- Set to null to allow OpenShift to assign arbitrary UIDs
-     runAsUser: null
-     # -- SELinux context configuration
-     seLinux:
-       enabled: false
-       level: ""
-     # -- Seccomp profile for the container
-     seccompProfile:
-       # -- Seccomp profile type (RuntimeDefault, Unconfined or Localhost)
-       type: RuntimeDefault
-       localhostProfile: ""
-   # -- Disable AppArmor for OpenShift compatibility
-   enableAppArmor: false
-   # -- Set execute permissions for ConfigMaps
-   configMaps:
-     scripts:
-       defaultMode: "0457"
-   ```
+        ```dockerfile
+        FROM wso2/wso2am:4.6.0
 
-## All-in-One Deployment
+        # Grant root group write access for OpenShift arbitrary UID support
+        USER root
+        RUN chgrp -R 0 /home/wso2carbon && chmod -R g=u /home/wso2carbon
+        USER wso2carbon
+        ```
 
-The All-in-One deployment is the simplest pattern to deploy WSO2 API Manager on OpenShift. This section provides detailed instructions for deploying the All-in-One pattern in an OpenShift environment.
+    === "Production (external database)"
 
-### Step 1 - Prepare Configuration Values
+        WSO2 images do not include a JDBC driver. Add the driver for your database:
 
-1. **Navigate to the All-in-One Helm Chart Directory**:
-   ```bash
-   cd helm-apim/all-in-one
-   ```
+        ```dockerfile
+        FROM wso2/wso2am:4.6.0
 
-2. **Create a Custom Values File**:
-   
-   Create a file named `openshift-values.yaml` with your OpenShift-specific configurations:
+        # Grant root group write access for OpenShift arbitrary UID support
+        USER root
+        RUN chgrp -R 0 /home/wso2carbon && chmod -R g=u /home/wso2carbon
+        USER wso2carbon
 
-   ```yaml
-   # OpenShift-specific settings
-   kubernetes:
-     securityContext:
-       runAsUser: null
-       seLinux:
-         enabled: false
-       seccompProfile:
-         type: RuntimeDefault
-     enableAppArmor: false
-     configMaps:
-       scripts:
-         defaultMode: "0457"
-   
-   # Database configuration
-   wso2:
-     apim:
-       configurations:
-         databases:
-           apim_db:
-             url: "jdbc:mysql://<DB_HOST>:3306/apim_db?useSSL=false"
-             username: "apimadmin"
-             password: "password"
-           shared_db:
-             url: "jdbc:mysql://<DB_HOST>:3306/shared_db?useSSL=false"
-             username: "sharedadmin"
-             password: "password"
-       
-       # Keystore configuration
-       configurations:
-         security:
-           jksSecretName: "apim-keystore-secret"
-   
-   # Docker image configuration
-   wso2:
-     deployment:
-       image:
-         registry: "<YOUR_REGISTRY>"
-         repository: "<YOUR_REPOSITORY>"
-         tag: "<YOUR_TAG>"
-         # If using private registry
-         imagePullSecrets:
-           enabled: true
-           username: "<REGISTRY_USERNAME>"
-           password: "<REGISTRY_PASSWORD>"
-   ```
+        # Add MySQL JDBC driver — replace URL for other databases
+        ADD --chown=wso2carbon:wso2 \
+          https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar \
+          ${WSO2_SERVER_HOME}/repository/components/lib/
+        ```
 
-!!! warning "Important"
-    Replace the placeholders with your actual values:
-    - `<DB_HOST>`: Your database host address
-    - `<YOUR_REGISTRY>`, `<YOUR_REPOSITORY>`, `<YOUR_TAG>`: Your OpenShift-compatible image details
-    - `<REGISTRY_USERNAME>`, `<REGISTRY_PASSWORD>`: Your private registry credentials (if applicable)
+2. Build and push the image, replacing `<REGISTRY>` and `<TAG>` with your values:
 
-### Step 2 - Deploy Using Helm
-
-1. **Create a Namespace**:
-   ```bash
-   oc create namespace wso2
-   ```
-
-2. **Deploy with Helm**:
-   ```bash
-   helm install apim wso2/wso2am-all-in-one \
-     --namespace wso2 \
-     --create-namespace \
-     --version 4.6.0-1 \
-     -f openshift-values.yaml
-   ```
-
-   Alternatively, if you want to use the default OpenShift configuration:
-
-   ```bash
-   helm install apim wso2/wso2am-all-in-one \
-     --namespace wso2 \
-     --create-namespace \
-     --version 4.6.0-1 \
-     --set wso2.subscription.username=<USERNAME> \
-     --set wso2.subscription.password=<PASSWORD> \
-     -f https://raw.githubusercontent.com/wso2/helm-apim/4.6.x/docs/am-pattern-0-all-in-one/default_openshift_values.yaml
-   ```
-
-### Step 3 - Verify Deployment
-
-1. **Check Deployment Status**:
-   ```bash
-   oc get pods -n wso2
-   ```
-
-2. **Check Services and Routes**:
-   ```bash
-   # List services
-   oc get svc -n wso2
-   
-   # List routes
-   oc get routes -n wso2
-   ```
-
-!!! note "Access and Exposure"
-    By default, the deployment will create Kubernetes services but not OpenShift routes. You may need to create routes to expose the API Manager services externally:
-    
     ```bash
-    oc create route passthrough apim-publisher \
-      --service=apim-wso2am-service \
-      --port=9443 \
-      --hostname=publisher.apim.example.com \
-      -n wso2
+    docker buildx build --platform linux/amd64 -t <REGISTRY>/wso2am-ocp:<TAG> .
+    docker push <REGISTRY>/wso2am-ocp:<TAG>
     ```
 
+    !!! note "Matching your cluster architecture"
+        The `--platform` flag must match the architecture of your cluster nodes:
 
-## Distributed Deployment
+        - **Managed clusters (AKS, ROSA, ARO)** — use `linux/amd64`
+        - **OpenShift Local (CRC) on Apple Silicon (M1/M2/M3/M4)** — use `linux/arm64`
 
-For distributed deployments of WSO2 API Manager on OpenShift, you need to apply the same OpenShift-specific configurations to each component of your chosen pattern:
+        Using the wrong platform will cause `ErrImagePull` when the pod starts.
 
-### Step 1 - Select an Appropriate Pattern
+3. Get the image digest — you will need it when configuring your values file:
 
-Review the [WSO2 API-M Deployment Patterns](../kubernetes/kubernetes-overview.md) and choose the pattern that suits your requirements:
+    ```bash
+    docker inspect <REGISTRY>/wso2am-ocp:<TAG> \
+      --format='{% raw %}{{index .RepoDigests 0}}{% endraw %}'
+    ```
 
-- [Pattern 1: HA All-in-One Deployment](../kubernetes/am-pattern-1-all-in-one-ha.md)
-- [Pattern 2: All-in-One with Gateway](../kubernetes/am-pattern-2-all-in-one-gw.md) 
-- [Pattern 3: Control Plane with Traffic Manager and Gateway](../kubernetes/am-pattern-3-acp-tm-gw.md)
-- [Pattern 4: Control Plane with Traffic Manager, Gateway and Key Manager](../kubernetes/am-pattern-4-acp-tm-gw-km.md)
-- [Pattern 5: API-M Deployment with Simple Scalable Setup](../kubernetes/am-pattern-5-all-in-one-gw-km.md)
+### Step 6 — Set Up the Database { #step-6 }
 
-### Step 2 - Configure Each Component
+The All-in-One pattern uses an embedded H2 database by default, which is suitable for evaluation. For production deployments, set up an external database before the pods start.
 
-For each component in your selected pattern:
+If you are using H2, skip this step and proceed to [Step 7](#step-7).
 
-!!! info "Component Configuration"
-    Each component requires the same OpenShift-specific configurations:
+For production, follow the [Setting Up Databases]({{base_path}}/install-and-setup/setup/setting-up-databases/overview/) guide to:
 
-    1. **Custom Docker Images**: Build OpenShift-compatible images for each component
-    2. **Security Context**: Apply the same security context settings as described in [Step 4](#step-4---configure-openshift-specific-settings-in-valuesyaml)
-    3. **Database Connections**: Configure the database connections for each component
-    4. **Service and Route Configuration**: Configure services and routes appropriate for OpenShift
+1. Set up a database instance accessible from your cluster
+2. Obtain the schema scripts for your database type
+3. Run the scripts to initialise both databases
 
-**Example Component Configuration**:
+### Step 7 — Create the Keystore Secret { #step-7 }
+
+The Helm chart mounts a Kubernetes secret named `apim-keystore-secret` as a volume into the pods. The pods will not start if this secret does not exist.
+
+1. Extract the default keystores from your image and create the secret:
+
+    ```bash
+    mkdir -p keystores
+
+    docker run --rm -v "$(pwd)/keystores:/keystores" --entrypoint bash \
+      <REGISTRY>/wso2am-ocp:<TAG> \
+      -c "cp \${WSO2_SERVER_HOME}/repository/resources/security/wso2carbon.jks \
+             \${WSO2_SERVER_HOME}/repository/resources/security/client-truststore.jks \
+             /keystores/"
+
+    kubectl create secret generic apim-keystore-secret \
+      --from-file=wso2carbon.jks=keystores/wso2carbon.jks \
+      --from-file=client-truststore.jks=keystores/client-truststore.jks \
+      -n apim
+    ```
+
+2. Verify the secret was created:
+
+    ```bash
+    kubectl get secret apim-keystore-secret -n apim
+    ```
+
+!!! note
+    The commands above use the default WSO2 keystores which are suitable for evaluation only. For production-level keystore setup, refer to [Configuring Keystores in WSO2 API Manager]({{base_path}}/install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/).
+
+### Step 8 — Deploy the All-in-One { #step-8 }
+
+1. Download the OpenShift default values file:
+
+    ```bash
+    curl -L https://raw.githubusercontent.com/wso2/helm-apim/4.6.x/all-in-one/default_openshift_values.yaml \
+      -o values.yaml
+    ```
+
+2. Open `values.yaml` and update the following sections:
+
+    **Custom image** — point to the OpenShift-compatible image you built in Step 5:
+
+    ```yaml
+    wso2:
+      deployment:
+        image:
+          registry: "<YOUR_REGISTRY>"
+          repository: "wso2am-ocp"
+          tag: "<YOUR_TAG>"
+          digest: "sha256:..."
+    ```
+
+    **Enable OpenShift mode:**
+
+    ```yaml
+    kubernetes:
+      openshift:
+        enabled: true
+    ```
+
+    !!! note
+        The `default_openshift_values.yaml` has `openshift.enabled: false` — make sure to set this to `true`.
+
+    **Ingress hostnames** — update to match your cluster's DNS:
+
+    ```yaml
+    kubernetes:
+      ingress:
+        management:
+          hostname: "am.example.com"
+        gateway:
+          hostname: "gw.example.com"
+        websocket:
+          hostname: "websocket.example.com"
+        websub:
+          hostname: "websub.example.com"
+    ```
+
+    **Database connection** (skip if using H2):
+
+    ```yaml
+    wso2:
+      apim:
+        configurations:
+          databases:
+            apim_db:
+              url: "<JDBC_URL_FOR_APIM_DB>"
+              username: "<DB_USERNAME>"
+              password: "<DB_PASSWORD>"
+            shared_db:
+              url: "<JDBC_URL_FOR_SHARED_DB>"
+              username: "<DB_USERNAME>"
+              password: "<DB_PASSWORD>"
+    ```
+
+3. Deploy:
+
+    ```bash
+    helm install apim wso2/wso2am-all-in-one \
+      --version 4.6.0-1 \
+      --namespace apim \
+      --dependency-update \
+      -f values.yaml
+    ```
+
+4. Wait for the pod to be ready:
+
+    ```bash
+    oc get pods -n apim -w
+    ```
+
+    The pod should show `1/1 Running` before proceeding.
+
+### Step 9 — Verify Ingress { #step-9 }
+
+The Helm chart creates Kubernetes `Ingress` objects automatically. Verify they were created:
+
+```bash
+kubectl get ing -n apim
+```
+
+You should see ingress entries for management, gateway, websocket, and websub with the hostnames you configured.
+
+### Step 10 — Configure DNS { #step-10 }
+
+You need to point your ingress hostnames to the NGINX Ingress Controller's external address.
+
+1. Get the NGINX controller's external IP:
+
+    ```bash
+    kubectl get svc -n ingress-nginx ingress-nginx-controller
+    ```
+
+    Note the `EXTERNAL-IP` value from the output.
+
+2. Map the hostnames to that IP:
+
+    === "OpenShift Local (CRC)"
+
+        CRC does not provision a load balancer, so `EXTERNAL-IP` will show `<pending>`. The NGINX NodePorts (`30400` for HTTPS) are not forwarded from the Mac to the CRC VM, so the browser cannot reach them directly.
+
+        The recommended workaround is to create OpenShift Routes manually. CRC's built-in HAProxy router handles port 443 traffic natively, so Routes work on standard ports without any extra configuration:
+
+        ```bash
+        oc create route passthrough apim-management \
+          --service=apim-wso2am-all-in-one-am-service \
+          --port=9443 \
+          --hostname=am.wso2.com \
+          -n apim
+
+        oc create route passthrough apim-gateway \
+          --service=apim-wso2am-all-in-one-am-service \
+          --port=8243 \
+          --hostname=gw.wso2.com \
+          -n apim
+
+        oc create route passthrough apim-websocket \
+          --service=apim-wso2am-all-in-one-am-service \
+          --port=8099 \
+          --hostname=websocket.wso2.com \
+          -n apim
+
+        oc create route passthrough apim-websub \
+          --service=apim-wso2am-all-in-one-am-service \
+          --port=8021 \
+          --hostname=websub.wso2.com \
+          -n apim
+        ```
+
+        Then add the hostnames to your `/etc/hosts`:
+
+        ```bash
+        sudo sh -c 'echo "127.0.0.1 am.wso2.com gw.wso2.com websocket.wso2.com websub.wso2.com" >> /etc/hosts'
+        ```
+
+    === "Managed cluster (ROSA / ARO)"
+
+        For quick testing, add the external address to your `/etc/hosts` file:
+
+        ```
+        <EXTERNAL-IP> am.wso2.com gw.wso2.com websocket.wso2.com websub.wso2.com
+        ```
+
+        For a production setup, create DNS records in your DNS provider mapping the hostnames to the external IP instead of using `/etc/hosts`.
+
+!!! note
+    These are the default hostnames. If you customised the hostnames in your `values.yaml`, use those values here instead.
+
+### Step 11 — Access the Portals { #step-11 }
+
+Once DNS is configured, open the following URLs in your browser:
+
+=== "OpenShift Local (CRC)"
+
+    If you created Routes manually in Step 10, access the portals on the standard port via the CRC HAProxy router:
+
+    | Portal | URL |
+    | ------ | --- |
+    | Publisher | `https://am.wso2.com/publisher` |
+    | Developer Portal | `https://am.wso2.com/devportal` |
+    | Admin Portal | `https://am.wso2.com/admin` |
+    | Carbon Console | `https://am.wso2.com/carbon` |
+    | Gateway | `https://gw.wso2.com` |
+
+=== "Managed cluster (ROSA / ARO)"
+
+    | Portal | URL |
+    | ------ | --- |
+    | Publisher | `https://<kubernetes.ingress.management.hostname>/publisher` |
+    | Developer Portal | `https://<kubernetes.ingress.management.hostname>/devportal` |
+    | Admin Portal | `https://<kubernetes.ingress.management.hostname>/admin` |
+    | Carbon Console | `https://<kubernetes.ingress.management.hostname>/carbon` |
+    | Gateway | `https://<kubernetes.ingress.gateway.hostname>` |
+
+    Replace the hostname placeholders with the actual values from your `values.yaml`. With default values, the management hostname is `am.wso2.com` and the gateway hostname is `gw.wso2.com`.
+
+Default credentials: **admin / admin**
+
+---
+
+## Advanced Configuration
+
+### 1. OpenShift Security Context { #section-1 }
+
+Every component deployed on OpenShift requires the following block in its values file. The `default_openshift_values.yaml` used in the Quick Start already includes this — you only need to add it manually when creating values files for distributed deployments.
 
 ```yaml
-# OpenShift security context settings for Control Plane component
 kubernetes:
   securityContext:
+    # Allow OpenShift to assign arbitrary UIDs
     runAsUser: null
     seLinux:
       enabled: false
+      level: ""
     seccompProfile:
       type: RuntimeDefault
+      localhostProfile: ""
+  # AppArmor is not available on OpenShift (which uses SELinux instead)
   enableAppArmor: false
   configMaps:
     scripts:
+      # Startup scripts mounted via ConfigMap require execute permission
       defaultMode: "0457"
 ```
 
-### Step 3 - Deploy Components in Order
+| Setting | Why it's needed |
+|---|---|
+| `runAsUser: null` | Lets OpenShift assign its random UID instead of the image's fixed UID |
+| `enableAppArmor: false` | AppArmor is not supported on OpenShift |
+| `seLinux.enabled: false` | Leave off unless your cluster has SELinux policies configured for WSO2 |
+| `configMaps.scripts.defaultMode: "0457"` | Startup scripts mounted as a ConfigMap need execute permission |
 
-Deploy components in the correct order, typically:
+### 2. Distributed Deployments { #section-2 }
 
-1. **Control Plane/All-in-One**:
-   ```bash
-   helm install apim wso2/wso2am-acp \
-     --namespace wso2 \
-     --create-namespace \
-     --version 4.6.0-1 \
-     -f control-plane-openshift-values.yaml
-   ```
+For distributed patterns, follow the corresponding Kubernetes pattern guide and apply the OpenShift-specific changes described in this page on top.
 
-2. **Traffic Manager** (if applicable):
-   ```bash
-   helm install tm wso2/wso2am-tm \
-     --namespace wso2 \
-     --create-namespace \
-     --version 4.6.0-1 \
-     -f tm-openshift-values.yaml
-   ```
+| Pattern | Guide |
+|---|---|
+| Pattern 1 — HA All-in-One | [am-pattern-1-all-in-one-ha.md](../kubernetes/am-pattern-1-all-in-one-ha.md) |
+| Pattern 2 — All-in-One + Gateway | [am-pattern-2-all-in-one-gw.md](../kubernetes/am-pattern-2-all-in-one-gw.md) |
+| Pattern 3 — ACP + TM + Gateway | [am-pattern-3-acp-tm-gw.md](../kubernetes/am-pattern-3-acp-tm-gw.md) |
+| Pattern 4 — ACP + TM + Gateway + KM | [am-pattern-4-acp-tm-gw-km.md](../kubernetes/am-pattern-4-acp-tm-gw-km.md) |
+| Pattern 5 — All-in-One + Gateway + KM | [am-pattern-5-all-in-one-gw-km.md](../kubernetes/am-pattern-5-all-in-one-gw-km.md) |
 
-3. **Key Manager** (if applicable): 
-   ```bash
-   helm install km wso2/wso2am-km \
-     --namespace wso2 \
-     --version 4.6.0-1 \
-     -f km-openshift-values.yaml
-   ```
+**For each component in your chosen pattern:**
 
-4. **Gateway**:
-   ```bash
-   helm install gw wso2/wso2am-universal-gw \
-     --namespace wso2 \
-     --version 4.6.0-1 \
-     -f gw-openshift-values.yaml
-   ```
+1. **Build an OpenShift-compatible image** — apply the same `USER root` / `chgrp` / `chmod` / `USER wso2carbon` pattern from [Step 5](#step-5) to each component's base image (`wso2/wso2am-acp:4.6.0`, `wso2/wso2am-tm:4.6.0`, `wso2/wso2am-universal-gw:4.6.0`). TM and Gateway do not need the JDBC driver.
+2. **Add the security context block** from [Section 1](#section-1) to each component's values file.
+3. **Set `kubernetes.openshift.enabled: true`** in each component's values file.
 
-!!! tip "Deployment Best Practices"
-    - **Namespace Strategy**: Use separate namespaces for different environments (dev, test, prod)
-    - **Resource Management**: Configure appropriate resource limits and requests for your OpenShift cluster
-    - **Health Monitoring**: Configure appropriate liveness and readiness probes for each component
-    - **Persistence**: Use persistent volumes for any stateful components
-    - **Route Configuration**: Set up OpenShift routes with proper TLS termination for external access
-    - **Integration**: Configure integration with OpenShift monitoring and logging stacks
+---
 
-## Troubleshooting OpenShift Deployments
+## Troubleshooting
 
-When deploying WSO2 API Manager on OpenShift, you might encounter some common issues. Here are solutions to the most frequent problems:
+### Permission denied errors
 
-### Permission Denied Errors
+**Symptom:** Pod fails to start with `Permission denied` in the logs.
 
-**Symptom**: Pods fail to start with permission denied errors in the logs.
+**Cause:** The container process cannot write to a directory because the image was not prepared with GID 0 group ownership.
 
-**Solution**: This typically happens because OpenShift runs containers with random UIDs. Check that:
+**Fix:** Ensure your Dockerfile includes the `chgrp -R 0` and `chmod -R g=u` steps from [Step 5](#step-5). Check the pod logs and the applied security context:
 
-1. Your custom Docker images have the proper group permissions:
-   ```bash
-   # Check container logs
-   oc logs <pod-name> -n <namespace>
-   ```
+```bash
+oc logs <pod-name> -n apim
+oc get pod <pod-name> -n apim -o yaml | grep -A 10 securityContext
+```
 
-2. Verify your security context settings in the values.yaml:
-   ```bash
-   # Ensure runAsUser is set to null
-   oc get deployment <deployment-name> -n <namespace> -o yaml | grep -A 10 securityContext
-   ```
+### Image pull errors
 
-### Image Pull Errors
+**Symptom:** Pod stuck in `ImagePullBackOff` or `ErrImagePull`.
 
-**Symptom**: Pods are stuck in "ImagePullBackOff" or "ErrImagePull" states.
+**Fix:** Create an image pull secret and link it to the service account:
 
-**Solution**:
+```bash
+oc create secret docker-registry registry-credentials \
+  --docker-server=<YOUR_REGISTRY> \
+  --docker-username=<USERNAME> \
+  --docker-password=<PASSWORD> \
+  -n apim
 
-1. Ensure your image repository is accessible from OpenShift:
-   ```bash
-   # Check image pull secrets
-   oc get secrets -n <namespace>
-   ```
+oc secrets link default registry-credentials --for=pull -n apim
+```
 
-2. Verify registry credentials:
-   ```bash
-   # Create or update image pull secret
-   oc create secret docker-registry regcred \
-     --docker-server=<your-registry-server> \
-     --docker-username=<your-username> \
-     --docker-password=<your-password> \
-     --docker-email=<your-email> \
-     -n <namespace>
-   ```
+### Ingress not reachable
 
-### Volume Mount Issues
+**Symptom:** Hostnames don't resolve or the browser cannot connect.
 
-**Symptom**: Pods crash with volume-related errors.
+**Fix:**
 
-**Solution**:
+1. Confirm the NGINX Ingress Controller has an external IP:
 
-1. Ensure any persistent volume claims are bound:
-   ```bash
-   oc get pvc -n <namespace>
-   ```
+    ```bash
+    kubectl get svc -n ingress-nginx ingress-nginx-controller
+    ```
 
-2. Check volume permissions:
-   ```bash
-   # Update deployment to allow writing to volumes
-   oc patch deployment <deployment-name> -n <namespace> \
-     -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroup":0}}}}}'
-   ```
+    If `EXTERNAL-IP` is `<pending>`, the load balancer hasn't been provisioned yet. On CRC this may stay pending — use `127.0.0.1` instead.
 
-### Network Policy Issues
+2. Confirm the Ingress objects were created:
 
-**Symptom**: Components cannot communicate with each other.
+    ```bash
+    kubectl get ing -n apim
+    ```
 
-**Solution**: OpenShift uses network policies that might block inter-service communication.
+### Volume mount errors
 
-1. Check current network policies:
-   ```bash
-   oc get netpol -n <namespace>
-   ```
+**Symptom:** Pod crashes with volume-related errors.
 
-2. Create a permissive network policy for API-M components:
-   ```bash
-   oc apply -f - <<EOF
-   apiVersion: networking.k8s.io/v1
-   kind: NetworkPolicy
-   metadata:
-     name: allow-wso2-internal
-     namespace: <namespace>
-   spec:
-     podSelector:
-       matchLabels:
-         app: wso2am
-     ingress:
-     - from:
-       - podSelector:
-           matchLabels:
-             app: wso2am
-   EOF
-   ```
+**Fix:** Check that PersistentVolumeClaims are bound:
+
+```bash
+oc get pvc -n apim
+```
+
+If a volume fails due to fsGroup permissions, patch the deployment:
+
+```bash
+oc patch deployment <deployment-name> -n apim \
+  -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroup":0}}}}}'
+```
+
+### Inter-component communication failures
+
+**Symptom:** Components cannot reach each other (e.g. GW cannot connect to ACP).
+
+**Cause:** OpenShift may enforce network policies that block cross-pod traffic within the namespace.
+
+**Fix:** Check for blocking policies and apply a permissive one for all APIM pods:
+
+```bash
+oc get netpol -n apim
+```
+
+```bash
+oc apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apim-internal
+  namespace: apim
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: apim
+EOF
+```
+
+This allows all pods within the `apim` namespace to communicate with each other.


### PR DESCRIPTION
## Purpose
> Complete rewrite of the OpenShift deployment guide for 4.6.0 — restructured as a step-by-step Quick Start, live-tested on OpenShift Local (CRC)