### PR TITLE
Fix: Update hardcoded Mocky URL to placeholder

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -118,7 +118,7 @@ Follow the instructions below to create, deploy and publish an API via the Publi
      <tr> 
      <th>Endpoint
      </th>
-     <td><code>https://run.mocky.io/v3/e42a76f0-95f3-4759-b658-dcc2b0c8bacd</code>
+     <td><code>https://run.mocky.io/v3/<YOUR_GENERATED_MOCKY_ID></code>
      </td>
      </tr>
      </table>

--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -118,7 +118,7 @@ Follow the instructions below to create, deploy and publish an API via the Publi
      <tr> 
      <th>Endpoint
      </th>
-     <td><code>https://run.mocky.io/v3/<YOUR_GENERATED_MOCKY_ID></code>
+     <td><code>https://run.mocky.io/v3/&lt;YOUR_GENERATED_MOCKY_ID&gt;</code>
      </td>
      </tr>
      </table>


### PR DESCRIPTION
Replaced the static, hardcoded Mocky endpoint with a descriptive placeholder in the Quick Start Guide to improve clarity for users.

## Purpose
The Quick Start Guide currently provides a hardcoded, static Mocky URL. If a user utilizes the hardcoded link, it removes the purpose of the step where they generate their own mock service.

## Goals
Replace the static endpoint with a clear, descriptive placeholder (&lt;YOUR_GENERATED_MOCKY_ID&gt;) so users know to use their own unique generated resource.

## Approach
Updated en/docs/get-started/api-manager-quick-start-guide.md to use the placeholder format inside the REST API configuration table.

## Learning
Learned the end-to-end open-source contribution workflow, including forking repositories, utilizing the GitHub web-based editor and submitting pull requests. Gained experience in navigating and auditing documentation to resolve configuration discrepancies.