### PR TITLE
Fix broken image links in generate-api-key.md by using base_path

### DIFF
--- a/en/docs/includes/design/generate-api-key.md
+++ b/en/docs/includes/design/generate-api-key.md
@@ -7,11 +7,11 @@
 
 3. Click **API Keys** from the left menu of the API.
 
-     [![Generate API Key Left Menu](../../../../assets/img/learn/api-keys/api-api-key-left-menu.png)](../../../../assets/img/learn/api-keys/api-api-key-left-menu.png)
+     [![Generate API Key Left Menu]({{base_path}}/assets/img/learn/api-keys/api-api-key-left-menu.png)]({{base_path}}/assets/img/learn/api-keys/api-api-key-left-menu.png)
 
 4. Click **Generate API Key** and provide a Key Name.
 
-     [![Generate API key](../../../../assets/img/learn/api-keys/generate-api-api-key.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/generate-api-api-key.png)
+     [![Generate API key]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key.png)
 
 5. Optionally, configure the validity period before generating the key.
 
@@ -21,7 +21,7 @@
 
 7. Copy the generated API key.
 
-     [![Copy API key](../../../../assets/img/learn/api-keys/generate-api-api-key-response.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/generate-api-api-key-response.png)
+     [![Copy API key]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key-response.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key-response.png)
 
 Once the API key is generated, the steps to use it depend on whether the API requires a subscription. Follow the relevant section below.
 
@@ -42,23 +42,23 @@ A valid subscription must exist and the generated API key must be associated wit
 
 3. Click **Subscribe**.
 
-     [![Subscribe to the API](../../../../assets/img/learn/subscribe-to-api.png)](../../../../assets/img/learn/subscribe-to-api.png)
+     [![Subscribe to the API]({{base_path}}/assets/img/learn/subscribe-to-api.png)]({{base_path}}/assets/img/learn/subscribe-to-api.png)
 
 4. Click **Associate** on the API key to link it to the subscribed application.
 
-     [![Associate API key button](../../../../assets/img/learn/api-keys/associate-api-key-button.png)](../../../../assets/img/learn/api-keys/associate-api-key-button.png)
+     [![Associate API key button]({{base_path}}/assets/img/learn/api-keys/associate-api-key-button.png)]({{base_path}}/assets/img/learn/api-keys/associate-api-key-button.png)
 
 5. Select the application from the drop-down and click **ASSOCIATE**.
 
-     [![Associate API key](../../../../assets/img/learn/api-keys/associate-api-key.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/associate-api-key.png)
+     [![Associate API key]({{base_path}}/assets/img/learn/api-keys/associate-api-key.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/associate-api-key.png)
 
      Alternatively, you can associate the API key from the subscribed application's **API Keys** page.
 
-     [![Associate API key from App button](../../../../assets/img/learn/api-keys/app-associate-buttopn.png)](../../../../assets/img/learn/api-keys/app-associate-buttopn.png)
+     [![Associate API key from App button]({{base_path}}/assets/img/learn/api-keys/app-associate-buttopn.png)]({{base_path}}/assets/img/learn/api-keys/app-associate-buttopn.png)
 
      Select the API and the generated API key from the drop-down and associate.
 
-     [![Associate API key from App](../../../../assets/img/learn/api-keys/associate-api-key-from-app.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/associate-api-key-from-app.png)
+     [![Associate API key from App]({{base_path}}/assets/img/learn/api-keys/associate-api-key-from-app.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/associate-api-key-from-app.png)
 
 ### For subscriptionless APIs
 


### PR DESCRIPTION
## Purpose
Resolves #11557

## Goals
Fix broken image links in the API keys documentation which previously used hardcoded relative paths that broke when the snippet was included in other pages.

## Approach
Replaced the hardcoded relative directory paths (`../../../../assets`) with the dynamic `{{base_path}}/assets` macro inside `en/docs/includes/design/generate-api-key.md`.

## User stories
N/A

## Release note
Fixed broken image links in the API keys documentation.

## Documentation
This PR is a documentation fix.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested locally using `mkdocs serve`.
 
## Learning
N/A