### PR TITLE
Document REST API token cache configuration

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -1991,6 +1991,83 @@ expiry_time = "900s"
 
 
 
+## REST API token cache
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="restapi_token" type="checkbox" id="_tab_restapi_token">
+                <label class="tab-selector" for="_tab_restapi_token"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[apim.cache.restapi_token]
+enable = true
+expiry_time = "300s"
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.cache.restapi_token]</code>
+                            <span class="badge-required">Required</span>
+                            <p>
+                                
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enable</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type boolean"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>TRUE</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Enable token caching at the Product REST APIs. Valid token information is stored in TokenCache and invalid tokens are stored in InvalidTokenCache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>expiry_time</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>300s</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Set the cache expiry time for the REST API token cache in seconds. The default value is 300s (5 minutes).</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
 ## Cache resource
 
 


### PR DESCRIPTION
## Purpose
Resolves #11398

## Goals
Document the configurations related to the new improvement in the cache layer for OAuth2 token validation in the REST API (introduced via PR #7342).

## Approach
Added a new `[apim.cache.restapi_token]` configuration block definition to `en/docs/reference/config-catalog.md`, detailing the `enable` and `expiry_time` parameters for the `TokenCache` and `InvalidTokenCache`.

## User stories
N/A

## Release note
Added documentation for the REST API token cache configuration (`apim.cache.restapi_token`).

## Documentation
This PR is a documentation fix.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Related to [carbon-apimgt#7342](https://github.com/wso2/carbon-apimgt/pull/7342)

## Migrations (if applicable)
N/A

## Test environment
Tested locally using `mkdocs serve`.
 
## Learning
N/A