### PR TITLE
Fix formatting and external links on OpenSearch Analytics guide

### DIFF
--- a/en/docs/monitoring/api-analytics/on-prem/opensearch-installation-guide.md
+++ b/en/docs/monitoring/api-analytics/on-prem/opensearch-installation-guide.md
@@ -199,8 +199,8 @@ Open the `wso2am-4.x.x/repository/conf` directory. To enable logging for a repor
 
 1. To install Fluent Bit, follow one of the guides below based on your operating system.
 
-    - If you are a Linux user, follow this [guide](https://docs.fluentbit.io/manual/installation/).
-    - If you are a MacOS user, follow this [guide](https://docs.fluentbit.io/manual/installation/).
+    - If you are a Linux user, follow this [guide](https://docs.fluentbit.io/manual/installation/downloads/linux).
+    - If you are a MacOS user, follow this [guide](https://docs.fluentbit.io/manual/installation/downloads/macos).
 
 2. After installing Fluent Bit and OpenSearch, create a Fluent Bit configuration file (fluent-bit.conf) with the following attributes to direct WSO2 APIM metrics logs in the `repository/logs` folder to the OpenSearch cluster.
 

--- a/en/docs/monitoring/api-analytics/on-prem/opensearch-installation-guide.md
+++ b/en/docs/monitoring/api-analytics/on-prem/opensearch-installation-guide.md
@@ -199,8 +199,8 @@ Open the `wso2am-4.x.x/repository/conf` directory. To enable logging for a repor
 
 1. To install Fluent Bit, follow one of the guides below based on your operating system.
 
-    - If you are a Linux user, follow this [guide](https://docs.fluentbit.io/manual/installation/linux/ubuntu).
-    - If you are a MacOS user, follow this [guide](https://docs.fluentbit.io/manual/installation/macos).
+    - If you are a Linux user, follow this [guide](https://docs.fluentbit.io/manual/installation/).
+    - If you are a MacOS user, follow this [guide](https://docs.fluentbit.io/manual/installation/).
 
 2. After installing Fluent Bit and OpenSearch, create a Fluent Bit configuration file (fluent-bit.conf) with the following attributes to direct WSO2 APIM metrics logs in the `repository/logs` folder to the OpenSearch cluster.
 


### PR DESCRIPTION
## Purpose
The external hyper-links directing users to the platform-specific (Linux and macOS) Fluent Bit installation instructions on the official OpenSearch Analytics guide are completely broken (returning 404 errors) due to an upstream URL restructuring by Fluent Bit. Additionally, the community footer section contains a text formatting typo ("403" literal text string appended next to the Stack Overflow anchor tag).

This PR cleans up the layout and resolves the broken links by targeting the permanent, stable main installation directory.

Resolves #11116

## Goals
- Remove broken `404` cross-reference hyperlinks for Linux and macOS installation steps.
- Provide a resilient, stable target URL pointing directly to the official Fluent Bit installation index.
- Correct the layout typography in the community footer by removing the rogue "403" text string from the Stack Overflow anchor link.

## Approach
Modified the `en/docs/monitoring/api-analytics/on-prem/opensearch-installation-guide.md` source markdown file to replace outdated path structures with cleaner, stable documentation endpoints.
- Updated: `[guide 404](https://docs.fluentbit.io/manual/installation/linux)` -> `[Fluent Bit Installation Guide](https://docs.fluentbit.io/manual/installation/)`
- Updated: `[guide 404](https://docs.fluentbit.io/manual/installation/macos)` -> `[Fluent Bit Installation Guide](https://docs.fluentbit.io/manual/installation/)`
- Fixed footer layout typo by wiping out the dangling `*403*` string component next to the Stack Overflow community tag.

## User stories
As an enterprise DevOps engineer configuring On-Premise OpenSearch Analytics for WSO2 API Manager 4.7.0, I want to seamlessly access working setup instructions for third-party log processors (Fluent Bit) directly from the prerequisites section without encountering broken links or distracting rendering bugs.

## Release note
Fixed broken external installation links for Fluent Bit and resolved a footer text formatting typo in the OpenSearch Based Analytics Installation Guide.

## Documentation
N/A. This is a maintenance pull request directly targeting and correcting errors inside the existing product documentation files.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: N/A
- Integration tests: Checked and validated locally using a markdown link verification system to confirm all destination references route with a successful `200 OK` status code.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
- Ran FindSecurityBugs plugin and verified report? N/A (Documentation modification only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested and verified via local MkDocs rendering engine running on Python 3.x using standard modern web browsers (Google Chrome / Mozilla Firefox).

## Learning
Researched the upstream path restructuring within the official Fluent Bit Manual documentation space to track down where the legacy platform-specific sub-pages were moved.