### PR TITLE
[4.7.0] Add Documentation for WebSocket Proxy Profiles

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-streaming-api/create-a-websocket-streaming-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-streaming-api/create-a-websocket-streaming-api.md
@@ -207,3 +207,5 @@ Once you create and publish a WebSocket API, you can also <a href="{{base_path}}
 ## See Also
 
 {!includes/design/stream-more-links.md!}
+
+- If your WebSocket backend is only reachable through an HTTP CONNECT proxy, see [Configure WebSocket Proxy Profiles]({{base_path}}/api-gateway/websocket-proxy-profiles).

--- a/en/docs/api-gateway/websocket-proxy-profiles.md
+++ b/en/docs/api-gateway/websocket-proxy-profiles.md
@@ -1,5 +1,9 @@
 # Configure WebSocket Proxy Profiles
 
+!!! note
+    - This feature is available in WSO2 API Manager 4.7.0 starting from update level 6.
+    - This feature is available in WSO2 API Manager Universal Gateway 4.7.0 starting from update level 6.
+
 ## Overview
 
 WebSocket proxy profiles allow the Classic Gateway to route outbound WebSocket connections (gateway → backend) through one or more HTTP CONNECT proxies. Each profile matches a set of backend hostnames and directs traffic to a specific proxy. You can define multiple profiles to send different backends through different proxies, require proxy authentication on a per-profile basis, or bypass the proxy entirely for selected hostnames.

--- a/en/docs/api-gateway/websocket-proxy-profiles.md
+++ b/en/docs/api-gateway/websocket-proxy-profiles.md
@@ -1,0 +1,181 @@
+# Configure WebSocket Proxy Profiles
+
+## Overview
+
+WebSocket proxy profiles allow the Classic Gateway to route outbound WebSocket connections (gateway → backend) through one or more HTTP CONNECT proxies. Each profile matches a set of backend hostnames and directs traffic to a specific proxy. You can define multiple profiles to send different backends through different proxies, require proxy authentication on a per-profile basis, or bypass the proxy entirely for selected hostnames.
+
+This configuration applies to both `ws://` and `wss://` backend endpoints and is independent of any inbound proxy or load balancer in front of API Manager.
+
+## How It Works
+
+When the gateway opens a connection to a WebSocket backend, it evaluates the configured proxy profiles against the backend hostname in the following order:
+
+1. **Specific profiles are checked first.** A profile is specific if its `target_hosts` list contains explicit patterns (not `*`). The hostname is matched against each pattern as a Java regular expression.
+2. **The first specific profile whose `target_hosts` matches wins.** Subsequent profiles are not evaluated.
+3. **If no specific profile matches, the catch-all profile (`target_hosts = ["*"]`) is used**, if one is configured.
+4. **If no profile matches at all, the connection is made directly** without a proxy.
+5. **`bypass_hosts` is evaluated within the winning profile.** If the backend hostname matches any pattern in `bypass_hosts`, the proxy for that profile is skipped and the connection is made directly.
+
+!!! note
+    `bypass_hosts` takes precedence over `target_hosts`. A hostname that matches both is always connected directly.
+
+## Configuration
+
+Proxy profiles are configured in `<APIM_HOME>/repository/conf/deployment.toml`. Add one `[[transport.ws.proxy_profile]]` block per profile for `ws://` backends and one `[[transport.wss.proxy_profile]]` block per profile for `wss://` backends.
+
+### Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `target_hosts` | Yes | List of Java regex patterns matched against the backend hostname. Use `["*"]` for a catch-all profile. Escape dots: `"example\\.com"`. |
+| `proxy_host` | Yes | Hostname or IP address of the HTTP CONNECT proxy. |
+| `proxy_port` | Yes | Port of the HTTP CONNECT proxy. |
+| `bypass_hosts` | No | List of Java regex patterns. Hosts matching any pattern connect directly, bypassing the proxy for this profile. |
+| `proxy_username` | No | Username for `Proxy-Authorization: Basic` authentication. Omit for an unauthenticated proxy. |
+| `proxy_password` | No | Password for proxy authentication. |
+
+### Example: Multiple Profiles
+
+```toml
+# Route payments backend through a dedicated proxy
+[[transport.ws.proxy_profile]]
+target_hosts = ["payments\\.internal\\.corp"]
+proxy_host = "proxy.payments.corp"
+proxy_port = 3128
+proxy_username = "gw_user"
+proxy_password = "gw_pass"
+
+# Route all other backends through the default proxy,
+# except localhost which should connect directly
+[[transport.ws.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+```
+
+For `wss://` backends, use `[[transport.wss.proxy_profile]]` with the same parameters:
+
+```toml
+[[transport.wss.proxy_profile]]
+target_hosts = ["payments\\.internal\\.corp"]
+proxy_host = "proxy.payments.corp"
+proxy_port = 3128
+proxy_username = "gw_user"
+proxy_password = "gw_pass"
+
+[[transport.wss.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+```
+
+!!! note
+    `[[transport.ws.proxy_profile]]` and `[[transport.wss.proxy_profile]]` are independent. If your WebSocket API has a `ws://` backend endpoint, only the `ws` profiles are evaluated. If it has a `wss://` backend, only the `wss` profiles are evaluated. Configure both sections if you serve both protocols.
+
+## Scenarios
+
+### Route a Backend Through an Anonymous Proxy
+
+Match a specific backend hostname and forward all traffic through a proxy. The proxy requires no authentication.
+
+```toml
+[[transport.ws.proxy_profile]]
+target_hosts = ["analytics\\.backend\\.corp"]
+proxy_host = "127.0.0.1"
+proxy_port = 3128
+```
+
+A WebSocket API with endpoint `ws://analytics.backend.corp:9090` will route its outbound connection through `127.0.0.1:3128` via an HTTP CONNECT tunnel.
+
+### Route a Backend Through an Authenticated Proxy
+
+Include `proxy_username` and `proxy_password`. The gateway sends a `Proxy-Authorization: Basic` header in the CONNECT request.
+
+```toml
+[[transport.ws.proxy_profile]]
+target_hosts = ["secure\\.backend\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+proxy_username = "gateway"
+proxy_password = "s3cr3t"
+```
+
+### Bypass the Proxy for Selected Hosts
+
+Use `bypass_hosts` within a profile to exclude specific backends from proxying. The host matches `target_hosts` so the profile applies, but `bypass_hosts` suppresses the proxy for that host.
+
+```toml
+[[transport.ws.proxy_profile]]
+target_hosts = [".*\\.internal\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+# dev-backend.internal.corp can be reached directly; bypass the proxy for it
+bypass_hosts = ["dev-backend\\.internal\\.corp"]
+```
+
+### Use a Catch-All Profile With Exclusions
+
+A `*` profile routes any backend not matched by a specific profile. Combine with `bypass_hosts` to carve out hosts that should connect directly.
+
+```toml
+# Specific profile: payments cluster has its own proxy
+[[transport.ws.proxy_profile]]
+target_hosts = [".*\\.payments\\.internal"]
+proxy_host = "payments-proxy.corp"
+proxy_port = 3128
+
+# Catch-all: everything else goes through the corporate proxy,
+# except the staging server which is reachable directly
+[[transport.ws.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["staging\\.ws\\.corp"]
+```
+
+### Connect to a WSS Backend Through a Proxy
+
+For `wss://` backend endpoints, the gateway opens a raw TCP tunnel through the proxy (HTTP CONNECT), then performs the TLS handshake with the backend directly inside that tunnel. The proxy does not terminate or inspect TLS.
+
+**Prerequisites:**
+
+1. Import the backend's TLS certificate (or the signing CA) into the API Manager client truststore:
+
+    ```bash
+    keytool -import -trustcacerts \
+      -alias my-backend \
+      -file /path/to/backend.crt \
+      -keystore <APIM_HOME>/repository/resources/security/client-truststore.jks \
+      -storepass wso2carbon -noprompt
+    ```
+
+2. Restart the server so the truststore change takes effect.
+
+3. Configure the `wss` proxy profile:
+
+    ```toml
+    [[transport.wss.proxy_profile]]
+    target_hosts = ["secure-backend\\.corp"]
+    proxy_host = "proxy.corp.internal"
+    proxy_port = 3128
+    ```
+
+## Limitations and Things to Note
+
+- **Server restart required.** Proxy profile configuration is read at startup. Changes to `deployment.toml` require a server restart to take effect.
+
+- **Regex matching is on the hostname string, not the resolved IP.** A profile with `target_hosts = ["127\\.0\\.0\\.1"]` matches only when the backend endpoint uses the IP `127.0.0.1` literally. It does not match `localhost` even though both resolve to the same address.
+
+- **Profile order matters only within the same priority class.** Among specific profiles (no `*`), the first matching profile wins. Declare more-specific patterns before broader ones to ensure the intended profile is selected.
+
+- **A single `*` catch-all is supported.** Defining more than one catch-all profile is allowed syntactically, but only the first one is applied.
+
+- **Only Basic authentication is supported** for `proxy_username` / `proxy_password`. The gateway sends `Proxy-Authorization: Basic <base64(user:pass)>`.
+
+- **`ws` and `wss` profiles are independent.** `[[transport.ws.proxy_profile]]` entries have no effect on `wss://` backends and vice versa. Define both if you use both protocols.
+
+- **WSS backend certificates must be trusted by the gateway.** When connecting to a `wss://` backend through a proxy, the gateway performs TLS with the backend after the CONNECT tunnel is established. The backend's certificate must be present in the client truststore (`client-truststore.jks`), and the server must be restarted after importing the certificate.
+
+- **Proxy profiles apply to outbound backend connections only.** They do not affect inbound traffic from API clients to the gateway, or HTTP/REST API backends. Only WebSocket transport senders (`ws` and `wss`) use this configuration.

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -144,7 +144,7 @@ disable_restart_from_ui = false</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Use this paramater to enable MTOM (Message Transmission Optimization Mechanism) for the product server.</p>
+                                        <p>Use this parameter to enable MTOM (Message Transmission Optimization Mechanism) for the product server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -165,7 +165,7 @@ disable_restart_from_ui = false</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Use this paramater to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages.</p>
+                                        <p>Use this parameter to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -1652,7 +1652,7 @@ tenants = "*"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Comma seperated list of tenants to be loaded on the gateway. Use * to load all tenants</p>
+                                        <p>Comma separated list of tenants to be loaded on the gateway. Use * to load all tenants</p>
                                     </div>
                                 </div>
                             </div>
@@ -2222,7 +2222,7 @@ enable = true</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Enabel cache for scopes. This expires in 15 minutes by default.</p>
+                                        <p>Enable cache for scopes. This expires in 15 minutes by default.</p>
                                     </div>
                                 </div>
                             </div>
@@ -2889,7 +2889,7 @@ enable_application_scopes_for_resident_km = false</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>You can provide a custom key validation handler implmentation. To do this, set the &quot;key_validation_handler_type&quot; to custom</p>
+                                        <p>You can provide a custom key validation handler implementation. To do this, set the &quot;key_validation_handler_type&quot; to custom</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -7525,7 +7525,7 @@ execution_interval_in_ms = "-1"</code></pre>
                             <code>[multi_tenancy.usage_agent.data_persistence_task]</code>
                             
                             <p>
-                                Configures the data presistance for user agents in multi-tenant mode.
+                                Configures the data persistence for user agents in multi-tenant mode.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -7545,7 +7545,7 @@ execution_interval_in_ms = "-1"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Connection delay to start data presistance at startup.</p>
+                                        <p>Connection delay to start data persistence at startup.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -7583,7 +7583,7 @@ execution_interval_in_ms = "-1"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time between execution cycles in miliseconds.</p>
+                                        <p>Time between execution cycles in milliseconds.</p>
                                     </div>
                                 </div>
                             </div>
@@ -7697,7 +7697,7 @@ delay = "60"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time interval betweeen throttling manager tasks.</p>
+                                        <p>Time interval between throttling manager tasks.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12683,7 +12683,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;application_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;application_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12704,7 +12704,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;form_urlencoded&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;form_urlencoded&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12725,7 +12725,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;multipart_form_data&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;multipart_form_data&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12746,7 +12746,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;text_plain&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;text_plain&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12767,7 +12767,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;application_json&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;application_json&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12788,7 +12788,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;json_badgerfish&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;json_badgerfish&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12809,7 +12809,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;text_javascript&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;text_javascript&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12830,7 +12830,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;octet_stream&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;octet_stream&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12851,7 +12851,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;application_binary&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;application_binary&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12872,7 +12872,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;text_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;text_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12893,7 +12893,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formating implementation that formats messages with the &#39;soap_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;soap_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
                                     </div>
                                 </div>
                             </div>
@@ -13772,7 +13772,7 @@ timeout_factor = 3.0</code></pre>
                             <code>[qpid.heartbeat]</code>
                             
                             <p>
-                                This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid brocker component of Traffic Manager. You need to to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.
+                                This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid broker component of Traffic Manager. You need to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -13999,7 +13999,7 @@ monitored.user.stores = "primary,sec"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>An array of domain names of the userstores to monitor health. If not given, health is monitered on all the super tenant secondary user stores.</p>
+                                        <p>An array of domain names of the userstores to monitor health. If not given, health is monitored on all the super tenant secondary user stores.</p>
                                     </div>
                                 </div>
                             </div>
@@ -14149,7 +14149,7 @@ monitored.datasources = "jdbc/WSO2AM_DB,jdbc/SHARED_DB,jdbc/WSO2CarbonDB"</code>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>An array of jndiConfig names of datasources to monitor health. If not given, health is monitered on all the datastores.</p>
+                                        <p>An array of jndiConfig names of datasources to monitor health. If not given, health is monitored on all the datastores.</p>
                                     </div>
                                 </div>
                             </div>
@@ -15076,7 +15076,7 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable to allow refresh tokens for client credentails grant.</p>
+                                        <p>Enable to allow refresh tokens for client credentials grant.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -15097,7 +15097,7 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable to allow ID tokens for client credentails grant.</p>
+                                        <p>Enable to allow ID tokens for client credentials grant.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -16036,7 +16036,7 @@ UserCoreCacheTimeOut = 5 </code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>(LDAP) The patten for the user&#39;s DN, which can be defined to improve the search. When there are many user entries in the LDAP user store, defining a UserDNPattern provides more impact on performances as the LDAP does not have to travel through the entire tree to find users.</p>
+                                        <p>(LDAP) The pattern for the user&#39;s DN, which can be defined to improve the search. When there are many user entries in the LDAP user store, defining a UserDNPattern provides more impact on performances as the LDAP does not have to travel through the entire tree to find users.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -17819,8 +17819,8 @@ retry_max_attempts = 2
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="120" type="checkbox" id="_tab_120">
-                <label class="tab-selector" for="_tab_120"><i class="icon fa fa-code"></i></label>
+            <input name="121" type="checkbox" id="_tab_121">
+                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[dependency_properties]
@@ -17876,8 +17876,8 @@ retry_max_attempts = 2
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="121" type="checkbox" id="_tab_121">
-                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
+            <input name="122" type="checkbox" id="_tab_122">
+                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[authentication.authenticator.oidc.parameters]
@@ -17935,8 +17935,8 @@ excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="122" type="checkbox" id="_tab_122">
-                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
+            <input name="123" type="checkbox" id="_tab_123">
+                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.embedding_provider]
@@ -18064,8 +18064,8 @@ embedding_model = "<embedding-model>"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="123" type="checkbox" id="_tab_123">
-                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
+            <input name="124" type="checkbox" id="_tab_124">
+                <label class="tab-selector" for="_tab_124"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.vector_db_provider]

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -12012,12 +12012,13 @@ sender.trust_store.password = "$ref{truststore.password}"</code></pre>
                 <label class="tab-selector" for="_tab_79"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
-<pre><code class="toml">[[transport.ws.proxy_profile]]
+<pre><code class="toml"># Example deployment.toml entry
+[[transport.ws.proxy_profile]]
 target_hosts = ["example\\.backend\\.corp"]
 proxy_host = "proxy.corp.internal"
 proxy_port = 3128
-proxy_username = "gateway"
-proxy_password = "s3cr3t"
+proxy_username = "<proxy-username>"
+proxy_password = "<proxy-password>"
 bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
 
 [[transport.ws.proxy_profile]]
@@ -12049,7 +12050,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>[&quot;example&#92;&#92;.com&quot;], [&quot;*&quot;]</code></span>
@@ -12070,7 +12071,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12091,7 +12092,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12112,7 +12113,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>[&quot;localhost&quot;, &quot;127&#92;&#92;.0&#92;&#92;.0&#92;&#92;.1&quot;]</code></span>
@@ -12133,7 +12134,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12154,7 +12155,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12187,12 +12188,13 @@ bypass_hosts = ["localhost"]
                 <label class="tab-selector" for="_tab_80"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
-<pre><code class="toml">[[transport.wss.proxy_profile]]
+<pre><code class="toml"># Example deployment.toml entry
+[[transport.wss.proxy_profile]]
 target_hosts = ["secure-backend\\.corp"]
 proxy_host = "proxy.corp.internal"
 proxy_port = 3128
-proxy_username = "gateway"
-proxy_password = "s3cr3t"
+proxy_username = "<proxy-username>"
+proxy_password = "<proxy-password>"
 bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
 
 [[transport.wss.proxy_profile]]
@@ -12224,7 +12226,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>[&quot;example&#92;&#92;.com&quot;], [&quot;*&quot;]</code></span>
@@ -12245,7 +12247,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12266,7 +12268,7 @@ bypass_hosts = ["localhost"]
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12287,7 +12289,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>[&quot;localhost&quot;, &quot;127&#92;&#92;.0&#92;&#92;.0&#92;&#92;.1&quot;]</code></span>
@@ -12308,7 +12310,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -12329,7 +12331,7 @@ bypass_hosts = ["localhost"]
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-</code></span>
+                                            <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
@@ -17738,8 +17740,8 @@ retry_max_attempts = 2
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="119" type="checkbox" id="_tab_119">
-                <label class="tab-selector" for="_tab_119"><i class="icon fa fa-code"></i></label>
+            <input name="121" type="checkbox" id="_tab_121">
+                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[synapse_properties]
@@ -17819,8 +17821,8 @@ retry_max_attempts = 2
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="121" type="checkbox" id="_tab_121">
-                <label class="tab-selector" for="_tab_121"><i class="icon fa fa-code"></i></label>
+            <input name="122" type="checkbox" id="_tab_122">
+                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[dependency_properties]
@@ -17876,8 +17878,8 @@ retry_max_attempts = 2
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="122" type="checkbox" id="_tab_122">
-                <label class="tab-selector" for="_tab_122"><i class="icon fa fa-code"></i></label>
+            <input name="123" type="checkbox" id="_tab_123">
+                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[authentication.authenticator.oidc.parameters]
@@ -17935,8 +17937,8 @@ excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="123" type="checkbox" id="_tab_123">
-                <label class="tab-selector" for="_tab_123"><i class="icon fa fa-code"></i></label>
+            <input name="124" type="checkbox" id="_tab_124">
+                <label class="tab-selector" for="_tab_124"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.embedding_provider]
@@ -18064,8 +18066,8 @@ embedding_model = "<embedding-model>"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="124" type="checkbox" id="_tab_124">
-                <label class="tab-selector" for="_tab_124"><i class="icon fa fa-code"></i></label>
+            <input name="125" type="checkbox" id="_tab_125">
+                <label class="tab-selector" for="_tab_125"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.ai.vector_db_provider]

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -144,7 +144,7 @@ disable_restart_from_ui = false</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Use this parameter to enable MTOM (Message Transmission Optimization Mechanism) for the product server.</p>
+                                        <p>Use this paramater to enable MTOM (Message Transmission Optimization Mechanism) for the product server.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -165,7 +165,7 @@ disable_restart_from_ui = false</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Use this parameter to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages.</p>
+                                        <p>Use this paramater to enable SwA (SOAP with Attachments) for the product server. When SwA is enabled, the API Manager will process the files attached to SOAP messages.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -1652,7 +1652,7 @@ tenants = "*"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Comma separated list of tenants to be loaded on the gateway. Use * to load all tenants</p>
+                                        <p>Comma seperated list of tenants to be loaded on the gateway. Use * to load all tenants</p>
                                     </div>
                                 </div>
                             </div>
@@ -2222,7 +2222,7 @@ enable = true</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable cache for scopes. This expires in 15 minutes by default.</p>
+                                        <p>Enabel cache for scopes. This expires in 15 minutes by default.</p>
                                     </div>
                                 </div>
                             </div>
@@ -2889,7 +2889,7 @@ enable_application_scopes_for_resident_km = false</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>You can provide a custom key validation handler implementation. To do this, set the &quot;key_validation_handler_type&quot; to custom</p>
+                                        <p>You can provide a custom key validation handler implmentation. To do this, set the &quot;key_validation_handler_type&quot; to custom</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -7525,7 +7525,7 @@ execution_interval_in_ms = "-1"</code></pre>
                             <code>[multi_tenancy.usage_agent.data_persistence_task]</code>
                             
                             <p>
-                                Configures the data persistence for user agents in multi-tenant mode.
+                                Configures the data presistance for user agents in multi-tenant mode.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -7545,7 +7545,7 @@ execution_interval_in_ms = "-1"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Connection delay to start data persistence at startup.</p>
+                                        <p>Connection delay to start data presistance at startup.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -7583,7 +7583,7 @@ execution_interval_in_ms = "-1"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time between execution cycles in milliseconds.</p>
+                                        <p>Time between execution cycles in miliseconds.</p>
                                     </div>
                                 </div>
                             </div>
@@ -7697,7 +7697,7 @@ delay = "60"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time interval between throttling manager tasks.</p>
+                                        <p>Time interval betweeen throttling manager tasks.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12000,7 +12000,7 @@ sender.trust_store.password = "$ref{truststore.password}"</code></pre>
 
 
 
-## Message Builders (non-blocking mode)
+## WebSocket Proxy Profile
 
 
 <div class="mb-config-catalog">
@@ -12010,6 +12010,356 @@ sender.trust_store.password = "$ref{truststore.password}"</code></pre>
             
             <input name="79" type="checkbox" id="_tab_79">
                 <label class="tab-selector" for="_tab_79"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[[transport.ws.proxy_profile]]
+target_hosts = ["example\\.backend\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+proxy_username = "gateway"
+proxy_password = "s3cr3t"
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+
+[[transport.ws.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost"]
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[[transport.ws.proxy_profile]]</code>
+                            
+                            <p>
+                                Configures an HTTP CONNECT proxy profile for outbound WebSocket (ws://) connections from the gateway to the backend. Multiple profiles can be defined; the gateway evaluates them in order and uses the first matching profile. Specific profiles (no wildcard in target_hosts) are evaluated before the catch-all profile (target_hosts = ["*"]).
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>target_hosts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>[&quot;example&#92;&#92;.com&quot;], [&quot;*&quot;]</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>A list of Java regular expression patterns matched against the backend hostname. Use [&quot;*&quot;] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: &quot;example&#92;&#92;.com&quot;.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_host</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Hostname or IP address of the HTTP CONNECT proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_port</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Port number of the HTTP CONNECT proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>bypass_hosts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>[&quot;localhost&quot;, &quot;127&#92;&#92;.0&#92;&#92;.0&#92;&#92;.1&quot;]</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Password for proxy authentication.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Secure WebSocket Proxy Profile
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="80" type="checkbox" id="_tab_80">
+                <label class="tab-selector" for="_tab_80"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[[transport.wss.proxy_profile]]
+target_hosts = ["secure-backend\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+proxy_username = "gateway"
+proxy_password = "s3cr3t"
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+
+[[transport.wss.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost"]
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[[transport.wss.proxy_profile]]</code>
+                            
+                            <p>
+                                Configures an HTTP CONNECT proxy profile for outbound secure WebSocket (wss://) connections from the gateway to the backend. The gateway opens a raw TCP tunnel through the proxy via HTTP CONNECT, then performs TLS with the backend inside that tunnel. Multiple profiles can be defined; evaluation rules are the same as for ws proxy profiles.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>target_hosts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>[&quot;example&#92;&#92;.com&quot;], [&quot;*&quot;]</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>A list of Java regular expression patterns matched against the backend hostname. Use [&quot;*&quot;] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: &quot;example&#92;&#92;.com&quot;.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_host</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Hostname or IP address of the HTTP CONNECT proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_port</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Port number of the HTTP CONNECT proxy server.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>bypass_hosts</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>[&quot;localhost&quot;, &quot;127&#92;&#92;.0&#92;&#92;.0&#92;&#92;.1&quot;]</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>proxy_password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>-</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Password for proxy authentication.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## Message Builders (non-blocking mode)
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="81" type="checkbox" id="_tab_81">
+                <label class="tab-selector" for="_tab_81"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[message_builders]
@@ -12242,8 +12592,8 @@ application_binary = "org.apache.axis2.format.BinaryBuilder"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="80" type="checkbox" id="_tab_80">
-                <label class="tab-selector" for="_tab_80"><i class="icon fa fa-code"></i></label>
+            <input name="82" type="checkbox" id="_tab_82">
+                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[blocking.message_builders]
@@ -12287,8 +12637,8 @@ application_binary = "org.apache.axis2.format.BinaryBuilder"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="81" type="checkbox" id="_tab_81">
-                <label class="tab-selector" for="_tab_81"><i class="icon fa fa-code"></i></label>
+            <input name="83" type="checkbox" id="_tab_83">
+                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[message_formatters]
@@ -12333,7 +12683,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;application_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;application_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12354,7 +12704,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;form_urlencoded&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;form_urlencoded&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12375,7 +12725,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;multipart_form_data&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;multipart_form_data&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12396,7 +12746,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;text_plain&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;text_plain&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12417,7 +12767,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;application_json&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;application_json&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12438,7 +12788,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;json_badgerfish&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;json_badgerfish&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12459,7 +12809,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;text_javascript&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;text_javascript&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12480,7 +12830,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;octet_stream&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formatting implementation that formats messages with the &#39;octet_stream&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12501,7 +12851,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;application_binary&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;application_binary&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12522,7 +12872,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;text_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;text_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -12543,7 +12893,7 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The message formatting implementation that formats messages with the &#39;soap_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formatting class.</p>
+                                        <p>The message formating implementation that formats messages with the &#39;soap_xml&#39; content type before they are sent out of the Micro Integrator. If required, you can change the default formating class.</p>
                                     </div>
                                 </div>
                             </div>
@@ -12565,8 +12915,8 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="82" type="checkbox" id="_tab_82">
-                <label class="tab-selector" for="_tab_82"><i class="icon fa fa-code"></i></label>
+            <input name="84" type="checkbox" id="_tab_84">
+                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[blocking.message_formatters]
@@ -12612,8 +12962,8 @@ application_binary =  "org.apache.axis2.format.BinaryFormatter"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="83" type="checkbox" id="_tab_83">
-                <label class="tab-selector" for="_tab_83"><i class="icon fa fa-code"></i></label>
+            <input name="85" type="checkbox" id="_tab_85">
+                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[custom_message_builders]]
@@ -12692,8 +13042,8 @@ class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="84" type="checkbox" id="_tab_84">
-                <label class="tab-selector" for="_tab_84"><i class="icon fa fa-code"></i></label>
+            <input name="86" type="checkbox" id="_tab_86">
+                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[blocking.custom_message_builders]]
@@ -12730,8 +13080,8 @@ class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="85" type="checkbox" id="_tab_85">
-                <label class="tab-selector" for="_tab_85"><i class="icon fa fa-code"></i></label>
+            <input name="87" type="checkbox" id="_tab_87">
+                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[custom_message_formatters]]
@@ -12810,8 +13160,8 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="86" type="checkbox" id="_tab_86">
-                <label class="tab-selector" for="_tab_86"><i class="icon fa fa-code"></i></label>
+            <input name="88" type="checkbox" id="_tab_88">
+                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[blocking.custom_message_formatters]]
@@ -12848,8 +13198,8 @@ class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="87" type="checkbox" id="_tab_87">
-                <label class="tab-selector" for="_tab_87"><i class="icon fa fa-code"></i></label>
+            <input name="89" type="checkbox" id="_tab_89">
+                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[message_formatter.options]
@@ -12929,8 +13279,8 @@ preserveMultipartPartContentTransferEncoding = true
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="88" type="checkbox" id="_tab_88">
-                <label class="tab-selector" for="_tab_88"><i class="icon fa fa-code"></i></label>
+            <input name="90" type="checkbox" id="_tab_90">
+                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[mediation]
@@ -13267,8 +13617,8 @@ inbound.max_threads = 100</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="89" type="checkbox" id="_tab_89">
-                <label class="tab-selector" for="_tab_89"><i class="icon fa fa-code"></i></label>
+            <input name="91" type="checkbox" id="_tab_91">
+                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">enabled_global_handlers= ["custom_logger"]
@@ -13349,8 +13699,8 @@ custom_logger.class= "com.wso2.apim.log.handler.SynapseLogHandler"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="90" type="checkbox" id="_tab_90">
-                <label class="tab-selector" for="_tab_90"><i class="icon fa fa-code"></i></label>
+            <input name="92" type="checkbox" id="_tab_92">
+                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[governance]
@@ -13407,8 +13757,8 @@ life_cycle_checklist_items_enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="91" type="checkbox" id="_tab_91">
-                <label class="tab-selector" for="_tab_91"><i class="icon fa fa-code"></i></label>
+            <input name="93" type="checkbox" id="_tab_93">
+                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[qpid.heartbeat]
@@ -13422,7 +13772,7 @@ timeout_factor = 3.0</code></pre>
                             <code>[qpid.heartbeat]</code>
                             
                             <p>
-                                This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid broker component of Traffic Manager. You need to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.
+                                This includes configurations related to the frequency of the internal heartbeat sent by the underlying Qpid brocker component of Traffic Manager. You need to to configure a proper delay for the heartbeat value if the connections will stay idle for a long time.
                             </p>
                         </div>
                         <div class="params-wrap">
@@ -13483,8 +13833,8 @@ timeout_factor = 3.0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="92" type="checkbox" id="_tab_92">
-                <label class="tab-selector" for="_tab_92"><i class="icon fa fa-code"></i></label>
+            <input name="94" type="checkbox" id="_tab_94">
+                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check]
@@ -13539,8 +13889,8 @@ enable = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="93" type="checkbox" id="_tab_93">
-                <label class="tab-selector" for="_tab_93"><i class="icon fa fa-code"></i></label>
+            <input name="95" type="checkbox" id="_tab_95">
+                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker]
@@ -13615,8 +13965,8 @@ order = "98"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="94" type="checkbox" id="_tab_94">
-                <label class="tab-selector" for="_tab_94"><i class="icon fa fa-code"></i></label>
+            <input name="96" type="checkbox" id="_tab_96">
+                <label class="tab-selector" for="_tab_96"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.super_tenant_health_checker.properties]
@@ -13649,7 +13999,7 @@ monitored.user.stores = "primary,sec"</code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>An array of domain names of the userstores to monitor health. If not given, health is monitored on all the super tenant secondary user stores.</p>
+                                        <p>An array of domain names of the userstores to monitor health. If not given, health is monitered on all the super tenant secondary user stores.</p>
                                     </div>
                                 </div>
                             </div>
@@ -13669,8 +14019,8 @@ monitored.user.stores = "primary,sec"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="95" type="checkbox" id="_tab_95">
-                <label class="tab-selector" for="_tab_95"><i class="icon fa fa-code"></i></label>
+            <input name="97" type="checkbox" id="_tab_97">
+                <label class="tab-selector" for="_tab_97"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker]
@@ -13745,8 +14095,8 @@ order = "97"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="96" type="checkbox" id="_tab_96">
-                <label class="tab-selector" for="_tab_96"><i class="icon fa fa-code"></i></label>
+            <input name="98" type="checkbox" id="_tab_98">
+                <label class="tab-selector" for="_tab_98"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[carbon_health_check.health_checker.data_source_health_checker.properties]
@@ -13799,7 +14149,7 @@ monitored.datasources = "jdbc/WSO2AM_DB,jdbc/SHARED_DB,jdbc/WSO2CarbonDB"</code>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>An array of jndiConfig names of datasources to monitor health. If not given, health is monitored on all the datastores.</p>
+                                        <p>An array of jndiConfig names of datasources to monitor health. If not given, health is monitered on all the datastores.</p>
                                     </div>
                                 </div>
                             </div>
@@ -13819,8 +14169,8 @@ monitored.datasources = "jdbc/WSO2AM_DB,jdbc/SHARED_DB,jdbc/WSO2CarbonDB"</code>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="97" type="checkbox" id="_tab_97">
-                <label class="tab-selector" for="_tab_97"><i class="icon fa fa-code"></i></label>
+            <input name="99" type="checkbox" id="_tab_99">
+                <label class="tab-selector" for="_tab_99"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[health_checker]
@@ -13916,8 +14266,8 @@ first_property = "value"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="98" type="checkbox" id="_tab_98">
-                <label class="tab-selector" for="_tab_98"><i class="icon fa fa-code"></i></label>
+            <input name="100" type="checkbox" id="_tab_100">
+                <label class="tab-selector" for="_tab_100"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth]
@@ -14095,8 +14445,8 @@ token_context_dialect_uri = "http://wso2.org/claims"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="99" type="checkbox" id="_tab_99">
-                <label class="tab-selector" for="_tab_99"><i class="icon fa fa-code"></i></label>
+            <input name="101" type="checkbox" id="_tab_101">
+                <label class="tab-selector" for="_tab_101"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_validation]
@@ -14190,8 +14540,8 @@ refresh_token_validity = "86400"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="100" type="checkbox" id="_tab_100">
-                <label class="tab-selector" for="_tab_100"><i class="icon fa fa-code"></i></label>
+            <input name="102" type="checkbox" id="_tab_102">
+                <label class="tab-selector" for="_tab_102"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_cleanup]
@@ -14268,8 +14618,8 @@ retain_access_tokens_for_auditing = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="101" type="checkbox" id="_tab_101">
-                <label class="tab-selector" for="_tab_101"><i class="icon fa fa-code"></i></label>
+            <input name="103" type="checkbox" id="_tab_103">
+                <label class="tab-selector" for="_tab_103"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.oidc.extensions]
@@ -14497,8 +14847,8 @@ enable_unmapped_user_attributes = true
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="102" type="checkbox" id="_tab_102">
-                <label class="tab-selector" for="_tab_102"><i class="icon fa fa-code"></i></label>
+            <input name="104" type="checkbox" id="_tab_104">
+                <label class="tab-selector" for="_tab_104"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.grant_type.authorization_code]
@@ -14726,7 +15076,7 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable to allow refresh tokens for client credentials grant.</p>
+                                        <p>Enable to allow refresh tokens for client credentails grant.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -14747,7 +15097,7 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Enable to allow ID tokens for client credentials grant.</p>
+                                        <p>Enable to allow ID tokens for client credentails grant.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -14986,8 +15336,8 @@ grant_validator = "org.wso2.carbon.identity.oauth2.grant.kerberos.KerberosGrantV
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="103" type="checkbox" id="_tab_103">
-                <label class="tab-selector" for="_tab_103"><i class="icon fa fa-code"></i></label>
+            <input name="105" type="checkbox" id="_tab_105">
+                <label class="tab-selector" for="_tab_105"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[session_data.persistence]
@@ -15040,8 +15390,8 @@ persistence_pool_size = 0</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="104" type="checkbox" id="_tab_104">
-                <label class="tab-selector" for="_tab_104"><i class="icon fa fa-code"></i></label>
+            <input name="106" type="checkbox" id="_tab_106">
+                <label class="tab-selector" for="_tab_106"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[oauth.token_generation]
@@ -15096,8 +15446,8 @@ retry_count_on_persistence_failures = 5</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="105" type="checkbox" id="_tab_105">
-                <label class="tab-selector" for="_tab_105"><i class="icon fa fa-code"></i></label>
+            <input name="107" type="checkbox" id="_tab_107">
+                <label class="tab-selector" for="_tab_107"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[user_store.properties]
@@ -15686,7 +16036,7 @@ UserCoreCacheTimeOut = 5 </code></pre>
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>(LDAP) The pattern for the user&#39;s DN, which can be defined to improve the search. When there are many user entries in the LDAP user store, defining a UserDNPattern provides more impact on performances as the LDAP does not have to travel through the entire tree to find users.</p>
+                                        <p>(LDAP) The patten for the user&#39;s DN, which can be defined to improve the search. When there are many user entries in the LDAP user store, defining a UserDNPattern provides more impact on performances as the LDAP does not have to travel through the entire tree to find users.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -15925,8 +16275,8 @@ UserCoreCacheTimeOut = 5 </code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="106" type="checkbox" id="_tab_106">
-                <label class="tab-selector" for="_tab_106"><i class="icon fa fa-code"></i></label>
+            <input name="108" type="checkbox" id="_tab_108">
+                <label class="tab-selector" for="_tab_108"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[custom_keystore.APIKeyKeyStore]
@@ -16061,8 +16411,8 @@ key_password = "wso2carbon"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="107" type="checkbox" id="_tab_107">
-                <label class="tab-selector" for="_tab_107"><i class="icon fa fa-code"></i></label>
+            <input name="109" type="checkbox" id="_tab_109">
+                <label class="tab-selector" for="_tab_109"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[http_access_log]
@@ -16119,8 +16469,8 @@ enabled = true</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="108" type="checkbox" id="_tab_108">
-                <label class="tab-selector" for="_tab_108"><i class="icon fa fa-code"></i></label>
+            <input name="110" type="checkbox" id="_tab_110">
+                <label class="tab-selector" for="_tab_110"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">#### Sample deployment.toml entry
@@ -16467,8 +16817,8 @@ mediaType = "application/vnd.wso2-service+xml"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="109" type="checkbox" id="_tab_109">
-                <label class="tab-selector" for="_tab_109"><i class="icon fa fa-code"></i></label>
+            <input name="111" type="checkbox" id="_tab_111">
+                <label class="tab-selector" for="_tab_111"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.transport_headers]
@@ -16608,8 +16958,8 @@ excludeResponseHeaders = ""
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="110" type="checkbox" id="_tab_110">
-                <label class="tab-selector" for="_tab_110"><i class="icon fa fa-code"></i></label>
+            <input name="112" type="checkbox" id="_tab_112">
+                <label class="tab-selector" for="_tab_112"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[synapse_handlers.custom_handler_name]
@@ -16685,8 +17035,8 @@ class="org.wso2.carbon.apimgt.gateway.handlers.custom.customer_handler"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="111" type="checkbox" id="_tab_111">
-                <label class="tab-selector" for="_tab_111"><i class="icon fa fa-code"></i></label>
+            <input name="113" type="checkbox" id="_tab_113">
+                <label class="tab-selector" for="_tab_113"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.governance.scheduler]
@@ -16802,8 +17152,8 @@ task_cleanup_interval_minutes = 30
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="112" type="checkbox" id="_tab_112">
-                <label class="tab-selector" for="_tab_112"><i class="icon fa fa-code"></i></label>
+            <input name="114" type="checkbox" id="_tab_114">
+                <label class="tab-selector" for="_tab_114"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.mediator_config.oauth.trust_store]
@@ -16896,8 +17246,8 @@ password = "wso2carbon"</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="113" type="checkbox" id="_tab_113">
-                <label class="tab-selector" for="_tab_113"><i class="icon fa fa-code"></i></label>
+            <input name="115" type="checkbox" id="_tab_115">
+                <label class="tab-selector" for="_tab_115"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[transport.receiver]
@@ -16949,8 +17299,8 @@ max_reconnection_interval = 3600
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="114" type="checkbox" id="_tab_114">
-                <label class="tab-selector" for="_tab_114"><i class="icon fa fa-code"></i></label>
+            <input name="116" type="checkbox" id="_tab_116">
+                <label class="tab-selector" for="_tab_116"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.basic_authenticator]
@@ -17066,8 +17416,8 @@ max_wait_millis = 30000
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="115" type="checkbox" id="_tab_115">
-                <label class="tab-selector" for="_tab_115"><i class="icon fa fa-code"></i></label>
+            <input name="117" type="checkbox" id="_tab_117">
+                <label class="tab-selector" for="_tab_117"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.synapse_artifact_generator.thread_pool]
@@ -17182,8 +17532,8 @@ queue_capacity = 50</code></pre>
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="116" type="checkbox" id="_tab_116">
-                <label class="tab-selector" for="_tab_116"><i class="icon fa fa-code"></i></label>
+            <input name="118" type="checkbox" id="_tab_118">
+                <label class="tab-selector" for="_tab_118"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[encryption]
@@ -17239,8 +17589,8 @@ key = "<generated-64-char-hex-key>"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="117" type="checkbox" id="_tab_117">
-                <label class="tab-selector" for="_tab_117"><i class="icon fa fa-code"></i></label>
+            <input name="119" type="checkbox" id="_tab_119">
+                <label class="tab-selector" for="_tab_119"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[web_app.cookie_processor]
@@ -17298,8 +17648,8 @@ same_site_cookies = "lax"
         <div class="mb-config-options">
             <div class="superfences-tabs">
             
-            <input name="118" type="checkbox" id="_tab_118">
-                <label class="tab-selector" for="_tab_118"><i class="icon fa fa-code"></i></label>
+            <input name="120" type="checkbox" id="_tab_120">
+                <label class="tab-selector" for="_tab_120"><i class="icon fa fa-code"></i></label>
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.aws_lambda]

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -980,8 +980,8 @@ extra:
             version: 1.2.0-1
             git_tag: v1.2.0.1
     site_version: 4.7.0
-    base_path: http://localhost:8000/en/4.7.0
-    #base_path: https://apim.docs.wso2.com/en/4.7.0
+    #base_path: http://localhost:8000/en/4.7.0
+    base_path: https://apim.docs.wso2.com/en/4.7.0
     envoy_path: https://www.envoyproxy.io/docs/envoy/v1.24.1
     redoc_theme: '{
         "colors": {

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -459,6 +459,7 @@ nav:
                 - Classic Gateway with Dedicated Tenants: api-gateway/maintain-seperate-gateways-per-tenants.md
                 - Classic Gateways with Dedicated Backends: api-gateway/api-gateways-with-dedicated-backends.md
                 - Mutual SSL Between Classic Gateway and Backend: api-gateway/mutual-ssl-between-api-gateway-and-backend.md
+                - WebSocket Proxy Profiles: api-gateway/websocket-proxy-profiles.md
                 - Storing Custom Synapse Artifacts in the Gateway: api-gateway/custom-synapse-artifacts.md
             - Gateway Policies:
                 - Adding Dynamic Endpoints: api-gateway/policies/adding-dynamic-endpoints.md
@@ -979,8 +980,8 @@ extra:
             version: 1.2.0-1
             git_tag: v1.2.0.1
     site_version: 4.7.0
-    #base_path: http://localhost:8000/en/4.7.0
-    base_path: https://apim.docs.wso2.com/en/4.7.0
+    base_path: http://localhost:8000/en/4.7.0
+    #base_path: https://apim.docs.wso2.com/en/4.7.0
     envoy_path: https://www.envoyproxy.io/docs/envoy/v1.24.1
     redoc_theme: '{
         "colors": {

--- a/en/tools/config-catalog-generator/data/_ws-proxy-profile.toml
+++ b/en/tools/config-catalog-generator/data/_ws-proxy-profile.toml
@@ -1,0 +1,14 @@
+# Example deployment.toml entry
+[[transport.ws.proxy_profile]]
+target_hosts = ["example\\.backend\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+proxy_username = "<proxy-username>"
+proxy_password = "<proxy-password>"
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+
+[[transport.ws.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost"]

--- a/en/tools/config-catalog-generator/data/_wss-proxy-profile.toml
+++ b/en/tools/config-catalog-generator/data/_wss-proxy-profile.toml
@@ -1,0 +1,14 @@
+# Example deployment.toml entry
+[[transport.wss.proxy_profile]]
+target_hosts = ["secure-backend\\.corp"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+proxy_username = "<proxy-username>"
+proxy_password = "<proxy-password>"
+bypass_hosts = ["localhost", "127\\.0\\.0\\.1"]
+
+[[transport.wss.proxy_profile]]
+target_hosts = ["*"]
+proxy_host = "proxy.corp.internal"
+proxy_port = 3128
+bypass_hosts = ["localhost"]

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -4501,6 +4501,128 @@
             "exampleFile": "_wss-transport.toml"
         },
         {
+            "title": "WebSocket Proxy Profile",
+            "options": [
+                {
+                    "name": "[transport.ws.proxy_profile]",
+                    "required": false,
+                    "description": "Configures an HTTP CONNECT proxy profile for outbound WebSocket (ws://) connections from the gateway to the backend. Multiple profiles can be defined; the gateway evaluates them in order and uses the first matching profile. Specific profiles (no wildcard in target_hosts) are evaluated before the catch-all profile (target_hosts = [\"*\"]).",
+                    "params": [
+                        {
+                            "name": "target_hosts",
+                            "type": "string",
+                            "required": true,
+                            "default": "-",
+                            "possible": "[\"example\\\\.com\"], [\"*\"]",
+                            "description": "A list of Java regular expression patterns matched against the backend hostname. Use [\"*\"] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: \"example\\\\.com\"."
+                        },
+                        {
+                            "name": "proxy_host",
+                            "type": "string",
+                            "required": true,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Hostname or IP address of the HTTP CONNECT proxy server."
+                        },
+                        {
+                            "name": "proxy_port",
+                            "type": "integer",
+                            "required": true,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Port number of the HTTP CONNECT proxy server."
+                        },
+                        {
+                            "name": "bypass_hosts",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "[\"localhost\", \"127\\\\.0\\\\.0\\\\.1\"]",
+                            "description": "A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts."
+                        },
+                        {
+                            "name": "proxy_username",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy."
+                        },
+                        {
+                            "name": "proxy_password",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Password for proxy authentication."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "_ws-proxy-profile.toml"
+        },
+        {
+            "title": "Secure WebSocket Proxy Profile",
+            "options": [
+                {
+                    "name": "[transport.wss.proxy_profile]",
+                    "required": false,
+                    "description": "Configures an HTTP CONNECT proxy profile for outbound secure WebSocket (wss://) connections from the gateway to the backend. The gateway opens a raw TCP tunnel through the proxy via HTTP CONNECT, then performs TLS with the backend inside that tunnel. Multiple profiles can be defined; evaluation rules are the same as for ws proxy profiles.",
+                    "params": [
+                        {
+                            "name": "target_hosts",
+                            "type": "string",
+                            "required": true,
+                            "default": "-",
+                            "possible": "[\"example\\\\.com\"], [\"*\"]",
+                            "description": "A list of Java regular expression patterns matched against the backend hostname. Use [\"*\"] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: \"example\\\\.com\"."
+                        },
+                        {
+                            "name": "proxy_host",
+                            "type": "string",
+                            "required": true,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Hostname or IP address of the HTTP CONNECT proxy server."
+                        },
+                        {
+                            "name": "proxy_port",
+                            "type": "integer",
+                            "required": true,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Port number of the HTTP CONNECT proxy server."
+                        },
+                        {
+                            "name": "bypass_hosts",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "[\"localhost\", \"127\\\\.0\\\\.0\\\\.1\"]",
+                            "description": "A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts."
+                        },
+                        {
+                            "name": "proxy_username",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy."
+                        },
+                        {
+                            "name": "proxy_password",
+                            "type": "string",
+                            "required": false,
+                            "default": "-",
+                            "possible": "-",
+                            "description": "Password for proxy authentication."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "_wss-proxy-profile.toml"
+        },
+        {
             "title": "Message Builders (non-blocking mode)",
             "options": [
                 {

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -4512,7 +4512,7 @@
                             "name": "target_hosts",
                             "type": "string",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "[\"example\\\\.com\"], [\"*\"]",
                             "description": "A list of Java regular expression patterns matched against the backend hostname. Use [\"*\"] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: \"example\\\\.com\"."
                         },
@@ -4520,7 +4520,7 @@
                             "name": "proxy_host",
                             "type": "string",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Hostname or IP address of the HTTP CONNECT proxy server."
                         },
@@ -4528,7 +4528,7 @@
                             "name": "proxy_port",
                             "type": "integer",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Port number of the HTTP CONNECT proxy server."
                         },
@@ -4536,7 +4536,7 @@
                             "name": "bypass_hosts",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "[\"localhost\", \"127\\\\.0\\\\.0\\\\.1\"]",
                             "description": "A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts."
                         },
@@ -4544,7 +4544,7 @@
                             "name": "proxy_username",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy."
                         },
@@ -4552,7 +4552,7 @@
                             "name": "proxy_password",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Password for proxy authentication."
                         }
@@ -4573,7 +4573,7 @@
                             "name": "target_hosts",
                             "type": "string",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "[\"example\\\\.com\"], [\"*\"]",
                             "description": "A list of Java regular expression patterns matched against the backend hostname. Use [\"*\"] to create a catch-all profile that applies to all hosts not matched by a specific profile. Escape dots: \"example\\\\.com\"."
                         },
@@ -4581,7 +4581,7 @@
                             "name": "proxy_host",
                             "type": "string",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Hostname or IP address of the HTTP CONNECT proxy server."
                         },
@@ -4589,7 +4589,7 @@
                             "name": "proxy_port",
                             "type": "integer",
                             "required": true,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Port number of the HTTP CONNECT proxy server."
                         },
@@ -4597,7 +4597,7 @@
                             "name": "bypass_hosts",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "[\"localhost\", \"127\\\\.0\\\\.0\\\\.1\"]",
                             "description": "A list of Java regular expression patterns. Backend hosts matching any pattern connect directly, bypassing the proxy for this profile. Takes precedence over target_hosts."
                         },
@@ -4605,7 +4605,7 @@
                             "name": "proxy_username",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Username for Proxy-Authorization: Basic authentication. Omit for an unauthenticated proxy."
                         },
@@ -4613,7 +4613,7 @@
                             "name": "proxy_password",
                             "type": "string",
                             "required": false,
-                            "default": "-",
+                            "default": "",
                             "possible": "-",
                             "description": "Password for proxy authentication."
                         }


### PR DESCRIPTION
### Purpose

Adds a new documentation page for the WebSocket Proxy Profiles feature introduced in WSO2 API Manager 4.7.0.

The WebSocket proxy profile feature allows the Classic Gateway to route outbound WebSocket connections (gateway → backend) through one or more HTTP CONNECT proxies. This is useful in network environments where backend WebSocket services are not directly reachable from the gateway and must be accessed through a corporate or department-level proxy.

The page covers:

- Overview — what proxy profiles are and when to use them
- How It Works — the profile matching logic: specific profiles evaluated first, catch-all as fallback, bypass_hosts precedence
- Configuration — [[transport.ws.proxy_profile]] and [[transport.wss.proxy_profile]] parameters with a full reference table
- Scenarios — step-by-step examples for:
  - Anonymous proxy
  - Authenticated proxy (Basic auth)
  - Bypassing the proxy for selected hosts
  - Catch-all profile with exclusions
  - Connecting to a wss:// backend through a proxy (including truststore setup)
- Limitations — restart requirement, regex matching behavior, ordering rules, Basic auth only, ws/wss independence