### PR TITLE
Add missing Advanced Configurations section to WSO2 IS 6.x Key Manager guide

### DIFF
--- a/en/docs/api-security/key-management/third-party-key-managers/configure-wso2is-connector.md
+++ b/en/docs/api-security/key-management/third-party-key-managers/configure-wso2is-connector.md
@@ -352,4 +352,29 @@ Follow the steps given below to configure WSO2 IS 6.x as a Key Manager component
       </tbody>
       </table>
 
+### Additional Configurations
+
+After adding the Key Manager, the following additional settings may be required
+depending on your setup:
+
+!!! tip "User Ownership and Self-Signed-Up Users"
+    If your Developer Portal allows self-signup and application owners are not
+    replicated to the WSO2 IS side, you must enable the **"Enable admin user as
+    the owner of created OAuth applications"** option. Without this, OAuth key
+    generation will fail for applications created by self-signed-up users.
+
+    To enable this:
+
+    1. In the Admin Portal, navigate to **Key Managers** and click on the WSO2
+       IS Key Manager you configured.
+    2. Under **Advanced Configurations**, enable **"Enable admin user as the
+       owner of created OAuth applications"**.
+    3. Click **Save**.
+
+!!! tip "Application Scopes"
+    To ensure that application-level scopes are properly enforced on OAuth
+    applications managed by this Key Manager, enable the **"Enable application
+    scopes for OAuth applications"** option under **Advanced Configurations**
+    of the Key Manager.
+
 You can also configure the WSO2 Identity Server as the identity provider. For more information on how to do this, see [Configuring WSO2 Identity Server as an Identity Provider]({{base_path}}/reference/customize-product/extending-api-manager/saml2-sso/configuring-identity-server-as-idp-for-sso/#configuring-wso2-identity-server-as-a-saml-20-sso-identity-provider).


### PR DESCRIPTION
Fixes #11168

The guide was missing two critical configuration options that cause silent
failures in real-world setups. Added an Additional Configurations section
covering:
- Enable admin user as owner of created OAuth applications (required for
  self-signup users in Developer Portal)
- Enable application scopes for OAuth applications (required for proper
  scope handling)
Relates to #11168.

## Purpose
Resolves #11168. The WSO2 IS 6.x Key Manager configuration guide was missing
two critical Advanced Configuration options. Users who follow the guide exactly
but have self-signup enabled in the Developer Portal experience silent OAuth key
generation failures with no indication of what is wrong or how to fix it.

## Goals
- Document the "Enable admin user as the owner of created OAuth applications"
  option and when it is required.
- Document the "Enable application scopes for OAuth applications" option and
  its purpose.
- Prevent silent failures for users with self-signup enabled in the Developer
  Portal.

## Approach
Added a new "### Additional Configurations" subsection at the end of the Step 2
subsection in configure-wso2is-connector.md, before the final paragraph about
configuring IS as an identity provider. The section uses two MkDocs tip
admonition blocks to clearly explain each option, when it is needed, and the
exact steps to enable it.

## User stories
- As a Developer Portal admin with self-signup enabled, I need to know that I
  must enable "Enable admin user as the owner of created OAuth applications" so
  that OAuth key generation does not silently fail for self-signed-up users.
- As an API manager admin, I need to know about the "Enable application scopes
  for OAuth applications" option so that application-level scopes are correctly
  enforced.

## Release note
Added missing Advanced Configurations section to the WSO2 IS 6.x Key Manager
guide documenting two options required in self-signup and scope-enforcement
setups to prevent silent OAuth key generation failures.

## Documentation
This PR itself is the documentation fix.
File changed: en/docs/api-security/key-management/third-party-key-managers/configure-wso2is-connector.md

## Training
N/A

## Certification
N/A — This is a documentation-only fix for a missing configuration note. No
new product feature or behaviour is introduced.

## Marketing
N/A

## Automation tests
- Unit tests: N/A — documentation only change
- Integration tests: N/A — documentation only change

## Security checks
- Followed secure coding standards: N/A — documentation only change
- Ran FindSecurityBugs plugin: N/A — documentation only change
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A — documentation only change

## Learning
Issue #11168 and its community comments identified this as a silent failure
that affects users with self-signup enabled. The two missing options were
identified by reviewing the WSO2 IS Key Manager Advanced Configurations UI
and cross-referencing community-reported failure scenarios.