### PR TITLE
[4.4.0] fix: Add guidance for searching API names with spaces and hyphens

### DIFF
--- a/en/docs/consume/discover-apis/search.md
+++ b/en/docs/consume/discover-apis/search.md
@@ -27,7 +27,7 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
 <tr class="odd">
 <td>By the API's name</td>
 <td><p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
-<p>Name is the API name.</p><p>Name is the API name.</p><p>For API names containing spaces or hyphens, enclose the API name in double quotes. For example, <strong>name:"Pizza Shack API"</strong> or <strong>name:"Pizza-Shack-API"</strong>.</p></td>
+<p>Name is the API name.</p><p>For API names containing spaces or hyphens, enclose the API name in double quotes. For example, <strong>name:"Pizza Shack API"</strong> or <strong>name:"Pizza-Shack-API"</strong>.</p></td>
 </tr>
 <tr class="even">
 <td>By the API provider</td>

--- a/en/docs/consume/discover-apis/search.md
+++ b/en/docs/consume/discover-apis/search.md
@@ -27,7 +27,7 @@ You can search for APIs in the API Publisher or Developer Portal in the followin
 <tr class="odd">
 <td>By the API's name</td>
 <td><p><strong>name:xxxx</strong> . For example, name:PizzaShackAPI</p>
-<p>Name is the API name.</p></td>
+<p>Name is the API name.</p><p>Name is the API name.</p><p>For API names containing spaces or hyphens, enclose the API name in double quotes. For example, <strong>name:"Pizza Shack API"</strong> or <strong>name:"Pizza-Shack-API"</strong>.</p></td>
 </tr>
 <tr class="even">
 <td>By the API provider</td>


### PR DESCRIPTION
## Purpose
Improves the Developer Portal search documentation to explain how to search
for APIs whose names contain spaces or hyphens. The current docs show only
`name:PizzaShackAPI` and give no guidance for complex names, which fail a
plain `name:` search unless quoted.

Resolves #11401 

## Goals
Add a note under the "By the API's name" search clause explaining that API
names containing spaces or hyphens must be enclosed in double quotes.

## Approach
Added a paragraph to the "By the API's name" row of the search clause table
in the Developer Portal search page, with examples for both space- and
hyphen-separated names (`name:"Pizza Shack API"` and `name:"Pizza-Shack-API"`).
Documentation-only change; no UI or code impact.

## User stories
N/A

## Release note
Documented how to search for APIs with names containing spaces or hyphens
using double quotes in the Developer Portal search.

## Documentation
This PR *is* the documentation change.
Affected page: https://apim.docs.wso2.com/en/4.4.0/consume/discover-apis/search/

## Training
N/A

## Certification
N/A since documentation clarification only; no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: N/A since documentation only change.
- Integration tests: N/A since documentation-only change.

## Security checks
- Followed secure coding standards: N/A since documentation only change.
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
PRs for the same fix on other release branches: 4.3.0, 4.5.0, 4.6.0, 4.7.0, Master (already fixed).

## Migrations (if applicable)
N/A

## Test environment
Verified locally by building the docs site with `mkdocs serve` and confirming
the new note renders correctly on the search page.
 
## Learning
N/A