### PR TITLE
Generalize WSO2 Identity Server 7.x compatibility in product compatibility matrix

### DIFF
--- a/en/docs/includes/compatibility-matrix.md
+++ b/en/docs/includes/compatibility-matrix.md
@@ -35,7 +35,7 @@
         </tr>
         <tr>
             <td colspan="2">WSO2 Identity Server</td>
-            <td>6.1.0, 7.0.0, 7.1.0, 7.2.0</td>
+            <td>6.1.0, 7.x</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Purpose

Resolves #11535.

The compatibility matrix currently lists individual WSO2 Identity Server 7.x versions. This can quickly become outdated as newer 7.x versions are released.

## Goals

Generalize the compatibility entry by replacing the specific versions with `7.x`.

## Approach

Updated the compatibility matrix by changing:

- `6.1.0, 7.0.0, 7.1.0, 7.2.0`

to

- `6.1.0, 7.x`

This keeps the documentation easier to maintain while matching the intended compatibility.

## Documentation

Updated `en/docs/includes/compatibility-matrix.md`.