### PR TITLE
Fix inconsistent URL paths in See Also section of Create a REST API page

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
@@ -177,11 +177,11 @@ Now, you have successfully created and configured a REST API. Next, [deploy the 
 
 Learn more on the concepts that you need to know when creating a REST API:
 
--   [Endpoints]({{base_path}}/manage-apis/design/endpoints/endpoint-types/)
--   [API Security]({{base_path}}/manage-apis/design/api-security/api-authentication/secure-apis-using-oauth2-tokens/)
--   [Rate Limiting]({{base_path}}/manage-apis/design/rate-limiting/introducing-throttling-use-cases/)
--   [Life Cycle Management]({{base_path}}/manage-apis/design/lifecycle-management/api-lifecycle/)
--   [API Monetization]({{base_path}}/manage-apis/design/api-monetization/monetizing-an-api/)
--   [API Visibility]({{base_path}}/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/)
--   [API Documentation]({{base_path}}/manage-apis/design/api-documentation/add-api-documentation/)
--   [Custom Properties]({{base_path}}/manage-apis/design/create-api/adding-custom-properties-to-apis/)
+-   [Endpoints]({{base_path}}/api-design-manage/design/endpoints/endpoint-types/)
+-   [API Security]({{base_path}}/api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens/)
+-   [Rate Limiting]({{base_path}}/api-gateway/rate-limiting/understand-rate-limit-enforcement/)
+-   [Life Cycle Management]({{base_path}}/api-design-manage/design/lifecycle-management/api-lifecycle/)
+-   [API Monetization]({{base_path}}/monitoring/api-monetization/monetizing-an-api/)
+-   [API Visibility]({{base_path}}/api-design-manage/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/)
+-   [API Documentation]({{base_path}}/api-design-manage/design/api-documentation/add-api-documentation/)
+-   [Custom Properties]({{base_path}}/api-design-manage/design/create-api/adding-custom-properties-to-apis/)


### PR DESCRIPTION
## Purpose
Resolves #11444. The "See Also" section at the bottom of `create-a-rest-api.md` links to the legacy `{{base_path}}/manage-apis/...` URL scheme, while the rest of the page uses `{{base_path}}/api-design-manage/...`. This inconsistency was introduced by PR #10492, which migrated part of the page but left the See Also section on the old scheme.

## Goals
Make all 8 "See Also" links consistent with the rest of the page and point at each topic's actual current location.

## Approach
Checked `en/redirects.yml` and the current file tree rather than assuming a simple `manage-apis` -> `api-design-manage` swap is correct for every link. That swap is correct for 5 of the 8 links (Endpoints, Life Cycle Management, API Visibility, API Documentation, Custom Properties), but 3 of the pages (API Security, Rate Limiting, API Monetization) were relocated to different top-level sections entirely during a later reorganization:
- API Security -> `api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens/`
- Rate Limiting -> `api-gateway/rate-limiting/understand-rate-limit-enforcement/`
- API Monetization -> `monitoring/api-monetization/monetizing-an-api/`

Each of the 8 replacement targets was confirmed to exist as a real file in the repo before making the change.

## User stories
N/A

## Release note
Fixed inconsistent/stale links in the "See Also" section of the Create a REST API page.

## Documentation
This PR is the documentation fix itself.

## Training
N/A

## Certification
N/A - no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: N/A (documentation content change)
- Integration tests: N/A

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (markdown-only change, no code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
Companion PR targeting the 4.7.0 branch (same fix).

## Migrations (if applicable)
N/A

## Test environment
Verified each of the 8 replacement target files exists in the repository via the GitHub Contents API before applying the change; diffed the file to confirm only the 8 See Also lines changed.

## Learning
Cross-referenced `en/redirects.yml` against the actual file tree to find the true current location of each linked topic, since 3 of the 8 pages had moved to different top-level sections since PR #10492.