### PR TITLE
Add divider option to Get Started section

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -888,7 +888,7 @@ extra:
     - title: Get Started
       options:
         - verticle-line
-        - no-collapsible
+        - divider
     - title: Install & Setup
       options:
         - verticle-line


### PR DESCRIPTION
The "Get Started" section in the left sidebar was missing the dropdown arrow icon, unlike other expandable sections such as "Install & Setup" and "Tutorials".

This fix adds the missing indicator so the sidebar is visually consistent.

Fixes #5109