### PR TITLE
Add guidance for searching API names with spaces and hyphens

### DIFF
--- a/en/docs/api-developer-portal/discover-apis/search.md
+++ b/en/docs/api-developer-portal/discover-apis/search.md
@@ -22,55 +22,67 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
   <p>This is the default option. Simply enter any attribute value from the API, its documentation, or definition, and search.</p>
   <p>For example, entering <strong>Pizza</strong> will search for the term <strong>Pizza</strong> across the API name, context, version, documents, and definition of all APIs.</p>
 </td>
-</td>
 </tr>
+  
 <tr class="odd">
 <td>By the API's name</td>
-<td><p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
-<p>Name is the API name.</p></td>
+<td>
+<p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
+<p>Name is the API name.</p>
+<p>For API names containing spaces or hyphens, enclose the API name in double quotes. For example, <strong>name:"Pizza Shack API"</strong> or <strong>name:"Pizza-Shack-API"</strong>.</p>
+</td>
 </tr>
+
 <tr class="even">
 <td>By the API provider</td>
 <td><p><strong>provider:xxxx</strong> . For example, provider:admin</p>
 <p>Provider is the user who created the API.</p></td>
 </tr>
+
 <tr class="odd">
 <td>By the API version</td>
 <td><p><strong>version:xxxx</strong> . For example, version:1.0.0</p>
 <p>A version is given to an API at the time it is created.</p></td>
 </tr>
+
 <tr class="even">
 <td>By the context</td>
 <td><p><strong>context:xxxx.</strong> For example, context:/phoneverify</p>
 <p>Context is the URL context of the API that is specified as /&lt;context_name&gt; at the time the API is created.</p></td>
 </tr>
+
 <tr class="odd">
 <td>By the API's status</td>
 <td><p><strong>status:xxxx</strong> . For example, status:PUBLISHED</p>
 <p>A state is any stage of an API's lifecycle. The default lifecycle stages include created, prototyped, published, deprecated, retired and blocked.</p></td>
 </tr>
+
 <tr class="even">
 <td>By description</td>
 <td><p><strong>description:xxxx</strong></p>
 <p>A description can be given to an API at the time it is created or later. There can be APIs without descriptions as this parameter is optional. <strong><br />
 </strong></p></td>
 </tr>
+
 <tr class="odd">
 <td>By tag</td>
 <td><p><strong>tag:xxxx</strong> . For example, tag:pizza</p>
 <p>A tag can be given to an API at the time it is created or later. There can be APIs without tags as this parameter is optional.</p></td>
 </tr>
+
 <tr class="even">
 <td>By a custom property</td>
 <td><p><strong>property_name:property_value</strong></p>
 <p>A property can be defined to an API at the time it is created or later. There can be APIs without properties as this parameter is optional. <strong><br />
 </strong></p></td>
 </tr>
+
 <tr class="odd">
 <td>By API category</td>
 <td><p><strong>api-category:xxxx</strong> . For example, api-category:test</p>
 <p>An API category can be used to group APIs based on any criteria. API categories can be defined from the Admin Portal and can be assigned to an API from the Design Configurations section of the Publisher Portal.</p></td>
 </tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
## Purpose

Adds guidance for searching APIs by name when the API name contains spaces or hyphens.

## Changes

- Added documentation note explaining the use of double quotes with the `name:` search filter.
- Added examples for API names containing spaces and hyphens.

