### PR TITLE
[DOCS 4.5.0] Add doc folder structure warning for API and API Product import

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -285,6 +285,9 @@
     ├── Definitions
     │   └── swagger.yaml
     ├── Docs
+    │   └── <DocName>
+    │       ├── document.yaml
+    │       └── <doc-file>
     ├── Endpoint-certificates
     ├── Image
     └── Policies
@@ -324,7 +327,12 @@
         </tr>
         <tr class="odd">
         <td>Docs</td>
-        <td>Contains the documents.</td>
+        <td>Contains the documents attached to the API. Each document must have its own folder named after the document, containing a <code>document.yaml</code> file with the document metadata and any associated files.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>Each documentation file must be placed inside its corresponding <code>Docs/&lt;DocName&gt;/</code> folder, alongside the <code>document.yaml</code> file. If a file is not found in that folder, the import process will silently skip that document without failing the import. The overall API import will still succeed, but the affected document will be missing from the imported API.</p>
+            </div>
+        </td>
         </tr>
         <tr class="even">
         <td>Endpoint-certificates</td>

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -210,6 +210,10 @@ data:
             <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
             <br> Similarly if you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>If a documentation file is not found in the individual folder described above, the import process will silently skip that document without failing the import. The overall API Product import will still succeed, but the affected document will be missing from the imported API Product. To avoid this, ensure that each file referenced in <code>document.yaml</code> is placed in the same individual folder alongside the <code>document.yaml</code> file before importing.</p>
+            </div>
             </td>
         </tr>
         <tr class="even">

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-apis-to-different-environments.md
@@ -224,6 +224,10 @@ data:
             <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
             <br> Similarly if the you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>If a documentation file is not found in the individual folder described above, the import process will silently skip that document without failing the import. The overall API import will still succeed, but the affected document will be missing from the imported API. To avoid this, ensure that each file referenced in <code>document.yaml</code> is placed in the same individual folder alongside the <code>document.yaml</code> file before importing.</p>
+            </div>
             </td>
         </tr>
         <tr class="odd">


### PR DESCRIPTION
## Summary

- Updated the `Docs/` folder structure diagram in the API import (dev-first approach) doc to show the expected `<DocName>/document.yaml` and `<doc-file>` layout.
- Added a warning note clarifying that each documentation file must be placed inside its corresponding `Docs/<DocName>/` folder alongside `document.yaml`, or it will be silently skipped during import without failing the overall import.
- Applied the same warning to the API migration and API Product migration docs for consistency.

## Screenshots

**1. Docs folder structure update — importing-apis-via-dev-first-approach**

<img width="864" height="708" alt="image" src="https://github.com/user-attachments/assets/7b999652-101b-462a-9028-33ac240f0a0b" />

---

**2. Warning note — migrating-apis-to-different-environments**

<img width="893" height="626" alt="image" src="https://github.com/user-attachments/assets/20b2423e-1b11-4b18-8e16-4e6b950d63db" />


---

**3. Warning note — migrating-api-products-to-different-environments**

<img width="894" height="571" alt="image" src="https://github.com/user-attachments/assets/bbf18c99-adf7-43ce-82dd-c9a5b3bf1f4a" />

---

Related PR
- https://github.com/wso2/carbon-apimgt/pull/13762