### PR TITLE
Generalize WSO2 IS 7.x version in compatibility matrix

### DIFF
--- a/en/docs/includes/compatibility-matrix.md
+++ b/en/docs/includes/compatibility-matrix.md
@@ -35,7 +35,7 @@
         </tr>
         <tr>
             <td colspan="2">WSO2 Identity Server</td>
-            <td>6.1.0, 7.0.0, 7.1.0, 7.2.0</td>
+            <td>6.1.0, 7.x</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Purpose
Resolves #11535

## Goals
Generalize the supported WSO2 Identity Server versions in the Product Compatibility matrix so it correctly encompasses newer 7.x releases (such as 7.3.0) without needing explicit minor version updates.

## Approach
Replaced the hardcoded specific versions (`6.1.0, 7.0.0, 7.1.0, 7.2.0`) with the generalized `6.1.0, 7.x` in `en/docs/includes/compatibility-matrix.md`.

## User stories
N/A

## Release note
Generalized WSO2 Identity Server versions to 7.x in the Product Compatibility matrix.

## Documentation
This PR is a documentation fix.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested locally.
 
## Learning
N/A