### PR TITLE
Fix inconsistent URL paths in Create a REST API page

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
@@ -1,6 +1,6 @@
 # Create a REST API
 
-**API creation** is the process of linking an existing backend API implementation to the [API Publisher]({{base_path}}/get-started/apim-architecture/#api-publisher), so that you can manage and monitor the [API's lifecycle]({{base_path}}/api-design-manage/design/lifecycle-management/api-lifecycle/), documentation, security, community, and subscriptions. Alternatively, you can provide the API implementation in-line in the [API Publisher]({{base_path}}/get-started/apim-architecture/#api-publisher) itself.
+**API creation** is the process of linking an existing backend API implementation to the [API Publisher]({{base_path}}/get-started/apim-architecture/#api-publisher), so that you can manage and monitor the [API's lifecycle]({{base_path}}/manage-apis/design/lifecycle-management/api-lifecycle/), documentation, security, community, and subscriptions. Alternatively, you can provide the API implementation in-line in the [API Publisher]({{base_path}}/get-started/apim-architecture/#api-publisher) itself.
 
 Follow the instructions below to create a REST API using the basic flow:
 
@@ -48,7 +48,7 @@ Follow the instructions below to create a REST API using the basic flow:
 
          <html><div class="admonition note">
          <p class="admonition-title">Note</p>
-         <p>By default, **All** users who have `creator` permission are allowed **<a href='{{base_path}}/api-design-manage/design/advanced-topics/enable-publisher-access-control-in-api-publisher-portal/'>Publisher Access Control</a>** and public **<a href='{{base_path}}/api-design-manage/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/'> 
+         <p>By default, **All** users who have `creator` permission are allowed **<a href='{{base_path}}/manage-apis/design/advanced-topics/enable-publisher-access-control-in-api-publisher-portal/'>Publisher Access Control</a>** and public **<a href='{{base_path}}/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/'> 
          Developer Portal visibility</a>**.</p>
          <p>
          </div>
@@ -171,7 +171,7 @@ Follow the instructions below to create a REST API using the basic flow:
         </div>
 
 
-Now, you have successfully created and configured a REST API. Next, [deploy the API]({{base_path}}/api-design-manage/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-an-api/), [test the API]({{base_path}}/api-design-manage/design/create-api/create-rest-api/test-a-rest-api/), and finally [publish the API]({{base_path}}/api-design-manage/deploy-and-publish/publish-on-dev-portal/publish-an-api).
+Now, you have successfully created and configured a REST API. Next, [deploy the API]({{base_path}}/manage-apis/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-an-api/), [test the API]({{base_path}}/manage-apis/design/create-api/create-rest-api/test-a-rest-api/), and finally [publish the API]({{base_path}}/manage-apis/deploy-and-publish/publish-on-dev-portal/publish-an-api).
 
 ## See Also
 


### PR DESCRIPTION
Completes the migration from api-design-manage/ to manage-apis/ for all remaining links in the page, making the URL scheme consistent with the See Also section updated in PR #10492.

Fixes #11444

## Purpose
Resolves #11444. All links in the page now consistently use `manage-apis/` instead of mixing `api-design-manage/` and `manage-apis/`.

## Goals
Make the URL scheme consistent across the entire page.

## Approach
Changed all 6 remaining `api-design-manage/` links to `manage-apis/` directly in the file.

## User stories
N/A

## Release note
N/A

## Documentation
N/A — This is a documentation fix itself.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 N/A


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (doc change)
 - Ran FindSecurityBugs plugin and verified report? N/A (doc change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A