### PR TITLE
Fix typo in HashiCorp Vault documentation link

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -119,7 +119,7 @@ nav:
                             - Work with Encrypted Passwords: install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
                             - Set Up ReCaptcha: install-and-setup/setup/security/logins-and-passwords/setting-up-recaptcha.md
                             - Configure reCaptcha for Single Sign On : install-and-setup/setup/security/logins-and-passwords/configuring-recaptcha-for-single-sign-on.md
-                            - Integrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+                            - Integrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/hashicorp-vault-extension.md
                     - Configure Keystores:
                         - Configure Keystores in API Manager: install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
                         - Keystore Basics:


### PR DESCRIPTION
## Purpose
> Corrects a typo in the mkdocs.yml navigation file where the HashiCorp Vault file reference was spelled as `harshicrop-vault-extension.md` instead of `hashicorp-vault-extension.md`.

## Goals
> Fix the incorrect file reference so the navigation points to the correctly named file.

## Approach
> Updated the file reference in `en/mkdocs.yml` from `harshicrop-vault-extension.md` to `hashicorp-vault-extension.md`.

## User stories
> N/A

## Release note
> Fixed typo in HashiCorp Vault documentation file reference in navigation.

## Documentation
> N/A - this is a documentation fix itself.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
- Unit tests
  > N/A - documentation change only
- Integration tests
  > N/A - documentation change only

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A - documentation change only
- Confirmed no secrets committed: yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations
> N/A

## Test environment
> N/A - documentation change only

## Learning
> N/A