### PR TITLE
Fix: remove duplicate 'the' in customizations guide

### DIFF
--- a/en/theme/material/customizations.md
+++ b/en/theme/material/customizations.md
@@ -150,7 +150,7 @@ theme/material/assets/stylesheets/application.*.css
 theme/material/base.html
 ```
 
-5. Copy the the new files back to your `docs-apim` clone from the `mkdocs-material` clone you built at step 3.
+5. Copy the new files back to your `docs-apim` clone from the `mkdocs-material` clone you built at step 3.
 
 ```
 material/assets/javascripts/application.*.js


### PR DESCRIPTION
Corrected a minor grammatical typographical error in the customizations guide to improve documentation flow and professionalism for users.

## Purpose
The documentation page contains a minor double-word typo ("the the") that breaks the reading flow for developers setting up portal customizations.

## Goals
Remove the repetitive word layout so the sentence structure is clean, accurate and professional.

## Approach
Updated line item 5 in en/theme/material/customizations.md to remove the duplicate word.

## Documentation
This PR addresses the documentation itself. No further doc impact.

## Learning
Expanded my experience navigating specific theme customization segments within large documentation repositories and maintaining accurate commit descriptions.