### PR TITLE
[4.6.0] Add docs for external WebSub hub and custom WebSub topic matcher

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api.md
@@ -140,3 +140,6 @@ Learn more by trying out an end-to-end tutorial on <a href="{{base_path}}/tutori
 ## See Also
 
 {!includes/design/stream-more-links.md!}
+
+- [Configure an External WebSub Hub]({{base_path}}/install-and-setup/setup/advance-configurations/configuring-external-websub-hub/) — delegate hub responsibilities to a dedicated external WebSub hub.
+- [Extend WebSub Topic Matching]({{base_path}}/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching/) — plug in custom topic-matching logic for WebSub APIs.

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -5,6 +5,15 @@ By default, WSO2 API Manager handles the WebSub protocol (topic registration, su
 When an external hub is configured, WebSub APIs deployed from the Publisher continue to handle authentication, authorization, and throttling at the Gateway as usual, but the hub requests (`subscribe`, `unsubscribe`, and `publish`) are forwarded to the external hub instead of being processed internally.
 
 !!! note
+    This feature requires the following minimum update levels for WSO2 API Manager 4.6.0:
+
+    - All-in-One (`wso2am`): 4.6.0.32
+    - Control Plane (`wso2am-acp`): 4.6.0.33
+    - Universal Gateway (`wso2am-universal-gw`): 4.6.0.32
+
+    Run the [WSO2 Update Tool](https://updates.docs.wso2.com/en/latest/updates/update-tool/) to get the latest updates.
+
+!!! note
     This configuration applies to WebSub APIs only. REST, GraphQL, WebSocket, and SSE APIs are not affected.
 
 ## Configuration

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -1,0 +1,93 @@
+# Configuring an External WebSub Hub
+
+By default, WSO2 API Manager handles the WebSub protocol (topic registration, subscription, unsubscription, and content publishing) inside the Universal Gateway itself. This works well for most deployments, but there are situations where you may want to delegate the hub responsibility to a dedicated external WebSub hub — for example, to reuse an existing hub that already serves other systems, to scale hub traffic independently of API traffic, or to take advantage of hub-specific features such as persistent subscriptions.
+
+When an external hub is configured, WebSub APIs deployed from the Publisher continue to handle authentication, authorization, and throttling at the Gateway as usual, but the hub-mode requests (`subscribe`, `unsubscribe`, and `publish`) are forwarded to the external hub instead of being processed internally.
+
+!!! note
+    This configuration applies to WebSub APIs only. REST, GraphQL, WebSocket, and SSE APIs are not affected.
+
+## Configuration
+
+Add the following section to the `<API-M_HOME>/repository/conf/deployment.toml` file.
+
+```toml
+[apim.external_websub_hub]
+url = "https://external-hub.example.com/hub"
+type = "external"
+disable_topic_context_prefix = false
+```
+
+### Configuration reference
+
+<table>
+<colgroup>
+<col width="25%" />
+<col width="60%" />
+<col width="15%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><b>Property</b></th>
+<th><b>Description</b></th>
+<th><b>Required</b></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p><code>url</code></p></td>
+<td><p>The base HTTP(S) URL of your external WebSub hub. Setting this value activates external-hub delegation for newly deployed WebSub APIs. If the URL is empty or the section is omitted, the gateway uses its built-in hub.</p></td>
+<td><p>Yes</p></td>
+</tr>
+<tr class="even">
+<td><p><code>type</code></p></td>
+<td><p>An identifier for the hub implementation (for example, <code>external</code>). Informational; used by custom extensions if you need to branch on hub type.</p></td>
+<td><p>No</p></td>
+</tr>
+<tr class="odd">
+<td><p><code>disable_topic_context_prefix</code></p></td>
+<td><p>Controls how topic names are sent to the external hub.
+<br/><br/>
+<code>false</code> (default) — topics are prefixed with the API context to avoid collisions between different APIs that expose the same topic name.
+<br/><br/>
+<code>true</code> — topics are sent to the hub verbatim. Use this when the external hub already provides namespacing, or when multiple APIs must intentionally share the same topic.</p></td>
+<td><p>No</p></td>
+</tr>
+</tbody>
+</table>
+
+### Topic naming
+
+When the topic-context prefix is enabled (the default), the gateway rewrites each topic before sending it to the external hub, so that topics from different APIs do not collide on a shared hub. The rewritten topic uses the API context as a prefix, with `/` characters replaced by `_`.
+
+For example, an API deployed at `/repo-watcher/1.0.0` publishing to topic `commits` is forwarded to the external hub as `repo-watcher_1.0.0_commits`. Publish and subscribe requests are rewritten the same way, so publishers and subscribers stay consistent.
+
+!!! warning
+    Because `_` is used as the separator, avoid embedding `_` in API contexts, API versions, and topic names when the prefix is enabled. Otherwise the resulting topic strings can become ambiguous.
+
+## Distributed deployment
+
+!!! note
+    In a fully distributed setup, add this configuration to the **Control Plane (Publisher)** node only. The hub URL is baked into the API's Gateway artifact when the API is deployed from the Publisher; Gateway nodes pick it up automatically. No configuration is required on the Gateway, Traffic Manager, or Key Manager nodes.
+
+!!! important
+    The configuration is read only when a WebSub API is deployed. Any WebSub API that was already deployed before you enable, disable, or change the external hub URL will continue to use its previous setup. To pick up the change, redeploy the affected APIs by creating and deploying a new revision from the Publisher.
+
+## Verifying the configuration
+
+1. Add the `[apim.external_websub_hub]` block to `deployment.toml` on the Control Plane and restart the node.
+2. [Create a WebSub API]({{base_path}}/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api/) with one or more topics from the Publisher and deploy a new revision to a Gateway environment.
+3. Send a subscription request against the API's callback endpoint (`POST /<context>/<version>?hub.mode=subscribe&hub.topic=<topic>&hub.callback=<callback-url>`) and confirm that:
+    - Your external hub receives the subscription request.
+    - The subscriber receives the WebSub verification callback from the external hub.
+4. Publish an event through the API (`POST /<context>/<version>/<topic>?hub.mode=publish`) and confirm that the external hub receives it and fans it out to the subscribed callback.
+
+## Reverting to the built-in hub
+
+Remove (or comment out) the `[apim.external_websub_hub]` block from `deployment.toml`, restart the Control Plane, and redeploy the affected WebSub APIs. New revisions will use the Gateway's built-in WebSub hub.
+
+## See also
+
+- [Create a WebSub/WebHook API]({{base_path}}/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api/)
+- [Test a WebSub/WebHook API]({{base_path}}/api-design-manage/design/create-api/create-streaming-api/test-a-websub-api/)
+- [Extend WebSub Topic Matching]({{base_path}}/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching/)

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -58,7 +58,7 @@ disable_topic_context_prefix = false
 
 ### Topic naming
 
-When the topic-context prefix is enabled (the default), the gateway rewrites each topic before sending it to the external hub, so that topics from different APIs do not collide on a shared hub. The rewritten topic uses the API context as a prefix, with `/` characters replaced by `_`.
+When the topic-context prefix is enabled (the default), the gateway rewrites each topic before sending it to the external hub, so that topics with the same name from different WebSub APIs do not collide on a shared hub. The rewritten topic uses the API context as a prefix, with `/` characters replaced by `_`.
 
 For example, the publish request to the `commits` topic of the `/repo-watcher/1.0.0` WebSub API is forwarded to the `repo-watcher_1.0.0_commits` topic of the external WebSub Hub. Publish and subscribe requests are rewritten the same way, so publishers and subscribers stay consistent.
 

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -1,6 +1,6 @@
 # Configuring an External WebSub Hub
 
-By default, WSO2 API Manager handles the WebSub protocol (topic registration, subscription, unsubscription, and content publishing) inside the Universal Gateway itself. This works well for most deployments, but there are situations where you may want to delegate the hub responsibility to a dedicated external WebSub hub — for example, to reuse an existing hub that already serves other systems, to scale hub traffic independently of API traffic, or to take advantage of hub-specific features such as persistent subscriptions.
+By default, WSO2 API Manager handles the WebSub protocol (topic registration, subscription, unsubscription, and content publishing) inside the Universal Gateway itself. This works well for most deployments, but there are situations where you may want to delegate the hub responsibility to a dedicated external WebSub hub — for example, to reuse an existing hub that already serves other systems, to scale hub traffic independently of API traffic, or to take advantage of hub-specific features such as guaranteed deliveries.
 
 When an external hub is configured, WebSub APIs deployed from the Publisher continue to handle authentication, authorization, and throttling at the Gateway as usual, but the hub-mode requests (`subscribe`, `unsubscribe`, and `publish`) are forwarded to the external hub instead of being processed internally.
 

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -60,7 +60,7 @@ disable_topic_context_prefix = false
 
 When the topic-context prefix is enabled (the default), the gateway rewrites each topic before sending it to the external hub, so that topics from different APIs do not collide on a shared hub. The rewritten topic uses the API context as a prefix, with `/` characters replaced by `_`.
 
-For example, an API deployed at `/repo-watcher/1.0.0` publishing to topic `commits` is forwarded to the external hub as `repo-watcher_1.0.0_commits`. Publish and subscribe requests are rewritten the same way, so publishers and subscribers stay consistent.
+For example, the publish request to the `commits` topic of the `/repo-watcher/1.0.0` WebSub API is forwarded to the `repo-watcher_1.0.0_commits` topic of the external WebSub Hub. Publish and subscribe requests are rewritten the same way, so publishers and subscribers stay consistent.
 
 !!! warning
     Because `_` is used as the separator, avoid embedding `_` in API contexts, API versions, and topic names when the prefix is enabled. Otherwise the resulting topic strings can become ambiguous.

--- a/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
+++ b/en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
@@ -2,7 +2,7 @@
 
 By default, WSO2 API Manager handles the WebSub protocol (topic registration, subscription, unsubscription, and content publishing) inside the Universal Gateway itself. This works well for most deployments, but there are situations where you may want to delegate the hub responsibility to a dedicated external WebSub hub — for example, to reuse an existing hub that already serves other systems, to scale hub traffic independently of API traffic, or to take advantage of hub-specific features such as guaranteed deliveries.
 
-When an external hub is configured, WebSub APIs deployed from the Publisher continue to handle authentication, authorization, and throttling at the Gateway as usual, but the hub-mode requests (`subscribe`, `unsubscribe`, and `publish`) are forwarded to the external hub instead of being processed internally.
+When an external hub is configured, WebSub APIs deployed from the Publisher continue to handle authentication, authorization, and throttling at the Gateway as usual, but the hub requests (`subscribe`, `unsubscribe`, and `publish`) are forwarded to the external hub instead of being processed internally.
 
 !!! note
     This configuration applies to WebSub APIs only. REST, GraphQL, WebSocket, and SSE APIs are not affected.

--- a/en/docs/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md
+++ b/en/docs/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md
@@ -9,6 +9,14 @@ If neither rule accepts the subscriber's topic, the request is rejected as inval
 
 These rules cover most use cases, but sometimes the topic scheme used by an external system cannot be expressed as an exact string or a URI template. Common examples include topics with versioning suffixes (`orders.v2`), hierarchical wildcards not supported by URI templates, or topics that need to be looked up against an external registry. For these cases, WSO2 API Manager exposes an extension point that lets you plug in your own topic-matching logic for WebSub APIs.
 
+!!! note
+    This feature requires the following minimum update levels for WSO2 API Manager 4.6.0:
+
+    - All-in-One (`wso2am`): 4.6.0.32
+    - Universal Gateway (`wso2am-universal-gw`): 4.6.0.32
+
+    Run the [WSO2 Update Tool](https://updates.docs.wso2.com/en/latest/updates/update-tool/) to get the latest updates.
+
 ## How it works
 
 Before the built-in matcher runs, the Gateway invokes your custom matcher and passes it two pieces of information:

--- a/en/docs/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md
+++ b/en/docs/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md
@@ -1,0 +1,202 @@
+# Extending WebSub Topic Matching
+
+When a subscriber sends a request to a WebSub API, the Universal Gateway decides whether the topic the subscriber asked for matches one of the topics defined on the API. Out of the box, this decision is based on two rules:
+
+1. An **exact string match** against the topics defined on the API.
+2. A **URI-template match** (so dynamic patterns such as `orders/{id}/updates` are supported).
+
+If neither rule accepts the subscriber's topic, the request is rejected as invalid.
+
+These rules cover most use cases, but sometimes the topic scheme used by an external system cannot be expressed as an exact string or a URI template. Common examples include topics with versioning suffixes (`orders.v2`), hierarchical wildcards not supported by URI templates, or topics that need to be looked up against an external registry. For these cases, WSO2 API Manager exposes an extension point that lets you plug in your own topic-matching logic for WebSub APIs.
+
+## How it works
+
+Before the built-in matcher runs, the Gateway invokes your custom matcher and passes it two pieces of information:
+
+- **The topic that the subscriber requested**, taken from the `hub.topic` value in the request.
+- **The list of topics defined on the API**.
+
+Your matcher returns either the topic it considers a match (in which case the Gateway accepts the request) or nothing (in which case the Gateway falls back to the built-in rules). Because the built-in rules still run as a fallback, your matcher only needs to handle the extra cases you want to support — you do not need to reimplement exact and URI-template matching.
+
+## Implementing a custom matcher
+
+### Step 1 - Add the dependency
+
+Create a Java project and add the following Maven dependency. Set `${carbon.apimgt.version}` to the version that ships with your WSO2 API Manager release (you can find it in `<API-M_HOME>/repository/components/plugins/` by looking at the version suffix of `org.wso2.carbon.apimgt.common.gateway_<version>.jar`).
+
+```xml
+<dependency>
+    <groupId>org.wso2.carbon.apimgt</groupId>
+    <artifactId>org.wso2.carbon.apimgt.common.gateway</artifactId>
+    <version>${carbon.apimgt.version}</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+### Step 2 - Implement the ExtensionListener interface
+
+Implement `org.wso2.carbon.apimgt.common.gateway.extensionlistener.ExtensionListener` and put your topic-matching logic in `preProcessRequest`. The other methods can return a "continue" response unchanged.
+
+```java
+package com.example.apim.websub;
+
+import org.wso2.carbon.apimgt.common.gateway.dto.ExtensionResponseDTO;
+import org.wso2.carbon.apimgt.common.gateway.dto.ExtensionResponseStatus;
+import org.wso2.carbon.apimgt.common.gateway.dto.ExtensionType;
+import org.wso2.carbon.apimgt.common.gateway.dto.RequestContextDTO;
+import org.wso2.carbon.apimgt.common.gateway.dto.ResponseContextDTO;
+import org.wso2.carbon.apimgt.common.gateway.extensionlistener.ExtensionListener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomWebSubTopicMatcher implements ExtensionListener {
+
+    private static final String WEBSUB_REQUESTED_TOPIC = "WEBSUB_REQUESTED_TOPIC";
+    private static final String WEBSUB_URL_PATTERNS = "WEBSUB_URL_PATTERNS";
+    private static final String WEBSUB_MATCHED_TOPIC = "WEBSUB_MATCHED_TOPIC";
+
+    @Override
+    public ExtensionResponseDTO preProcessRequest(RequestContextDTO requestContextDTO) {
+        Map<String, Object> customProps = requestContextDTO.getCustomProperty();
+        if (customProps == null) {
+            customProps = new HashMap<>();
+        }
+
+        String requestedTopic = (String) customProps.get(WEBSUB_REQUESTED_TOPIC);
+        @SuppressWarnings("unchecked")
+        List<String> apiTopics = (List<String>) customProps.get(WEBSUB_URL_PATTERNS);
+
+        String matchedTopic = match(requestedTopic, apiTopics);
+        if (matchedTopic != null) {
+            customProps.put(WEBSUB_MATCHED_TOPIC, matchedTopic);
+        }
+
+        ExtensionResponseDTO response = new ExtensionResponseDTO();
+        response.setCustomProperty(customProps);
+        response.setResponseStatus(ExtensionResponseStatus.CONTINUE.toString());
+        return response;
+    }
+
+    private String match(String requestedTopic, List<String> apiTopics) {
+        if (requestedTopic == null || apiTopics == null) {
+            return null;
+        }
+        // Example: match case-insensitively, ignoring any '.v<n>' version suffix.
+        // Replace this block with your own matching logic.
+        String normalized = requestedTopic.replaceAll("\\.v\\d+$", "").toLowerCase();
+        for (String topic : apiTopics) {
+            if (topic.equalsIgnoreCase(normalized)) {
+                return topic;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ExtensionResponseDTO postProcessRequest(RequestContextDTO requestContextDTO) {
+        return continueResponse();
+    }
+
+    @Override
+    public ExtensionResponseDTO preProcessResponse(ResponseContextDTO responseContextDTO) {
+        return continueResponse();
+    }
+
+    @Override
+    public ExtensionResponseDTO postProcessResponse(ResponseContextDTO responseContextDTO) {
+        return continueResponse();
+    }
+
+    @Override
+    public String getType() {
+        return ExtensionType.WEBSUB_TOPIC_RESOLVER.toString();
+    }
+
+    private static ExtensionResponseDTO continueResponse() {
+        ExtensionResponseDTO response = new ExtensionResponseDTO();
+        response.setResponseStatus(ExtensionResponseStatus.CONTINUE.toString());
+        return response;
+    }
+}
+```
+
+The values your matcher exchanges with the Gateway are passed through the request's custom-property map.
+
+<table>
+<colgroup>
+<col width="30%" />
+<col width="15%" />
+<col width="55%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><b>Key</b></th>
+<th><b>Type</b></th>
+<th><b>Description</b></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p><code>WEBSUB_REQUESTED_TOPIC</code></p></td>
+<td><p><code>String</code></p></td>
+<td><p>The topic value the subscriber requested. Provided by the Gateway.</p></td>
+</tr>
+<tr class="even">
+<td><p><code>WEBSUB_URL_PATTERNS</code></p></td>
+<td><p><code>List&lt;String&gt;</code></p></td>
+<td><p>The list of topics defined on the API. Provided by the Gateway.</p></td>
+</tr>
+<tr class="odd">
+<td><p><code>WEBSUB_MATCHED_TOPIC</code></p></td>
+<td><p><code>String</code></p></td>
+<td><p>Set this to the topic you consider a match. Leave it unset (or <code>null</code>) to let the built-in matcher take over.</p></td>
+</tr>
+</tbody>
+</table>
+
+!!! note
+    Your implementation must expose a public no-argument constructor. The class is instantiated by API Manager at startup.
+
+### Step 3 - Deploy the extension
+
+1. Build the project as a plain JAR (not an OSGi bundle):
+    ```bash
+    mvn clean package
+    ```
+2. Copy the JAR into `<API-M_HOME>/repository/components/lib/` on every Gateway node.
+3. Register the class in `<API-M_HOME>/repository/conf/deployment.toml` on every Gateway node:
+    ```toml
+    [[apim.extension.listener]]
+    type = "WEBSUB_TOPIC_RESOLVER"
+    class = "com.example.apim.websub.CustomWebSubTopicMatcher"
+    enable_extension_fault_sequence_mediation = false
+    ```
+4. Restart the Gateway nodes.
+
+## Distributed deployment
+
+!!! note
+    In a fully distributed setup, add the JAR and the `[[apim.extension.listener]]` configuration to every **Gateway** node. Custom topic matching runs at request-processing time on the Gateway; the Control Plane, Traffic Manager, and Key Manager nodes are not involved.
+
+!!! warning
+    Only one custom matcher can be registered at a time. If more than one `[[apim.extension.listener]]` block uses `type = "WEBSUB_TOPIC_RESOLVER"`, the last one wins.
+
+## Verifying the extension
+
+1. Deploy a WebSub API that has at least one topic defined (see [Create a WebSub/WebHook API]({{base_path}}/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api/)).
+2. Enable `DEBUG` logging for your extension package by adding the following to `<API-M_HOME>/repository/conf/log4j2.properties` on the Gateway:
+    ```
+    logger.custom-websub.name = com.example.apim.websub
+    logger.custom-websub.level = DEBUG
+    ```
+    Append `custom-websub` to the `loggers` list.
+3. Send a subscription request whose `hub.topic` value only your custom matcher (not the built-in matcher) would accept, and confirm that the Gateway accepts it.
+4. Send a subscription request whose `hub.topic` value neither matcher would accept, and confirm that the Gateway rejects it.
+
+## See also
+
+- [Configuring an External WebSub Hub]({{base_path}}/install-and-setup/setup/advance-configurations/configuring-external-websub-hub/)
+- [Write Custom Handlers]({{base_path}}/reference/customize-product/extending-api-manager/extending-gateway/writing-custom-handlers/)
+- [Create a WebSub/WebHook API]({{base_path}}/api-design-manage/design/create-api/create-streaming-api/create-a-websub-streaming-api/)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
                     - Configure Caching: install-and-setup/setup/advance-configurations/configuring-caching.md
                     - Customize the Management Console: install-and-setup/setup/advance-configurations/customizing-the-management-console.md
                     - Configure the Crypto Provider: install-and-setup/setup/advance-configurations/configuring-the-crypto-provider.md
+                    - Configure an External WebSub Hub: install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md
         - Deploy:
             - Deploy on VMs:
                 - All-In-One Deployment:
@@ -698,6 +699,7 @@ nav:
                 - Extend API Gateway:
                     - Customize API Template: reference/customize-product/extending-api-manager/extending-gateway/customizing-api-template-for-gateway.md
                     - Write Custom Handlers: reference/customize-product/extending-api-manager/extending-gateway/writing-custom-handlers.md
+                    - Extend WebSub Topic Matching: reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md
                 - Extend Workflows:
                     - Invoke the API Manager from the BPEL Engine: reference/customize-product/extending-api-manager/extending-workflows/invoking-the-api-manager-from-the-bpel-engine.md
                     - Customize a Workflow Extension: reference/customize-product/extending-api-manager/extending-workflows/customizing-a-workflow-extension.md


### PR DESCRIPTION
## Purpose
Documents two WebSub-related capabilities in WSO2 API Manager 4.6.0 that were shipped without user-facing documentation:

1. Delegating WebSub hub operations to an **external WebSub hub** via `[apim.external_websub_hub]` in `deployment.toml`.
2. Extending WebSub **topic matching** in the Gateway through the `WEBSUB_TOPIC_RESOLVER` extension listener.

Related to: https://github.com/wso2-enterprise/wso2-apim-internal/issues/16295

## Goals
- Give admins a clear path for configuring an external hub, including which node in a distributed deployment needs the configuration and how the topic-context prefix behaves.
- Give extension developers a working reference (interface, sample implementation, deployment steps) for a custom WebSub topic matcher.
- Cross-link both docs from the existing "Create a WebSub/WebHook API" page so users discover them from the natural entry point.

## Approach
- New page: `en/docs/install-and-setup/setup/advance-configurations/configuring-external-websub-hub.md`
- New page: `en/docs/reference/customize-product/extending-api-manager/extending-gateway/extending-websub-topic-matching.md`
- Both pages registered in `en/mkdocs.yml` under the existing *Advanced Configurations* and *Extend API Gateway* sections.
- Added two bullets to the *See Also* section of `create-a-websub-streaming-api.md`.

Docs follow the sparser house style used by peer pages (`configuring-caching.md`, `writing-custom-handlers.md`): TOML-first guidance, `!!! note` admonitions for distributed deployment placement, `<colgroup>`-based tables, and no gateway-internal class/line references in user-facing prose.

## User stories
- As an admin, I can configure API-M to route WebSub hub traffic to an existing external hub instead of the built-in one.
- As an extension developer, I can plug a custom topic-matching implementation into the Gateway for WebSub APIs.

## Release note
Added documentation for configuring an external WebSub hub and for extending WebSub topic matching with a custom `ExtensionListener` implementation.

## Documentation
This PR **is** the documentation.

## Training
N/A

## Certification
N/A — no impact on certification.

## Marketing
N/A

## Automation tests
- Unit tests: N/A (docs-only change)
- Integration tests: N/A (docs-only change)

## Security checks
- Followed secure coding standards: N/A (docs-only)
- Ran FindSecurityBugs plugin and verified report: N/A (docs-only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
Java sample for a custom `ExtensionListener` implementation is included inline in the topic-matcher doc.

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified locally via \`mkdocs serve\` on macOS.

## Learning
N/A