### PR TITLE
Fix typo in monetization implementation instructions

### DIFF
--- a/en/docs/monitoring/api-monetization/monetizing-an-api.md
+++ b/en/docs/monitoring/api-monetization/monetizing-an-api.md
@@ -136,7 +136,7 @@ For more information go to, [Using Connect with Standard Accounts](https://strip
 
     4. Define the monetization implementation in WSO2 API Manager.
 
-        If you are using the [wso2-am-stripe-plugin](https://github.com/wso2-extensions/wso2-am-stripe-plugin), add the full qualified class name of the monetization implementation in the `<API-M_HOME>/repository/conf/deployment.toml` file as follows.
+        If you are using the [wso2-am-stripe-plugin](https://github.com/wso2-extensions/wso2-am-stripe-plugin), add the fully qualified class name of the monetization implementation in the `<API-M_HOME>/repository/conf/deployment.toml` file as follows.
 
         ```toml
         [apim.monetization]


### PR DESCRIPTION
Fix adjective error in Monetizing an API page

## Purpose
Fix a grammatical error in the monetization implementation configuration section.

## Goals
- Fix adjective error: "full qualified" → "fully qualified"

## Approach
Direct single-word correction with no functional changes.

## Documentation
N/A - This PR itself is a documentation fix.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
- Followed secure coding standards: N/A (documentation only)
- Ran FindSecurityBugs plugin: N/A (documentation only)
- Confirmed no keys, passwords, or secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
N/A

## Learning
N/A