### PR TITLE
Fix incorrect capitalization in quick-start-guide

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -170,7 +170,7 @@ Follow the instructions below to invoke the created API.
 
      [![Test API]({{base_path}}/assets/img/get_started/test-api.png)]({{base_path}}/assets/img/get_started/test-api.png)
 
-2. Click on the `GET` resource of the API to expand the resource and Click **Try It Out**.
+2. Click on the `GET` resource of the API to expand the resource and click **Try It Out**.
    
      [![GET resource]({{base_path}}/assets/img/get_started/expanded-get-resource.png)]({{base_path}}/assets/img/get_started/expanded-get-resource.png)
 


### PR DESCRIPTION
Fixed incorrect capitalization of "Click" in the middle 
of a sentence. "Click" should be "click" as it appears 
mid-sentence and is not a proper noun or start of a sentence.