### PR TITLE
[4.7.0] fix: singular/plural inconsistency in Consume APIs overview

### DIFF
--- a/en/docs/api-developer-portal/consume-api-overview.md
+++ b/en/docs/api-developer-portal/consume-api-overview.md
@@ -22,7 +22,7 @@ When APIs are created and published through the **Publisher**, they become avail
 
 ### Subscribe to APIs
 
-Before using an API, the developer must first subscribe to the APIs and obtain the required authentication keys through an **application**.
+Before using an API, the developer must first subscribe to the API and obtain the required authentication keys through an **application**.
 
 **Applications**
 


### PR DESCRIPTION
## Purpose
Corrects a noun-number disagreement in the first sentence under the
"Subscribe to APIs" heading on the Consume APIs Overview page. The sentence
switches from singular ("an API") to plural ("the APIs") within the same
clause, which reads awkwardly.

Resolves wso2/api-manager#5080

## Goals
Fix the singular/plural inconsistency so the sentence reads consistently in
the singular.

## Approach
Changed "subscribe to the APIs" to "subscribe to the API" in the first sentence under the "Subscribe to APIs" heading.

## User stories
N/A

## Release note
Fixed a grammatical inconsistency in the Consume APIs Overview documentation.

## Documentation
N/A

## Training
N/A

## Certification
N/A since documentation grammar correction only; no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: N/A since documentation-only change.
- Integration tests: N/A since documentation-only change.

## Security checks
- Followed secure coding standards: N/A since documentation-only change.
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified locally by building the docs site with `mkdocs serve` and confirming the corrected sentence renders correctly on the Consume APIs Overview page.
 
## Learning
N/A