### PR TITLE
Fix nav title: remove admin_ prefix from Directory Structure page

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -773,7 +773,7 @@ nav:
         - Guides:
             - Message Flow in the API Manager Gateway: reference/guides/message-flow-in-the-api-manager-gateway.md
             - Accessing API Manager by Multiple Devices Simultaneously: reference/guides/accessing-api-manager-by-multiple-devices-simultaneously.md
-            - admin_Directory Structure of WSO2 Products: reference/guides/directory-structure-of-wso2-products.md
+            - Directory Structure of WSO2 Products: reference/guides/directory-structure-of-wso2-products.md
         - Common Runtime and Configuration Artifacts: reference/common-runtime-and-configuration-artifacts.md
         - Default Product Ports: reference/default-product-ports.md
         - Product Compatibility: reference/product-compatibility.md


### PR DESCRIPTION
## Summary
Removed an internal `admin_` prefix that was accidentally left 
in the navigation title.

## Problem
The nav entry and page title incorrectly displayed as:
❌ `admin_Directory Structure of WSO2 Products`

When it should be:
✅ `Directory Structure of WSO2 Products`

## Changes
- Removed `admin_` prefix from the nav entry in `mkdocs.yml` (line 776)