### PR TITLE
Fixed typos in configs.json

### DIFF
--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -38,7 +38,7 @@
                             "required": false,
                             "default": "false",
                             "possible": "true,false",
-                            "description": "Use this paramater to enable MTOM (Message Transmission Optimization Mechanism) for the product server."
+                            "description": "Use this parameter to enable MTOM (Message Transmission Optimization Mechanism) for the product server."
                         }, 
                         {
                             "name": "enableSwA",
@@ -46,7 +46,7 @@
                             "required": false,
                             "default": "false",
                             "possible": "true,false",
-                            "description": "Use this paramater to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages."
+                            "description": "Use this parameter to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages."
                         },   
                         {
                             "name": "disable_shutdown_from_ui",
@@ -846,7 +846,7 @@
                             "required": false,
                             "default": "TRUE",
                             "possible": "",
-                            "description": "Enabel cache for scopes. This expires in 15 minutes by default."
+                            "description": "Enable cache for scopes. This expires in 15 minutes by default."
                         }
                     ]
                 }
@@ -4734,7 +4734,7 @@
                 {
                     "name": "qpid.heartbeat",
                     "required": false,
-                    "description": "This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid brocker component of Traffic Manager. You need to to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.",
+                    "description": "This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid broker component of Traffic Manager. You need to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.",
                     "params": [
                         {
                             "name": "delay",


### PR DESCRIPTION
 **Summary**

  - Fixed typo paramater → parameter in MTOM and SwA descriptions
  - Fixed typo Enabel → Enable in scope cache description
  - Fixed typo brocker → broker and to to → to in Qpid heartbeat description

These are the same typos fixed in config-catalog.md via commit ed27851 (https://github.com/wso2/docs-apim/commit/ed27851f1035340c544dca104a8ecf14bccf67e3). 

Since config-catalog.md is auto-generated from this file, the source also needs to be corrected to prevent the typos from reappearing on the next generation.