### PR TITLE
Fix [apim.event_hub] password guidance for special characters

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/maintaining-logins-and-passwords.md
@@ -33,19 +33,24 @@ Follow the instructions below to change the default admin password:
         Add the following configuration.
 
     Therefore, if you have special characters, add the following configurations.
-    If you have special characters, be mindful to wrap values with CDATA tag in super_admin configurations and to encode values in the `apim.throttling.jms` and `apim.event_hub` configurations.  
+    Wrap values with CDATA in the `super_admin` and `apim.event_hub` configurations, and URL-encode values in the `apim.event_hub.jms` and `apim.throttling.jms` configurations.
+
     ``` toml
     [super_admin]
     username = "your-name"
-    password = "<![CDATA[your-password]]>" 
-    
-    [apim.throttling.jms]
-    username = "your-name"
-    password = "your-encoded-password"
+    password = "<![CDATA[your-password]]>"
 
     [apim.event_hub]
     username = "your-name"
-    password = "your-encoded-password"        
+    password = "<![CDATA[your-password]]>"
+
+    [apim.event_hub.jms]
+    username = "your-name"
+    password = "your-url-encoded-password"
+
+    [apim.throttling.jms]
+    username = "your-name"
+    password = "your-url-encoded-password"
     ```
 
     ??? info "sample deployment.toml configs"
@@ -53,12 +58,16 @@ Follow the instructions below to change the default admin password:
         [super_admin]
         username = "foo_admin"
         password = "<![CDATA[~^&*#`43d:3;]]>"
-        
-        [apim.throttling.jms]
+
+        [apim.event_hub]
+        username = "foo_admin"
+        password = "<![CDATA[~^&*#`43d:3;]]>"
+
+        [apim.event_hub.jms]
         username = "foo_admin"
         password = "~%5E%26*%23%6043d%3A3%3B"
 
-        [apim.event_hub]
+        [apim.throttling.jms]
         username = "foo_admin"
         password = "~%5E%26*%23%6043d%3A3%3B"
         ```


### PR DESCRIPTION
## Summary

Follow-up to #10534, which is incomplete. The previous change instructed users to URL-encode the password under `[apim.event_hub].password`, but this value is used directly as a plain-text credential for the Event Hub REST endpoints — URL-encoding it causes authentication failures at runtime.

The correct approach is to keep `[apim.event_hub].password` as CDATA-wrapped plain text (same as `[super_admin].password`) and add a separate `[apim.event_hub.jms]` section with the URL-encoded password, which is used only for the AMQP broker URL.

This PR:

- Updates the special characters guidance in `maintaining-logins-and-passwords.md` to correctly cover all four sections: `[super_admin]` (CDATA), `[apim.event_hub]` (CDATA), `[apim.event_hub.jms]` (URL-encoded), and `[apim.throttling.jms]` (URL-encoded).
- Updates the `??? info "sample deployment.toml configs"` block to match.