### PR TITLE
[4.6.0] Add AWS Lambda proxy response mapping and SDK retry configuration docs

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -17487,7 +17487,13 @@ same_site_cookies = "lax"
                 <label class="tab-selector" for="_tab_118"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
-<pre><code class="toml">[apim.aws_lambda.http_client]
+<pre><code class="toml">[apim.aws_lambda]
+enable_proxy_response_mapping = true
+
+[apim.aws_lambda.sdk]
+retry_max_attempts = 2
+
+[apim.aws_lambda.http_client]
 max_connections = 50
 connection_timeout = 10
 socket_timeout = 30
@@ -17498,6 +17504,64 @@ connection_acquisition_timeout = 60
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
+                            <code>[apim.aws_lambda]</code>
+                            
+                            <p>
+                                Configures the AWS Lambda backend integration for WSO2 API Manager.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_proxy_response_mapping</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enables proxy response mapping mode for the AWS Lambda mediator. When enabled, Lambda functions must return payloads in the AWS API Gateway Lambda proxy integration response envelope format (containing statusCode, headers, multiValueHeaders, body, and isBase64Encoded fields). The mediator maps these fields to the HTTP response, allowing Lambda functions to control the response status code, headers, and content type. Supported content types for body routing are application/json, text/plain, and application/xml. Note that this configuration is available in wso2am-4.6.0 and wso2am-universal-gw-4.6.0 starting from update level 24.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div><div class="config-wrap">
+                            <code>[apim.aws_lambda.sdk]</code>
+                            
+                            <p>
+                                Configures the AWS SDK behavior used by the AWS Lambda mediator.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>retry_max_attempts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>4</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The total number of attempts for AWS Lambda invocations, including the initial request. Must be an integer greater than or equal to 1. If this configuration is not provided, the AWS SDK default retry behavior will be used. Note that this configuration is available in wso2am-4.6.0 and wso2am-universal-gw-4.6.0 starting from update level 28.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div><div class="config-wrap">
                             <code>[apim.aws_lambda.http_client]</code>
                             
                             <p>

--- a/en/docs/tutorials/create-and-publish-awslambda-api.md
+++ b/en/docs/tutorials/create-and-publish-awslambda-api.md
@@ -219,3 +219,38 @@ You have successfully published the AWS Lambda API. Try invoking the Lambda API 
     </table>
 
     These configurations serve as the global settings for all AWS Lambda endpoints in the Gateway. However, please note that each API resource initializes its own independent **AWS Lambda client**. Therefore, the values defined here (such as <code>max_connections</code>) are applied per API resource, not as a server-wide aggregate limit.
+
+!!! note "Configure Proxy Response Mapping"
+        This capability is supported only from the U2 levels listed below in APIM products
+        
+        - wso2am-4.6.0 - U2 level 24
+        - wso2am-universal-gw-4.6.0 - U2 level 24
+
+    By default, WSO2 API Manager forwards the raw Lambda function response payload directly to clients as JSON with an HTTP 200 status code. To allow Lambda functions to control the response status code, headers, and content type, you can enable proxy response mapping.
+
+    When enabled, the API Manager parses the Lambda response as an [AWS API Gateway Lambda proxy integration response](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format) envelope and maps the `statusCode`, `headers`, `multiValueHeaders`, `body`, and `isBase64Encoded` fields to the HTTP response.
+
+    To enable proxy response mapping, add the following configuration to the <code>&lt;API-M_HOME&gt;/repository/conf/deployment.toml</code> file. For more information, see [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+    ```toml
+    [apim.aws_lambda]
+    enable_proxy_response_mapping = true
+    ```
+
+    !!! warning
+        When enabled, Lambda functions must return payloads in the proxy envelope format. Existing integrations are not affected unless this is explicitly enabled (default: `false`). Supported content types for body routing are `application/json`, `text/plain`, and `application/xml`.
+
+!!! note "Configure AWS SDK Retry Behavior"
+        This capability is supported only from the U2 levels listed below in APIM products
+        
+        - wso2am-4.6.0 - U2 level 28
+        - wso2am-universal-gw-4.6.0 - U2 level 28
+
+    You can configure the maximum number of retry attempts for AWS Lambda invocations. When not configured, the AWS SDK default retry behavior is preserved.
+
+    To configure the retry behavior, add the following configuration to the <code>&lt;API-M_HOME&gt;/repository/conf/deployment.toml</code> file. For more information, see [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+    ```toml
+    [apim.aws_lambda.sdk]
+    retry_max_attempts = 2
+    ```

--- a/en/tools/config-catalog-generator/data/apim.aws_lambda.toml
+++ b/en/tools/config-catalog-generator/data/apim.aws_lambda.toml
@@ -1,3 +1,9 @@
+[apim.aws_lambda]
+enable_proxy_response_mapping = true
+
+[apim.aws_lambda.sdk]
+retry_max_attempts = 2
+
 [apim.aws_lambda.http_client]
 max_connections = 50
 connection_timeout = 10

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6641,6 +6641,36 @@
             "title": "API-M AWS Lambda Configurations",
             "options": [
                 {
+                    "name": "apim.aws_lambda",
+                    "required": false,
+                    "description": "Configures the AWS Lambda backend integration for WSO2 API Manager.",
+                    "params": [
+                        {
+                            "name": "enable_proxy_response_mapping",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Enables proxy response mapping mode for the AWS Lambda mediator. When enabled, Lambda functions must return payloads in the AWS API Gateway Lambda proxy integration response envelope format (containing statusCode, headers, multiValueHeaders, body, and isBase64Encoded fields). The mediator maps these fields to the HTTP response, allowing Lambda functions to control the response status code, headers, and content type. Supported content types for body routing are application/json, text/plain, and application/xml. Note that this configuration is available in wso2am-4.6.0 and wso2am-universal-gw-4.6.0 starting from update level 24."
+                        }
+                    ]
+                },
+                {
+                    "name": "apim.aws_lambda.sdk",
+                    "required": false,
+                    "description": "Configures the AWS SDK behavior used by the AWS Lambda mediator.",
+                    "params": [
+                        {
+                            "name": "retry_max_attempts",
+                            "type": "integer",
+                            "required": false,
+                            "default": "4",
+                            "possible": "",
+                            "description": "The total number of attempts for AWS Lambda invocations, including the initial request. Must be an integer greater than or equal to 1. If this configuration is not provided, the AWS SDK default retry behavior will be used. Note that this configuration is available in wso2am-4.6.0 and wso2am-universal-gw-4.6.0 starting from update level 28."
+                        }
+                    ]
+                },
+                {
                     "name": "apim.aws_lambda.http_client",
                     "required": false,
                     "description": " Configurations to tune the underlying HTTP connection pool settings used by each AWS Lambda client instance, to improve performance under high load.",
@@ -6680,7 +6710,7 @@
                     ]
                 }
             ],
-            "exampleFile": "apim.aws_lambda.http_client.toml"
+            "exampleFile": "apim.aws_lambda.toml"
         },
         {
           "title": "Synapse Properties",


### PR DESCRIPTION
## Summary

Documents two new AWS Lambda configuration options introduced in WSO2 API Manager 4.6.0.

**1. Proxy Response Mapping** (`enable_proxy_response_mapping`)

When enabled, the API Manager reads the Lambda response as an AWS API Gateway proxy integration envelope (`statusCode`, `headers`, `body`, etc.) and maps those fields to the HTTP response, allowing Lambda functions to control status codes, headers, and content type.

**2. SDK Retry Behavior** (`retry_max_attempts`) 

Configures the total number of AWS SDK invocation attempts (including the initial request). Defaults to `4`. Falls back to AWS SDK default behavior if not set.

- Configure Proxy Response Mapping: 
<img width="683" height="542" alt="image" src="https://github.com/user-attachments/assets/1fb0616a-23de-4ba8-9fff-1fb94f9c851f" />

- Configure AWS SDK Retry Behavior: <img width="667" height="320" alt="image" src="https://github.com/user-attachments/assets/51b49de5-f15b-4494-a3fc-6f56773057a0" />
- Config Catalog (API-M AWS Lambda Configurations section): 
<img width="684" height="762" alt="image" src="https://github.com/user-attachments/assets/0bff4948-bb03-4583-bc4e-1e0251619e4d" />
