### PR TITLE
Add guidance for searching API names with spaces or hyphens

### DIFF
--- a/en/docs/api-developer-portal/discover-apis/search.md
+++ b/en/docs/api-developer-portal/discover-apis/search.md
@@ -24,14 +24,12 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
 </td>
 </tr>
   
-<tr class="odd">
 <td>By the API's name</td>
 <td>
 <p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
 <p>Name is the API name.</p>
 <p>For API names containing spaces or hyphens, enclose the API name in double quotes. For example, <strong>name:"Pizza Shack API"</strong> or <strong>name:"Pizza-Shack-API"</strong>.</p>
 </td>
-</tr>
 
 <tr class="even">
 <td>By the API provider</td>


### PR DESCRIPTION
This PR adds a note about using double quotes when searching for API names that contain spaces or hyphens.

Example: name:"Pizza Shack API" or name:"Pizza-Shack-API"