### PR TITLE
Fix grammatical errors in API overview documentation

### DIFF
--- a/en/docs/api-design-manage/design/design-api-overview.md
+++ b/en/docs/api-design-manage/design/design-api-overview.md
@@ -16,7 +16,7 @@ There are multiple options available to API designers to create an API in WSO2 A
 
 You have two options to create a REST API via the API Publisher in WSO2 API Manager.
 
-- [Create a REST API through the API Publisher]({{base_path}}/api-design-manage/design/create-api/create-rest-api/create-a-rest-api) - You can directly create your API in the API Publisher by linking your existing backend API implementation.
+- [Create a REST API through the API Publisher]({{base_path}}/api-design-manage/design/create-api/create-rest-api/create-a-rest-api) - You can directly create your API in the API Publisher by linking to your existing backend API implementation.
 - [Create a REST API from an OpenAPI Definition]({{base_path}}/api-design-manage/design/create-api/create-rest-api/create-a-rest-api-from-an-openapi-definition) - An OpenAPI definition is a format that describes REST APIs. You can create a REST API based on this definition.
 
 Additionally, you can also convert existing SOAP services or backends to REST APIs. Refer to [Expose a SOAP Service as a REST API]({{base_path}}/api-design-manage/design/create-api/create-rest-api/expose-a-soap-service-as-a-rest-api) or [Generate REST API from SOAP Backend]({{base_path}}/api-design-manage/design/create-api/create-rest-api/generate-rest-api-from-soap-backend) for more information.
@@ -40,7 +40,7 @@ A Streaming API is a logical collection of related topics through which clients 
 
 ## Secure APIs
 
-Many enterprises need to implement API management solutions that provide mechanisms such as authentication, authorization, and rate limiting. These are must-have capabilities for controlling who access APIs across an API ecosystem — and how often.
+Many enterprises need to implement API management solutions that provide mechanisms such as authentication, authorization, and rate limiting. These are must-have capabilities for controlling who accesses APIs across an API ecosystem — and how often.
 
 **Rate Limiting**
 


### PR DESCRIPTION
Fix grammatical errors in Design API Overview

## Purpose
Fix two grammatical errors in the Design API Overview page.

## Goals
- Add missing preposition "to": "linking your existing backend API implementation" → "linking to your existing backend API implementation"
- Fix subject-verb agreement: "who access APIs" → "who accesses APIs"

## Approach
Direct text corrections with no functional changes.

## User stories
N/A

## Release note
N/A

## Documentation
N/A - This PR itself is a documentation fix.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
- Followed secure coding standards: N/A (documentation only)
- Ran FindSecurityBugs plugin: N/A (documentation only)
- Confirmed no keys, passwords, or secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
N/A

## Learning
N/A