### PR TITLE
Fix incorrect capitalization of URL in quick-start-guide

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -77,7 +77,7 @@ Follow the instructions below to create, deploy and publish an API via the Publi
     | `Charset`               | UTF-8                 |
     | `HTTP Response Body`    | `{"hello": "world"}`  |
 
-    Finally, click **Generate My HTTP Response** to save and generate the mock service url.
+    Finally, click **Generate My HTTP Response** to save and generate the mock service URL.
 
     
 4. Select **REST API** from the home screen and then click **Start From Scratch**.


### PR DESCRIPTION
Fixed incorrect lowercase "url" to the correctly 
capitalized "URL" in the mock service step.

Original:
"...save and generate the mock service url."

Fix:
"...save and generate the mock service URL."

"URL" is an acronym (Uniform Resource Locator) and 
should always be written in uppercase according to 
standard technical writing conventions.