### PR TITLE
Fix: Remove admin_ prefix from Directory Structure page title in navi…

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -752,7 +752,7 @@ nav:
         - Guides:
             - Message Flow in the API Manager Gateway: reference/guides/message-flow-in-the-api-manager-gateway.md
             - Accessing API Manager by Multiple Devices Simultaneously: reference/guides/accessing-api-manager-by-multiple-devices-simultaneously.md
-            - admin_Directory Structure of WSO2 Products: reference/guides/directory-structure-of-wso2-products.md
+            - Directory Structure of WSO2 Products: reference/guides/directory-structure-of-wso2-products.md
         - Common Runtime and Configuration Artifacts: reference/common-runtime-and-configuration-artifacts.md
         - Default Product Ports: reference/default-product-ports.md
         - Product Compatibility: reference/product-compatibility.md


### PR DESCRIPTION
…gation

## Purpose
> Removes the admin_ prefix from the Directory Structure page title in the navigation menu of mkdocs.yml, which was causing the page to appear incorrectly in the public documentation.

## Goals
> Fix the page title to display correctly as "Directory Structure of WSO2 Products" instead of "admin_Directory Structure of WSO2 Products"

## Approach
> Removed the admin_ prefix from the navigation entry in mkdocs.yml

## User stories
> N/A

## Release note
> Fixed incorrect page title in navigation menu

## Documentation
> N/A - this is a documentation fix itself

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A - documentation change only



## Security checks
> N/A - documentation change only

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A - documentation change only
 
## Learning
> N/A