### PR TITLE
Fix broken image links in API Keys doc

### DIFF
--- a/en/docs/includes/design/generate-api-key.md
+++ b/en/docs/includes/design/generate-api-key.md
@@ -7,11 +7,11 @@
 
 3. Click **API Keys** from the left menu of the API.
 
-     [![Generate API Key Left Menu](../../../../assets/img/learn/api-keys/api-api-key-left-menu.png)](../../../../assets/img/learn/api-keys/api-api-key-left-menu.png)
+     [![Generate API Key Left Menu]({{base_path}}/assets/img/learn/api-keys/api-api-key-left-menu.png)]({{base_path}}/assets/img/learn/api-keys/api-api-key-left-menu.png)
 
 4. Click **Generate API Key** and provide a Key Name.
 
-     [![Generate API key](../../../../assets/img/learn/api-keys/generate-api-api-key.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/generate-api-api-key.png)
+     [![Generate API key]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key.png)
 
 5. Optionally, configure the validity period before generating the key.
 
@@ -21,7 +21,7 @@
 
 7. Copy the generated API key.
 
-     [![Copy API key](../../../../assets/img/learn/api-keys/generate-api-api-key-response.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/generate-api-api-key-response.png)
+     [![Copy API key]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key-response.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/generate-api-api-key-response.png)
 
 Once the API key is generated, the steps to use it depend on whether the API requires a subscription. Follow the relevant section below.
 
@@ -42,23 +42,23 @@ A valid subscription must exist and the generated API key must be associated wit
 
 3. Click **Subscribe**.
 
-     [![Subscribe to the API](../../../../assets/img/learn/subscribe-to-api.png)](../../../../assets/img/learn/subscribe-to-api.png)
+     [![Subscribe to the API]({{base_path}}/assets/img/learn/subscribe-to-api.png)]({{base_path}}/assets/img/learn/subscribe-to-api.png)
 
 4. Click **Associate** on the API key to link it to the subscribed application.
 
-     [![Associate API key button](../../../../assets/img/learn/api-keys/associate-api-key-button.png)](../../../../assets/img/learn/api-keys/associate-api-key-button.png)
+     [![Associate API key button]({{base_path}}/assets/img/learn/api-keys/associate-api-key-button.png)]({{base_path}}/assets/img/learn/api-keys/associate-api-key-button.png)
 
 5. Select the application from the drop-down and click **ASSOCIATE**.
 
-     [![Associate API key](../../../../assets/img/learn/api-keys/associate-api-key.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/associate-api-key.png)
+     [![Associate API key]({{base_path}}/assets/img/learn/api-keys/associate-api-key.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/associate-api-key.png)
 
      Alternatively, you can associate the API key from the subscribed application's **API Keys** page.
 
-     [![Associate API key from App button](../../../../assets/img/learn/api-keys/app-associate-buttopn.png)](../../../../assets/img/learn/api-keys/app-associate-buttopn.png)
+     [![Associate API key from App button]({{base_path}}/assets/img/learn/api-keys/app-associate-buttopn.png)]({{base_path}}/assets/img/learn/api-keys/app-associate-buttopn.png)
 
      Select the API and the generated API key from the drop-down and associate.
 
-     [![Associate API key from App](../../../../assets/img/learn/api-keys/associate-api-key-from-app.png){: style="width:80%"}](../../../../assets/img/learn/api-keys/associate-api-key-from-app.png)
+     [![Associate API key from App]({{base_path}}/assets/img/learn/api-keys/associate-api-key-from-app.png){: style="width:80%"}]({{base_path}}/assets/img/learn/api-keys/associate-api-key-from-app.png)
 
 ### For subscriptionless APIs
 


### PR DESCRIPTION
## Purpose
Resolves #11557. Images on the API Keys documentation page (`https://apim.docs.wso2.com/en/latest/includes/design/generate-api-key/`) are broken.

## Goals
Restore the images on that page without breaking the same content when it is transcluded into `secure-apis-using-api-keys.md`.

## Approach
`en/docs/includes/design/generate-api-key.md` is built as a standalone mkdocs page (only `wip/*` is excluded via the `exclude` plugin in `en/mkdocs.yml`), in addition to being transcluded into `secure-apis-using-api-keys.md` via `{!includes/design/generate-api-key.md!}`. The file hardcoded image links as `../../../../assets/img/...` (4 levels up), which is only correct for the transcluded context (built 4 levels deep) and breaks on the standalone page (built 3 levels deep).

Replaced all 8 occurrences with the `{{base_path}}/assets/img/...` convention already used throughout the rest of the docs (e.g. `en/docs/api-gateway/message-tracing.md`), which resolves correctly regardless of nesting depth.

## User stories
N/A

## Release note
Fixed broken image links on the API Keys documentation page.

## Documentation
This PR is the documentation fix itself.

## Training
N/A

## Certification
N/A - no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: N/A (documentation content change)
- Integration tests: N/A

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (markdown-only change, no code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
Companion PR targeting the 4.7.0 branch (same fix, since #11557 reports version 4.7.0).

## Migrations (if applicable)
N/A

## Test environment
Verified all 8 referenced image files exist at `en/docs/assets/img/learn/api-keys/` (and `en/docs/assets/img/learn/subscribe-to-api.png`) and that the `{{base_path}}` pattern is the established convention elsewhere in this repo.

## Learning
Traced the mkdocs build config (`en/mkdocs.yml`) to confirm the `includes/` directory is not excluded from the build, which is why this file is served as two separate pages at different depths.