### PR TITLE
[DOCS 4.7.0] Add doc folder structure warning for API, MCP and API Product import

### DIFF
--- a/en/docs/apiops/cli/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/apiops/cli/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -285,6 +285,9 @@
     ├── Definitions
     │   └── swagger.yaml
     ├── Docs
+    │   └── <DocName>
+    │       ├── document.yaml
+    │       └── <doc-file>
     ├── Endpoint-certificates
     ├── Image
     └── Policies
@@ -324,7 +327,12 @@
         </tr>
         <tr class="odd">
         <td>Docs</td>
-        <td>Contains the documents.</td>
+        <td>Contains the documents attached to the API. Each document must have its own folder named after the document, containing a <code>document.yaml</code> file with the document metadata and any associated files.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>Each documentation file must be placed inside its corresponding <code>Docs/&lt;DocName&gt;/</code> folder, alongside the <code>document.yaml</code> file. If a file is not found in that folder, the import process will silently skip that document without failing the import. The overall API import will still succeed, but the affected document will be missing from the imported API.</p>
+            </div>
+        </td>
         </tr>
         <tr class="even">
         <td>Endpoint-certificates</td>

--- a/en/docs/apiops/cli/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/apiops/cli/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -210,6 +210,10 @@ data:
             <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
             <br> Similarly if you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>If a documentation file is not found in the individual folder described above, the import process will silently skip that document without failing the import. The overall API Product import will still succeed, but the affected document will be missing from the imported API Product. To avoid this, ensure that each file referenced in <code>document.yaml</code> is placed in the same individual folder alongside the <code>document.yaml</code> file before importing.</p>
+            </div>
             </td>
         </tr>
         <tr class="even">

--- a/en/docs/apiops/cli/managing-apis-api-products/migrating-apis-to-different-environments.md
+++ b/en/docs/apiops/cli/managing-apis-api-products/migrating-apis-to-different-environments.md
@@ -224,6 +224,10 @@ data:
             <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
             <br> Similarly if the you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>If a documentation file is not found in the individual folder described above, the import process will silently skip that document without failing the import. The overall API import will still succeed, but the affected document will be missing from the imported API. To avoid this, ensure that each file referenced in <code>document.yaml</code> is placed in the same individual folder alongside the <code>document.yaml</code> file before importing.</p>
+            </div>
             </td>
         </tr>
         <tr class="odd">

--- a/en/docs/apiops/cli/managing-mcp-servers/migrating-mcp-servers-to-different-environments.md
+++ b/en/docs/apiops/cli/managing-mcp-servers/migrating-mcp-servers-to-different-environments.md
@@ -197,6 +197,10 @@ data:
             <br>If the you have attached an <b>INLINE</b> document, the <code>sourceType</code> will be changed to <b>INLINE</b> and the field named <code>fileName</code> will not be available. The inline content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc2</code>).
             <br> Similarly if you have attached a <b>MARKDOWN</b> document, the <code>sourceType</code> will be changed to <b>MARKDOWN</b> and there will not be a field named <code>fileName</code>. The markdown content of that particular document will be included in the same individual document directory named by the document name (E.g., <code>Doc3</code>).
             <br> If the document is just a URL, the <code>sourceType</code> will be changed to <b>URL</b> and a field named <code>sourceURL</code> will be there which will consist the URL of the document.
+            <div class="admonition warning">
+            <p class="admonition-title">Warning</p>
+            <p>If a documentation file is not found in the individual folder described above, the import process will silently skip that document without failing the import. The overall MCP Server import will still succeed, but the affected document will be missing from the imported MCP Server. To avoid this, ensure that each file referenced in <code>document.yaml</code> is placed in the same individual folder alongside the <code>document.yaml</code> file before importing.</p>
+            </div>
             </td>
         </tr>
         <tr class="odd">


### PR DESCRIPTION
## Summary

- Updated the `Docs/` folder structure diagram in the API import (dev-first approach) doc to show the expected `<DocName>/document.yaml` and `<doc-file>` layout.
- Added a warning note clarifying that each documentation file must be placed inside its corresponding `Docs/<DocName>/` folder alongside `document.yaml`, or it will be silently skipped during import without failing the overall import.
- Applied the same warning to the API migration and API Product migration docs for consistency.
- Added MCP Server project folder structure section to the MCP Server importing doc with the same Docs warning.
- Added the silent-skip warning to the MCP Server migration doc.

## Screenshots

**1. Docs folder structure update — importing-apis-via-dev-first-approach**

<img width="602" height="710" alt="image" src="https://github.com/user-attachments/assets/27bf8930-4218-4410-aa51-c6652a70197d" />

---

**2. Warning note — migrating-apis-to-different-environments**

<img width="630" height="714" alt="image" src="https://github.com/user-attachments/assets/dff46c0e-f13e-4d56-9a8e-7880b3680fdd" />

---

**3. Warning note — migrating-api-products-to-different-environments**

<img width="630" height="714" alt="image" src="https://github.com/user-attachments/assets/2ef289a4-b3ec-4026-9cf3-fcb95a7f851c" />

---

**4. Warning note — migrating-mcp-servers-to-different-environments**

<img width="638" height="733" alt="image" src="https://github.com/user-attachments/assets/292d2e1a-1750-4a84-b905-acacd2debf38" />

---

Related PR
- https://github.com/wso2/carbon-apimgt/pull/13762