### PR TITLE
Fix typo: xs:enumaration -> xs:enumeration in SOAP-to-REST docs

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
+++ b/en/docs/api-design-manage/design/create-api/create-rest-api/generate-rest-api-from-soap-backend.md
@@ -21,7 +21,7 @@
     - **<xs:attributeGroup\>**
     - **<xs:any\>**
     - **<xs:anyAttribute\>**
-    - **<xs:enumaration\>**
+    - **<xs:enumeration\>**
     - **<xs:alternative\>**
     - **<xs:assert\>**
     - **<xs:key\>**


### PR DESCRIPTION
## Purpose
The supported XSD elements list in the SOAP-to-REST page lists the element as "xs:enumaration", but the correct XSD element name is "xs:enumeration". No related issue exists.

## Goals
Correct the misspelled XSD element name so the list of supported elements accurately reflects the real XML Schema element.

## Approach
Single-character fix in the Markdown documentation. No UI text or product behavior is affected.

## User stories
N/A - documentation typo fix.

## Release note
Fixed a typo in the SOAP-to-REST supported XSD elements list.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - documentation-only change.
 - Ran FindSecurityBugs plugin and verified report? N/A - documentation-only change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A