### PR TITLE
[3.2.0] Remove opensaml hostname verifcation property

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -129,13 +129,12 @@ If you need to set additional system properties when the server starts, you can 
   start the server. To avoid having to modify the script each time you upgrade, the best approach is to create your own startup script that wraps the WSO2 startup script and adds the properties you want to set, rather than editing the WSO2 startup script directly.
 
     !!! note
-        Be sure to set the system properties `org.opensaml.httpclient.https.disableHostnameVerification` and `httpclient.hostnameVerifier`
+        Be sure to set the system property `httpclient.hostnameVerifier`
          in the the product's startup script file to as follows. This setting will enable hostname verification of 
          HTTP requests and responses in the Carbon server, and thereby avoid security issues in production environments. 
          For more information, see [Enabling HostName Verification]({{base_path}}/administer/product-security/enabling-hostname-verification/).
 
 ```  
-    -Dorg.opensaml.httpclient.https.disableHostnameVerification=false \
     -Dhttpclient.hostnameVerifier=Strict \
 ```
 

--- a/en/docs/install-and-setup/setup/security/enabling-hostname-verification.md
+++ b/en/docs/install-and-setup/setup/security/enabling-hostname-verification.md
@@ -9,10 +9,9 @@ If hostname verification is disabled for your product, the hostnames (that are a
 
 ### Configuring hostname verification
 
-The hostname verification is **disabled** by default. This is done using the `org.opensaml.httpclient.https.disableHostnameVerification` and `httpclient.hostnameVerifier` properties in the product's startup script ( `wso2server.sh` for Linux and `wso2server.bat` for Windows) as shown below. The product startup script is stored in the `<PRODUCT_HOME>/bin` directory. This property will be effective during server startup.
+The hostname verification is **disabled** by default. This is done using the `httpclient.hostnameVerifier` property in the product's startup script ( `wso2server.sh` for Linux and `wso2server.bat` for Windows) as shown below. The product startup script is stored in the `<PRODUCT_HOME>/bin` directory. This property will be effective during server startup.
 
 ```  
-    -Dorg.opensaml.httpclient.https.disableHostnameVerification=true \
     -Dhttpclient.hostnameVerifier=AllowAll \
 ```
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the recommended way to configure hostname verification for production deployments. The main change is the removal of references to the deprecated `org.opensaml.httpclient.https.disableHostnameVerification` system property, ensuring that only the supported `httpclient.hostnameVerifier` property is documented for enabling or disabling hostname verification.

**Documentation updates for hostname verification:**

* Removed references to the `org.opensaml.httpclient.https.disableHostnameVerification` property from the production deployment guidelines and hostname verification documentation, leaving only `httpclient.hostnameVerifier` as the recommended property to set. [[1]](diffhunk://#diff-6debf8615b39f2f0bf6ee4be356e652749b10a7e490a39a0a645a1c85c4f3001L132-L138) [[2]](diffhunk://#diff-1f462fda83704279a9da036218333a52336f434dc45569e904fb454545a8dce9L12-L15)
* Updated code examples and explanatory text to reflect the removal of the deprecated property, improving clarity for users configuring secure deployments. [[1]](diffhunk://#diff-6debf8615b39f2f0bf6ee4be356e652749b10a7e490a39a0a645a1c85c4f3001L132-L138) [[2]](diffhunk://#diff-1f462fda83704279a9da036218333a52336f434dc45569e904fb454545a8dce9L12-L15)