### PR TITLE
Add AWS Lambda proxy response mapping and SDK retry configuration docs

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -17268,7 +17268,7 @@ same_site_cookies = "lax"
 
 
 
-## Synapse Properties
+## API-M AWS Lambda Configurations
 
 
 <div class="mb-config-catalog">
@@ -17278,6 +17278,96 @@ same_site_cookies = "lax"
             
             <input name="118" type="checkbox" id="_tab_118">
                 <label class="tab-selector" for="_tab_118"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[apim.aws_lambda]
+enable_proxy_response_mapping = true
+
+[apim.aws_lambda.sdk]
+retry_max_attempts = 2
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.aws_lambda]</code>
+                            
+                            <p>
+                                Configures the AWS Lambda backend integration for WSO2 API Manager.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable_proxy_response_mapping</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enables proxy response mapping mode for the AWS Lambda mediator. When enabled, Lambda functions must return payloads in the AWS API Gateway Lambda proxy integration response envelope format (containing statusCode, headers, multiValueHeaders, body, and isBase64Encoded fields). The mediator maps these fields to the HTTP response, allowing Lambda functions to control the response status code, headers, and content type. Supported content types for body routing are application/json, text/plain, and application/xml.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div><div class="config-wrap">
+                            <code>[apim.aws_lambda.sdk]</code>
+                            
+                            <p>
+                                Configures the AWS SDK behavior used by the AWS Lambda mediator.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>retry_max_attempts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>4</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The total number of attempts for AWS Lambda invocations, including the initial request. Must be an integer greater than or equal to 1. If this configuration is not provided, the AWS SDK default retry behavior will be used.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Synapse Properties
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="119" type="checkbox" id="_tab_119">
+                <label class="tab-selector" for="_tab_119"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[synapse_properties]
@@ -17357,8 +17447,8 @@ same_site_cookies = "lax"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="119" type="checkbox" id="_tab_119">
-                <label class="tab-selector" for="_tab_119"><i class="icon fa fa-code"></i></label>
+            <input name="120" type="checkbox" id="_tab_120">
+                <label class="tab-selector" for="_tab_120"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[dependency_properties]
@@ -17414,8 +17504,8 @@ same_site_cookies = "lax"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="120" type="checkbox" id="_tab_120">
-                <label class="tab-selector" for="_tab_120"><i class="icon fa fa-code"></i></label>
+            <input name="121" type="checkbox" id="_tab_121">
+                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[authentication.authenticator.oidc.parameters]
@@ -17473,8 +17563,8 @@ excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="121" type="checkbox" id="_tab_121">
-                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
+            <input name="122" type="checkbox" id="_tab_122">
+                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml"># API KEY CONFIGS
@@ -17651,8 +17741,8 @@ azure_umi_scope = "https://cognitiveservices.azure.com/.default"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="122" type="checkbox" id="_tab_122">
-                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
+            <input name="123" type="checkbox" id="_tab_123">
+                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.vector_db_provider]
@@ -17780,8 +17870,8 @@ ttl = 3600
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="123" type="checkbox" id="_tab_123">
-                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
+            <input name="124" type="checkbox" id="_tab_124">
+                <label class="tab-selector" for="_tab_124"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.azure_umi]

--- a/en/docs/tutorials/create-and-publish-awslambda-api.md
+++ b/en/docs/tutorials/create-and-publish-awslambda-api.md
@@ -146,3 +146,28 @@ When using AWS Lambda, you can execute your code without having to manage or pro
 2. Go to **Lifecycle** page and click on **PUBLISH** to publish the API to Developer Portal.
 
 You have successfully published the AWS Lambda API. Try invoking the Lambda API in the Developer Portal.
+
+!!! note "Configure Proxy Response Mapping"
+    By default, WSO2 API Manager forwards the raw Lambda function response payload directly to clients as JSON with an HTTP 200 status code. To allow Lambda functions to control the response status code, headers, and content type, you can enable proxy response mapping.
+
+    When enabled, the API Manager parses the Lambda response as an [AWS API Gateway Lambda proxy integration response](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format) envelope and maps the `statusCode`, `headers`, `multiValueHeaders`, `body`, and `isBase64Encoded` fields to the HTTP response.
+
+    To enable proxy response mapping, add the following configuration to the <code>&lt;API-M_HOME&gt;/repository/conf/deployment.toml</code> file. For more information, see [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+    ```toml
+    [apim.aws_lambda]
+    enable_proxy_response_mapping = true
+    ```
+
+    !!! warning
+        When enabled, Lambda functions must return payloads in the proxy envelope format. Existing integrations are not affected unless this is explicitly enabled (default: `false`). Supported content types for body routing are `application/json`, `text/plain`, and `application/xml`.
+
+!!! note "Configure AWS SDK Retry Behavior"
+    You can configure the maximum number of retry attempts for AWS Lambda invocations. When not configured, the AWS SDK default retry behavior is preserved.
+
+    To configure the retry behavior, add the following configuration to the <code>&lt;API-M_HOME&gt;/repository/conf/deployment.toml</code> file. For more information, see [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+    ```toml
+    [apim.aws_lambda.sdk]
+    retry_max_attempts = 2
+    ```

--- a/en/tools/config-catalog-generator/data/apim.aws_lambda.toml
+++ b/en/tools/config-catalog-generator/data/apim.aws_lambda.toml
@@ -1,0 +1,5 @@
+[apim.aws_lambda]
+enable_proxy_response_mapping = true
+
+[apim.aws_lambda.sdk]
+retry_max_attempts = 2

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6558,6 +6558,42 @@
             "exampleFile": "web_app.cookie_processor.toml"
         },
         {
+            "title": "API-M AWS Lambda Configurations",
+            "options": [
+                {
+                    "name": "apim.aws_lambda",
+                    "required": false,
+                    "description": "Configures the AWS Lambda backend integration for WSO2 API Manager.",
+                    "params": [
+                        {
+                            "name": "enable_proxy_response_mapping",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Enables proxy response mapping mode for the AWS Lambda mediator. When enabled, Lambda functions must return payloads in the AWS API Gateway Lambda proxy integration response envelope format (containing statusCode, headers, multiValueHeaders, body, and isBase64Encoded fields). The mediator maps these fields to the HTTP response, allowing Lambda functions to control the response status code, headers, and content type. Supported content types for body routing are application/json, text/plain, and application/xml."
+                        }
+                    ]
+                },
+                {
+                    "name": "apim.aws_lambda.sdk",
+                    "required": false,
+                    "description": "Configures the AWS SDK behavior used by the AWS Lambda mediator.",
+                    "params": [
+                        {
+                            "name": "retry_max_attempts",
+                            "type": "integer",
+                            "required": false,
+                            "default": "4",
+                            "possible": "",
+                            "description": "The total number of attempts for AWS Lambda invocations, including the initial request. Must be an integer greater than or equal to 1. If this configuration is not provided, the AWS SDK default retry behavior will be used."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "apim.aws_lambda.toml"
+        },
+        {
             "title": "Synapse Properties",
             "options": [
                 {


### PR DESCRIPTION
## Summary

Documents two new AWS Lambda configuration options introduced in WSO2 API Manager.

**1. Proxy Response Mapping** (`enable_proxy_response_mapping`) 

When enabled, the API Manager reads the Lambda response as an AWS API Gateway proxy integration envelope (`statusCode`, `headers`, `body`, etc.) and maps those fields to the HTTP response, allowing Lambda functions to control status codes, headers, and content type.

**2. SDK Retry Behavior** (`retry_max_attempts`)

Configures the total number of AWS SDK invocation attempts (including the initial request). Defaults to `4`. Falls back to AWS SDK default behavior if not set.

- Configure Proxy Response Mapping: 
<img width="663" height="411" alt="image" src="https://github.com/user-attachments/assets/c5a820e8-84e6-4a11-8577-389411a46088" />

- Configure AWS SDK Retry Behavior: 
<img width="664" height="203" alt="image" src="https://github.com/user-attachments/assets/5acd10ad-6bd7-4c26-ba9c-127de70cd402" />

- Config Catalog (API-M AWS Lambda Configurations section): 
<img width="830" height="674" alt="image" src="https://github.com/user-attachments/assets/c740351e-cc96-42f9-8bd3-fbefc2deafe1" />

## Related Issue
- https://github.com/wso2/api-manager/issues/4926
- https://github.com/wso2/api-manager/issues/5029