### PR TITLE
[4.6.0] Fix disableSendingMultipartPartCharset config default value

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -12993,10 +12993,10 @@ preserveMultipartPartContentTransferEncoding = true
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>false</code></span>
+                                            <span class="param-default-value">Default: <code>true</code></span>
                                         </div>
                                         <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">
@@ -13017,7 +13017,7 @@ preserveMultipartPartContentTransferEncoding = true
                                             <span class="param-default-value">Default: <code>false</code></span>
                                         </div>
                                         <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>true false</code></span>
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -4845,8 +4845,8 @@
                             "name": "disableSendingMultipartPartCharset",
                             "type": "boolean",
                             "required": false,
-                            "default": "false",
-                            "possible": "true false",
+                            "default": "true",
+                            "possible": "true, false",
                             "description": "Defines whether the charset parameter in the Content-Type header should be preserved in each part of multipart form data."
                         },
                         {
@@ -4854,7 +4854,7 @@
                             "type": "boolean",
                             "required": false,
                             "default": "false",
-                            "possible": "true false",
+                            "possible": "true, false",
                             "description": "Defines whether the Content-Transfer-Encoding header should be preserved in each part of multipart form data."
                         }
                     ]


### PR DESCRIPTION
Set the default value of `disableSendingMultipartPartCharset` to `true`.