### PR TITLE
Fix invalid admonition types and heading spacing issues

### DIFF
--- a/en/docs/administer/multitenancy/managing-tenants.md
+++ b/en/docs/administer/multitenancy/managing-tenants.md
@@ -1,7 +1,7 @@
 # Managing Tenants
 
 
-##Adding a new tenant
+## Adding a new tenant
 You can add a new tenant in the management console and then view it by following the procedure below. In order to add a new tenant, you should be logged in as a super user.
 
 1.  Click **Add New Tenant** in the **Configure** tab of the management console.

--- a/en/docs/ai-gateway/ai-guardrails/semantic-tool-filtering-guardrail.md
+++ b/en/docs/ai-gateway/ai-guardrails/semantic-tool-filtering-guardrail.md
@@ -57,7 +57,7 @@ Follow these steps to integrate the Semantic Tool Filtering policy into your AI 
 	embedding_endpoint = "https://api.mistral.ai/v1/embeddings"
 	embedding_model = "mistral-embed"
     ```
-	##Policy parameter configurations for text based and JSON formatted tools list.
+	## Policy parameter configurations for text based and JSON formatted tools list.
 	### Tools as JSON list
 
 	JSON formatted Tool List Policy parameters Configuration

--- a/en/docs/ai-gateway/mcp-gateway/invoke-a-mcp-server-using-playground.md
+++ b/en/docs/ai-gateway/mcp-gateway/invoke-a-mcp-server-using-playground.md
@@ -25,7 +25,7 @@ The Integrated MCP Playground is a visual testing interface in the Developer Por
 
 Follow the instructions below to use the MCP Playground to test a MCP Server:
 
-!!! prerequisite
+!!! info "Prerequisites"
     - You need to have an application subscribed to the MCP Server. For more information, see [Subscribe to a MCP Server]({{base_path}}/ai-gateway/mcp-gateway/subscribe-to-a-mcp-server/).
     - Obtain an access token for the application. You can use the token endpoint to get a JWT token. For more information, see [Generate an Access Token]({{base_path}}/consume/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-the-integrated-api-console/#step-3-get-an-access-token).
 

--- a/en/docs/api-design-manage/deploy-and-publish/deploy-on-gateway/api-gateway/gateway-policies.md
+++ b/en/docs/api-design-manage/deploy-and-publish/deploy-on-gateway/api-gateway/gateway-policies.md
@@ -1,4 +1,4 @@
-#Gateway Policies
+# Gateway Policies
 
 In WSO2 API Manager, managing Global Level Policies within the gateway infrastructure is made easier. This streamlines policy handling, eliminating the need for administrators to manually create XML-type policy files. This feature facilitates a user-friendly approach to handling policies, eliminates the requirement for manual XML creation and placement in specific directories, and enhances control by providing a clear interface for creating, deploying, and undeploying policies, offering administrators better control over policy management.
 

--- a/en/docs/api-design-manage/deploy-and-publish/deploy-on-gateway/api-gateway/response-caching.md
+++ b/en/docs/api-design-manage/deploy-and-publish/deploy-on-gateway/api-gateway/response-caching.md
@@ -1,8 +1,8 @@
-#Response caching
+# Response caching
 
 The API Manager uses [WSO2 ESB's cache mediator](https://docs.wso2.com/display/EI650/Cache+Mediator) to cache response messages for each API. Caching improves performance, because the backend server does not have to process the same data for a request multiple times. You need to set an appropriate timeout period to offset the risk of stale data in the cache.
 
-##Enabling Response Caching for an API
+## Enabling Response Caching for an API
 
 You need to enable response caching when creating a new API or editing an existing API using the API Publisher.
 

--- a/en/docs/api-design-manage/design/create-api/create-streaming-api/test-a-websub-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-streaming-api/test-a-websub-api.md
@@ -4,7 +4,7 @@
 
 Follow the instructions below to test a WebSub API (WebHook API):
 
-!!! Prerequisites
+!!! info "Prerequisites"
      1. The WebSub/WebHook API should have been published.
 
      2. The WebSub/WebHook API topic should have been registered with your WebHook provider. For more details, see [Create a WebSub/WebHook API](../../../../design/create-api/create-streaming-api/create-a-websub-streaming-api).

--- a/en/docs/api-developer-portal/manage-application/advanced-topics/changing-the-owner-of-an-application.md
+++ b/en/docs/api-developer-portal/manage-application/advanced-topics/changing-the-owner-of-an-application.md
@@ -38,7 +38,7 @@ Follow the instructions below to change the ownership of an application:
 
     4.  Update the **Owner** field with the new owner's username (Chris).
 
-        !!! Troubleshooting
+        !!! tip "Troubleshooting"
             If you get a "`Error while updating ownership to <username> `" error (e.g., Error while updating ownership to Kim) in the Admin Portal, make sure to request that specific user (e.g., Kim) to sign in to the WSO2 Developer Portal, because users are not added as subscribers until they sign in to the Developer Portal at least once.
 
 

--- a/en/docs/api-developer-portal/manage-application/advanced-topics/changing-the-provider-of-an-api.md
+++ b/en/docs/api-developer-portal/manage-application/advanced-topics/changing-the-provider-of-an-api.md
@@ -38,7 +38,7 @@ Follow the instructions below to change the ownership of an application:
 
     4.  Update the **Provider** field with the new provider's username (Chris).
 
-        !!! Troubleshooting
+        !!! tip "Troubleshooting"
             If you get a "`Not a valid user `" error (e.g., Chris123 not is a valid user) in the Admin Portal, make sure to request that specific user (e.g., Kim) by checking the spellings.
 
 

--- a/en/docs/api-gateway/gateway-policies.md
+++ b/en/docs/api-gateway/gateway-policies.md
@@ -1,4 +1,4 @@
-#Gateway Policies
+# Gateway Policies
 
 In WSO2 API Manager, managing Global Level Policies within the gateway infrastructure is made easier. This streamlines policy handling, eliminating the need for administrators to manually create XML-type policy files. This feature facilitates a user-friendly approach to handling policies, eliminates the requirement for manual XML creation and placement in specific directories, and enhances control by providing a clear interface for creating, deploying, and undeploying policies, offering administrators better control over policy management.
 

--- a/en/docs/api-gateway/response-caching.md
+++ b/en/docs/api-gateway/response-caching.md
@@ -1,8 +1,8 @@
-#Response caching
+# Response caching
 
 The API Manager uses [WSO2 ESB's cache mediator](https://docs.wso2.com/display/EI650/Cache+Mediator) to cache response messages for each API. Caching improves performance, because the backend server does not have to process the same data for a request multiple times. You need to set an appropriate timeout period to offset the risk of stale data in the cache.
 
-##Enabling Response Caching for an API
+## Enabling Response Caching for an API
 
 You need to enable response caching when creating a new API or editing an existing API using the API Publisher.
 

--- a/en/docs/api-security/key-management/authentication/grant-types/overview.md
+++ b/en/docs/api-security/key-management/authentication/grant-types/overview.md
@@ -1,4 +1,4 @@
-#OAuth2 Grant Types
+# OAuth2 Grant Types
 
 
 In OAuth2, the term **Grant Type** refers to the way for a client application to acquire an access token depending on the type of the resource owner, type of the application and the trust relationship between the authorization server and the resource owner. 

--- a/en/docs/api-security/runtime/api-authentication/secure-apis-using-basic-authentication.md
+++ b/en/docs/api-security/runtime/api-authentication/secure-apis-using-basic-authentication.md
@@ -1,4 +1,4 @@
-#Securing APIs with Basic Authentication
+# Securing APIs with Basic Authentication
 
 Basic authentication is a simple HTTP authentication scheme in which the request will contain an authorization header with a valid  base64 encoded username and password. The WSO2 API Manager is able to authenticate requests using Basic and OAuth2 authentication 
 schemes. In addition to using these schemes individually, it is also possible to use 
@@ -44,7 +44,7 @@ Use the cURL command below to invoke the API via the gateway.
     curl -k -X GET "https://localhost:8243/pizzashack/1.0.0/menu" -H  "accept: application/json" -H  "Authorization: Basic c2hhbmk6c2hhbmkxMjM="
     ```
 
-##Basic Authentication with Scopes
+## Basic Authentication with Scopes
 WSO2 API Manager allow users to configure [Scopes]({{base_path}}/api-security/runtime/authorization/oauth2-scopes/fine-grained-access-control-with-oauth-scopes/) with role bindings which can associate with API Resources. Basic authentication
 uses credentials of the user to authenticate with the Basic Authentication protected API.
 

--- a/en/docs/api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens.md
+++ b/en/docs/api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens.md
@@ -230,7 +230,7 @@ Follow the instructions below to add a customized authorization header for an AP
       x-wso2-auth-header: "CustomAuthorizationHeader"
       ```
       
-##Try out the customized authorization header
+## Try out the customized authorization header
   
 Before you start, sign in to the API Publisher and deploy the sample API (`PizzaShackAPI`) if you have not done so already, as the following example is based on the `PizzaShackAPI` API.
 

--- a/en/docs/apiops/cli/cicd-using-cli.md
+++ b/en/docs/apiops/cli/cicd-using-cli.md
@@ -642,5 +642,5 @@ Let us assume that the **PetsApp** application is in the development environment
 Now, you know the building blocks of creating a CI/CD pipeline using apictl. By using the above, you can create 
 an automated pipeline for API promotion between environments using either one of the latter mentioned approaches. 
 
-!!! More
+!!! info "More"
     Next let us use the above knowledge to create a [Jenkins CI/CD Pipeline with WSO2 API Management for a Dev First Approach]({{base_path}}/install-and-setup/setup/api-controller/building-jenkins-ci-cd-pipeline-for-dev-first-approach/).

--- a/en/docs/apiops/cli/getting-started-with-wso2-api-controller.md
+++ b/en/docs/apiops/cli/getting-started-with-wso2-api-controller.md
@@ -19,7 +19,7 @@
 4.  Add the current working directory to your system's `$PATH` variable to be able to access the executable from anywhere.
 5.  Execute the following command to start the apictl.
 
-    !!! Warn
+    !!! warning
         If you have previously used an apictl old version, backup and remove `/home/<user>/.wso2apictl` directory and reconfigure the environments using the commands as explained below in [Add an environment](#add-an-environment) section.
 
     ``` go

--- a/en/docs/install-and-setup/install/deploying-api-manager-with-kubernetes-resources.md
+++ b/en/docs/install-and-setup/install/deploying-api-manager-with-kubernetes-resources.md
@@ -5,7 +5,7 @@ Follow the instructions below to use Kubernetes (K8s) and Helm resources for con
 !!! note
         -   In the context of this document, **&lt;`HELM_HOME>         `** refers to a local copy of the [`wso2/helm-apim         `](https://github.com/wso2/helm-apim/).
 
-!!! Prerequisites
+!!! info "Prerequisites"
     
     - Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Helm](https://helm.sh/docs/intro/install/), [Dep](https://golang.github.io/dep/docs/installation.html)
       and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager.md
@@ -321,7 +321,7 @@ Start WSO2 Identity Server for the changes to take effect. For more information,
         wso2server.bat 
         ```
 
-    !!! Troubleshooting
+    !!! tip "Troubleshooting"
 
         If you have configured the hostnames for WSO2 API Manager and WSO2 Identity Server, during the server startup, you will see the following warning in the WSO2 API Manager backend logs.
 

--- a/en/docs/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer.md
+++ b/en/docs/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer.md
@@ -141,7 +141,7 @@ Carry out the following steps to configure the load balancer to front multiple 
     -   The placeholders {tm-1-ip-address} and {tm-2-ip-address} correspond to the IP addresses of the back-end nodes in which APIM Traffic Managers are running.
 
 
-!!! configurations
+!!! example "Configurations"
     === "Single node"
         ```
         upstream sslapi.am.wso2.com {

--- a/en/docs/install-and-setup/setup/sso/configuring-external-idp-using-oidc-for-multi-tenancy.md
+++ b/en/docs/install-and-setup/setup/sso/configuring-external-idp-using-oidc-for-multi-tenancy.md
@@ -373,8 +373,8 @@ http_method = "all"
     [![Tenant Selection Page]({{base_path}}/assets/img/setup-and-install/tenant-selection-page.png)]({{base_path}}/assets/img/setup-and-install/tenant-selection-page.png)
 
 
-!!! Note For secondary user stores
+!!! note "For secondary user stores"
     If your Identity Provider has multiple secondary user stores (such as LDAP) and you want to include the user domain in the subject identifier (`LDAP_DOMAIN/username`), you must also connect the same user stores to the API Manager in read-only mode. This is required when the secondary user stores contain users with the same name and you cannot provision those users to the API Manager primary user store.
 
-!!! Tips
+!!! tip
     This approach is not limited to WSO2 IS 7.x, you can connect any third party identity provider using this method

--- a/en/docs/monitoring/observability/configuring-logging.md
+++ b/en/docs/monitoring/observability/configuring-logging.md
@@ -8,7 +8,7 @@ WSO2 API Manager uses various types of logs to track real time internal and exte
 
 WSO2 API Manager is shipped with log4j2 logging capabilities, which generate logs for administrative and server-side activities. By default, the Carbon Logs are persisted in the `wso2carbon.log` file, which is located in the `<API-M_HOME>/repository/logs` directory. You can configure the details that are captured in this log file by configuring the `<API-M_HOME>/repository/conf/log4j2.properties`.
 
-!!! Java logging and Log4j integration
+!!! info "Java logging and Log4j integration"
     In addition to the logs from libraries that use Log4j, all logs from libraries such as, Tomcat and Hazelcast, which use Java logging framework are also visible in the same log files. Therefore, when Java logging is enabled in Carbon, only the Log4j appenders will write to the log files. If the Java Logging Handlers have logs, these logs will be delegated to the log events of the corresponding Log4j appenders. A Pub/Sub registry pattern implementation has been used in the latter mentioned scenario to plug the handlers and appenders. 
     
 ### Configuring Carbon Logs
@@ -217,7 +217,7 @@ The following is a sample Gateway Wire Log for an API request.
 
 4. Observe the logs for incoming and outgoing traffic in the `<API-M_HOME>/repository/logs/wso2carbon.log` file.
 
-!!! Limitation
+!!! warning "Limitation"
     If synapse-wire logs are enabled during high load, outgoing traffic between the gateway and the backend will not be printed in the `wso2carbon.log` file. This happens when the backend connection is keep alive. As we are maintaining connections in a connection pool, the same connections will be reused in keep alive mode irrespective of the changes done in the `log4j2.properties` file.
 
 ## HTTP Access Logs

--- a/en/docs/monitoring/observability/monitoring-correlation-logs.md
+++ b/en/docs/monitoring/observability/monitoring-correlation-logs.md
@@ -921,7 +921,7 @@ In order to enable denying of threads:
     !!! note
         If the correlation logs are enabled using the system property, DevOps API will not be able to change the denied threads of the JDBC component. 
 
-    !!! Limitation
+    !!! warning "Limitation"
         Thread denying is currently supported only for JDBC type logs. HTTP and METHOD level logs cannot be blocked using this option.
 
 If the above configuration is not added, by default, the `MessageDeliveryTaskThreadPool` thread will be denied as it is found to print a considerable amount of messages for API-M instances. However, if the above configuration is added, the default value will be overridden. 


### PR DESCRIPTION
## Purpose
Fixes rendering and layout bugs in several documentation pages caused by non-standard MkDocs admonition types and missing spaces in Markdown headings.

## Goals
Ensure all warning/note/info callout boxes and headings render correctly on the live documentation site.

## Approach
1. Updated 13 instances of non-standard admonition types (such as `!!! prerequisite`, `!!! Troubleshooting`, `!!! configurations`, and `!!! Tips`) to use standard MkDocs Material styles (`!!! note`, `!!! warning`, `!!! tip`, `!!! info`, or `!!! example`) with custom headers where appropriate.
2. Fixed 10 instances of missing spaces after `#` and `##` in Markdown headers (e.g., `#Gateway Policies` -> `# Gateway Policies`) to ensure the headers are parsed and indexed correctly by MkDocs.
3. Verified the build success locally using `python -m mkdocs build --dirty`.

## User stories
As a documentation reader, I want warning blocks, callout notes, and headings to render clearly and consistently so that I can easily follow instructions without formatting noise.

## Release note
N/A (Formatting fixes)

## Documentation
N/A (This PR fixes the formatting of the existing documentation pages)

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests: N/A
 - Integration tests: N/A (Successfully verified using local `mkdocs build`)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested locally on Windows 11 using Python 3.13, MkDocs, and properdocs.

## Learning
Used the standard MkDocs Material Admonitions documentation reference for formatting compliance.
