### PR TITLE
[4.5.0] Add multipart message formatter options docs

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -16855,12 +16855,13 @@ connection_acquisition_timeout = 60
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="111" type="checkbox" id="_tab_111">
-                <label class="tab-selector" for="_tab_111"><i class="icon fa fa-code"></i></label>
+            <input name="112" type="checkbox" id="_tab_112">
+                <label class="tab-selector" for="_tab_112"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[authentication.authenticator.oidc.parameters]
-excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"</code></pre>
+excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"
+</code></pre>
                     </div>
                 </div>
                 <div class="doc-wrapper">

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -12238,7 +12238,7 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
 
 
 
-## Message Mediation
+## Message Formatter Options
 
 
 <div class="mb-config-catalog">
@@ -12248,6 +12248,87 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
             
             <input name="81" type="checkbox" id="_tab_81">
                 <label class="tab-selector" for="_tab_81"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[message_formatter.options]
+disableSendingMultipartPartCharset = true
+preserveMultipartPartContentTransferEncoding = true
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[message_formatter.options]</code>
+                            
+                            <p>
+                                
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>disableSendingMultipartPartCharset</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Defines whether the charset parameter in the Content-Type header should be preserved in each part of multipart form data.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>preserveMultipartPartContentTransferEncoding</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Defines whether the Content-Transfer-Encoding header should be preserved in each part of multipart form data.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Message Mediation
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="82" type="checkbox" id="_tab_82">
+                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[mediation]
@@ -12584,8 +12665,8 @@ inbound.max_threads = 100</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="82" type="checkbox" id="_tab_82">
-                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
+            <input name="83" type="checkbox" id="_tab_83">
+                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">enabled_global_handlers= ["custom_logger"]
@@ -12666,8 +12747,8 @@ custom_logger.class= "com.wso2.apim.log.handler.SynapseLogHandler"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="83" type="checkbox" id="_tab_83">
-                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
+            <input name="84" type="checkbox" id="_tab_84">
+                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[governance]
@@ -12724,8 +12805,8 @@ life_cycle_checklist_items_enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="84" type="checkbox" id="_tab_84">
-                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
+            <input name="85" type="checkbox" id="_tab_85">
+                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[qpid.heartbeat]
@@ -12800,8 +12881,8 @@ timeout_factor = 3.0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="85" type="checkbox" id="_tab_85">
-                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
+            <input name="86" type="checkbox" id="_tab_86">
+                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check]
@@ -12856,8 +12937,8 @@ enable = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="86" type="checkbox" id="_tab_86">
-                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
+            <input name="87" type="checkbox" id="_tab_87">
+                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker]
@@ -12932,8 +13013,8 @@ order = "98"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="87" type="checkbox" id="_tab_87">
-                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
+            <input name="88" type="checkbox" id="_tab_88">
+                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker.properties]
@@ -12986,8 +13067,8 @@ monitored.user.stores = "primary,sec"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="88" type="checkbox" id="_tab_88">
-                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
+            <input name="89" type="checkbox" id="_tab_89">
+                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker]
@@ -13062,8 +13143,8 @@ order = "97"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="89" type="checkbox" id="_tab_89">
-                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
+            <input name="90" type="checkbox" id="_tab_90">
+                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker.properties]
@@ -13136,8 +13217,8 @@ monitored.datasources = "jdbc/WSO2AM_DB,jdbc/SHARED_DB,jdbc/WSO2CarbonDB"</code>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="90" type="checkbox" id="_tab_90">
-                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
+            <input name="91" type="checkbox" id="_tab_91">
+                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[health_checker]
@@ -13233,8 +13314,8 @@ first_property = "value"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="91" type="checkbox" id="_tab_91">
-                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
+            <input name="92" type="checkbox" id="_tab_92">
+                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth]
@@ -13412,8 +13493,8 @@ token_context_dialect_uri = "http://wso2.org/claims"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="92" type="checkbox" id="_tab_92">
-                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
+            <input name="93" type="checkbox" id="_tab_93">
+                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_validation]
@@ -13507,8 +13588,8 @@ refresh_token_validity = "86400"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="93" type="checkbox" id="_tab_93">
-                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
+            <input name="94" type="checkbox" id="_tab_94">
+                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_cleanup]
@@ -13585,8 +13666,8 @@ retain_access_tokens_for_auditing = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="94" type="checkbox" id="_tab_94">
-                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
+            <input name="95" type="checkbox" id="_tab_95">
+                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.oidc.extensions]
@@ -13814,8 +13895,8 @@ enable_unmapped_user_attributes = true
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="95" type="checkbox" id="_tab_95">
-                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
+            <input name="96" type="checkbox" id="_tab_96">
+                <label class="tab-selector" for="_tab_96"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.grant_type.authorization_code]
@@ -14431,8 +14512,8 @@ enable_multi_value_claim_handling = false
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="96" type="checkbox" id="_tab_96">
-                <label class="tab-selector" for="_tab_96"><i class="icon fa fa-code"></i></label>
+            <input name="97" type="checkbox" id="_tab_97">
+                <label class="tab-selector" for="_tab_97"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[session_data.persistence]
@@ -14485,8 +14566,8 @@ persistence_pool_size = 0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="97" type="checkbox" id="_tab_97">
-                <label class="tab-selector" for="_tab_97"><i class="icon fa fa-code"></i></label>
+            <input name="98" type="checkbox" id="_tab_98">
+                <label class="tab-selector" for="_tab_98"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_generation]
@@ -14541,8 +14622,8 @@ retry_count_on_persistence_failures = 5</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="98" type="checkbox" id="_tab_98">
-                <label class="tab-selector" for="_tab_98"><i class="icon fa fa-code"></i></label>
+            <input name="99" type="checkbox" id="_tab_99">
+                <label class="tab-selector" for="_tab_99"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[user_store.properties]
@@ -15370,8 +15451,8 @@ UserCoreCacheTimeOut = 5 </code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="99" type="checkbox" id="_tab_99">
-                <label class="tab-selector" for="_tab_99"><i class="icon fa fa-code"></i></label>
+            <input name="100" type="checkbox" id="_tab_100">
+                <label class="tab-selector" for="_tab_100"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[custom_keystore.APIKeyKeyStore]
@@ -15506,8 +15587,8 @@ key_password = "wso2carbon"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="100" type="checkbox" id="_tab_100">
-                <label class="tab-selector" for="_tab_100"><i class="icon fa fa-code"></i></label>
+            <input name="101" type="checkbox" id="_tab_101">
+                <label class="tab-selector" for="_tab_101"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[http_access_log]
@@ -15564,8 +15645,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="101" type="checkbox" id="_tab_101">
-                <label class="tab-selector" for="_tab_101"><i class="icon fa fa-code"></i></label>
+            <input name="102" type="checkbox" id="_tab_102">
+                <label class="tab-selector" for="_tab_102"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">#### Sample deployment.toml entry
@@ -15912,8 +15993,8 @@ mediaType = "application/vnd.wso2-service+xml"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="102" type="checkbox" id="_tab_102">
-                <label class="tab-selector" for="_tab_102"><i class="icon fa fa-code"></i></label>
+            <input name="103" type="checkbox" id="_tab_103">
+                <label class="tab-selector" for="_tab_103"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.transport_headers]
@@ -16053,8 +16134,8 @@ excludeResponseHeaders = ""
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="103" type="checkbox" id="_tab_103">
-                <label class="tab-selector" for="_tab_103"><i class="icon fa fa-code"></i></label>
+            <input name="104" type="checkbox" id="_tab_104">
+                <label class="tab-selector" for="_tab_104"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[synapse_handlers.custom_handler_name]
@@ -16130,8 +16211,8 @@ class="org.wso2.carbon.apimgt.gateway.handlers.custom.customer_handler"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="104" type="checkbox" id="_tab_104">
-                <label class="tab-selector" for="_tab_104"><i class="icon fa fa-code"></i></label>
+            <input name="105" type="checkbox" id="_tab_105">
+                <label class="tab-selector" for="_tab_105"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.governance.scheduler]
@@ -16247,8 +16328,8 @@ task_cleanup_interval_minutes = 30
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="105" type="checkbox" id="_tab_105">
-                <label class="tab-selector" for="_tab_105"><i class="icon fa fa-code"></i></label>
+            <input name="106" type="checkbox" id="_tab_106">
+                <label class="tab-selector" for="_tab_106"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.organization_based_access_control]
@@ -16343,8 +16424,8 @@ organization_id_local_claim = "http://wso2.org/claims/organizationId"</code></pr
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="106" type="checkbox" id="_tab_106">
-                <label class="tab-selector" for="_tab_106"><i class="icon fa fa-code"></i></label>
+            <input name="107" type="checkbox" id="_tab_107">
+                <label class="tab-selector" for="_tab_107"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[service_provider]
@@ -16400,8 +16481,8 @@ use_username_as_sub_claim = true
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="107" type="checkbox" id="_tab_107">
-                <label class="tab-selector" for="_tab_107"><i class="icon fa fa-code"></i></label>
+            <input name="108" type="checkbox" id="_tab_108">
+                <label class="tab-selector" for="_tab_108"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.basic_authenticator]
@@ -16517,8 +16598,8 @@ max_wait_millis = 30000
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="108" type="checkbox" id="_tab_108">
-                <label class="tab-selector" for="_tab_108"><i class="icon fa fa-code"></i></label>
+            <input name="109" type="checkbox" id="_tab_109">
+                <label class="tab-selector" for="_tab_109"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[web_app.cookie_processor]
@@ -16576,8 +16657,8 @@ same_site_cookies = "lax"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="109" type="checkbox" id="_tab_109">
-                <label class="tab-selector" for="_tab_109"><i class="icon fa fa-code"></i></label>
+            <input name="110" type="checkbox" id="_tab_110">
+                <label class="tab-selector" for="_tab_110"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.aws_lambda.http_client]
@@ -16693,8 +16774,8 @@ connection_acquisition_timeout = 60
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="110" type="checkbox" id="_tab_110">
-                <label class="tab-selector" for="_tab_110"><i class="icon fa fa-code"></i></label>
+            <input name="111" type="checkbox" id="_tab_111">
+                <label class="tab-selector" for="_tab_111"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[synapse_properties]

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -38,7 +38,7 @@
                             "required": false,
                             "default": "false",
                             "possible": "true,false",
-                            "description": "Use this paramater to enable MTOM (Message Transmission Optimization Mechanism) for the product server."
+                            "description": "Use this parameter to enable MTOM (Message Transmission Optimization Mechanism) for the product server."
                         }, 
                         {
                             "name": "enableSwA",
@@ -46,7 +46,7 @@
                             "required": false,
                             "default": "false",
                             "possible": "true,false",
-                            "description": "Use this paramater to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages."
+                            "description": "Use this parameter to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages."
                         },   
                         {
                             "name": "disable_shutdown_from_ui",
@@ -846,7 +846,7 @@
                             "required": false,
                             "default": "TRUE",
                             "possible": "",
-                            "description": "Enabel cache for scopes. This expires in 15 minutes by default."
+                            "description": "Enable cache for scopes. This expires in 15 minutes by default."
                         }
                     ]
                 }
@@ -4562,6 +4562,35 @@
             "exampleFile": "_message-formatters-custom-blocking.toml"
         },
         {
+            "title": "Message Formatter Options",
+            "options": [
+                {
+                    "name": "message_formatter.options",
+                    "required": false,
+                    "description": "",
+                    "params": [
+                        {
+                            "name": "disableSendingMultipartPartCharset",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true false",
+                            "description": "Defines whether the charset parameter in the Content-Type header should be preserved in each part of multipart form data."
+                        },
+                        {
+                            "name": "preserveMultipartPartContentTransferEncoding",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true false",
+                            "description": "Defines whether the Content-Transfer-Encoding header should be preserved in each part of multipart form data."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "message_formatter.options.toml"
+        },
+        {
             "title": "Message Mediation",
             "options": [
                 {
@@ -4734,7 +4763,7 @@
                 {
                     "name": "qpid.heartbeat",
                     "required": false,
-                    "description": "This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid brocker component of Traffic Manager. You need to to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.",
+                    "description": "This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid broker component of Traffic Manager. You need to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.",
                     "params": [
                         {
                             "name": "delay",

--- a/en/tools/config-catalog-generator/data/message_formatter.options.toml
+++ b/en/tools/config-catalog-generator/data/message_formatter.options.toml
@@ -1,0 +1,3 @@
+[message_formatter.options]
+disableSendingMultipartPartCharset = true
+preserveMultipartPartContentTransferEncoding = true


### PR DESCRIPTION
This pull request adds documentation and configuration support for new message formatter options, specifically for handling multipart form data in message formatting. It introduces two new boolean options—`disableSendingMultipartPartCharset` and `preserveMultipartPartContentTransferEncoding`—and updates both the documentation and the config catalog generator to include these options.

* If the `disableSendingMultipartPartCharset` is `false`, allow overwriting the `charset` parameter in the `Content-Type` header, even if the `charset` parameter  is sent in the request.
* If the `disableSendingMultipartPartCharset` is `true`, do not manipulate the `charset` parameter in the `Content-Type` header.

* If the `preserveContentTransferEncoding` is `false`, allow overwriting the `Content-Transfer-Encoding` header, even if the `Content-Transfer-Encoding` header is sent in the request.
* If the `preserveContentTransferEncoding` is `true`, do not manipulate the `Content-Transfer-Encoding` header.

**Message Formatter Options Documentation:**

- Added a new section, "Message Formatter Options," before the "Message Mediation" section to document available options for message formatting.
- Introduced two new message formatter options with TOML examples and detailed parameter descriptions:
  - [`disableSendingMultipartPartCharset`](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dR12253-R12333): Controls whether the charset parameter is preserved in multipart form data.
  - [`preserveMultipartPartContentTransferEncoding`](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dR12253-R12333): Determines if the Content-Transfer-Encoding header is preserved in multipart form data.

**Configuration Catalog Structure Updates:**

- Shifted the "Message Mediation" section and all subsequent sections down to accommodate the new "Message Formatter Options" section.
- Incremented all tab indices and related input/label identifiers by one throughout the document to maintain correct tab navigation after the insertion of the new section. [[1]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12587-R12669) [[2]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12669-R12751) [[3]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12727-R12809) [[4]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12803-R12885) [[5]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12859-R12941) [[6]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12935-R13017) [[7]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL12989-R13071) [[8]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13065-R13147) [[9]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13139-R13221) [[10]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13236-R13318) [[11]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13415-R13497) [[12]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13510-R13592) [[13]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13588-R13670) [[14]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL13817-R13899) [[15]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL14434-R14516) [[16]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL14488-R14570) [[17]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL14544-R14626) [[18]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15373-R15455) [[19]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15509-R15591) [[20]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15567-R15649) [[21]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15915-R15997)

