### PR TITLE
Update API Manager release version to 4.7.0 in upgrade doc

### DIFF
--- a/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-api-manager.md
+++ b/en/docs/install-and-setup/upgrading-wso2-api-manager/upgrading-api-manager.md
@@ -12,7 +12,7 @@ There are multiple reasons why you would want to upgrade the WSO2 product to the
 
 ## What has changed
 
-Over the course of its lifetime, WSO2 API Manager has changed significantly. To learn what’s new in the WSO2 API Manager 4.5.0 release, see the [About this Release page]({{base_path}}/get-started/about-this-release/).
+Over the course of its lifetime, WSO2 API Manager has changed significantly. To learn what’s new in the WSO2 API Manager 4.7.0 release, see the [About this Release page]({{base_path}}/get-started/about-this-release/).
 
 <div class="admonition info">
     <p class="admonition-title">Seamless product upgrade from WSO2 API Manager 4.2.0</p>


### PR DESCRIPTION
## Purpose
Updates the referenced WSO2 API Manager release version from 4.5.0 to 4.7.0 in the "What has changed" section of the upgrading guide. Port of #11446 to the 4.7.0 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)