### PR TITLE
Updated configuration in monitoring HTTP access logs

### DIFF
--- a/en/docs/monitoring/observability/monitoring-http-access-logs.md
+++ b/en/docs/monitoring/observability/monitoring-http-access-logs.md
@@ -22,12 +22,12 @@ In the API Manager, access logs of applications get recorded or written into the
 3. Open <APIM_HOME>/repository/conf/log4j2.properties file:
  
     Add HTTP_ACCESS to the existing "appenders"
-    ```Sample
+    ```
     appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, DELETE_EVENT_LOGFILE, TRANSACTION_LOGFILE, osgi, HTTP_ACCESS
     ```
 
      Add HTTP_ACCESS to existing "loggers"
-    ```Sample
+    ```
     loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, HTTP_ACCESS
     ```
 

--- a/en/docs/monitoring/observability/monitoring-http-access-logs.md
+++ b/en/docs/monitoring/observability/monitoring-http-access-logs.md
@@ -16,64 +16,64 @@ In the API Manager, access logs of applications get recorded or written into the
 
     ```properties
     [http_access_log]
-    enabled = true
+    useLogger = true
     ```
 
- 3. Open <APIM_HOME>/repository/conf/log4j2.properties file:
+3. Open <APIM_HOME>/repository/conf/log4j2.properties file:
  
- Add HTTP_ACCESS to the existing "appenders"
-```Sample
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, DELETE_EVENT_LOGFILE, TRANSACTION_LOGFILE, osgi, HTTP_ACCESS
-```
+    Add HTTP_ACCESS to the existing "appenders"
+    ```Sample
+    appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, DELETE_EVENT_LOGFILE, TRANSACTION_LOGFILE, osgi, HTTP_ACCESS
+    ```
 
- Add HTTP_ACCESS to existing "loggers"
-```Sample
-loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, HTTP_ACCESS
-```
+     Add HTTP_ACCESS to existing "loggers"
+    ```Sample
+    loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, HTTP_ACCESS
+    ```
 
-Add logger configurations for HTTP_ACCESS log
-```
-logger.HTTP_ACCESS.name = HTTP_ACCESS
-logger.HTTP_ACCESS.level = INFO
-logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS.ref = HTTP_ACCESS
-logger.HTTP_ACCESS.additivity = false
-```
+     Add logger configurations for HTTP_ACCESS log
+    ```
+    logger.HTTP_ACCESS.name = HTTP_ACCESS
+    logger.HTTP_ACCESS.level = INFO
+    logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS.ref = HTTP_ACCESS
+    logger.HTTP_ACCESS.additivity = false
+    ```
 
-Add appender configurations for HTTP_ACCESS log
-```
-appender.HTTP_ACCESS.type = RollingFile
-appender.HTTP_ACCESS.name = HTTP_ACCESS
-appender.HTTP_ACCESS.fileName =${sys:carbon.home}/repository/logs/wso2carbon.log
-appender.HTTP_ACCESS.filePattern =${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}.log
-appender.HTTP_ACCESS.layout.type = PatternLayout
-appender.HTTP_ACCESS.layout.pattern = [%X{Correlation-ID}] %mm%n
-appender.HTTP_ACCESS.policies.type = Policies
-appender.HTTP_ACCESS.policies.time.type = TimeBasedTriggeringPolicy
-appender.HTTP_ACCESS.policies.time.interval = 1
-appender.HTTP_ACCESS.policies.time.modulate = true
-appender.HTTP_ACCESS.policies.size.type = SizeBasedTriggeringPolicy
-appender.HTTP_ACCESS.policies.size.size=10MB
-appender.HTTP_ACCESS.strategy.type = DefaultRolloverStrategy
-appender.HTTP_ACCESS.strategy.max = 20
-appender.HTTP_ACCESS.filter.threshold.type = ThresholdFilter
-appender.HTTP_ACCESS.filter.threshold.level = INFO
-```
- 
+     Add appender configurations for HTTP_ACCESS log
+    ```
+    appender.HTTP_ACCESS.type = RollingFile
+    appender.HTTP_ACCESS.name = HTTP_ACCESS
+    appender.HTTP_ACCESS.fileName =${sys:carbon.home}/repository/logs/wso2carbon.log
+    appender.HTTP_ACCESS.filePattern =${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}.log
+    appender.HTTP_ACCESS.layout.type = PatternLayout
+    appender.HTTP_ACCESS.layout.pattern = [%X{Correlation-ID}] %mm%n
+    appender.HTTP_ACCESS.policies.type = Policies
+    appender.HTTP_ACCESS.policies.time.type = TimeBasedTriggeringPolicy
+    appender.HTTP_ACCESS.policies.time.interval = 1
+    appender.HTTP_ACCESS.policies.time.modulate = true
+    appender.HTTP_ACCESS.policies.size.type = SizeBasedTriggeringPolicy
+    appender.HTTP_ACCESS.policies.size.size=10MB
+    appender.HTTP_ACCESS.strategy.type = DefaultRolloverStrategy
+    appender.HTTP_ACCESS.strategy.max = 20
+    appender.HTTP_ACCESS.filter.threshold.type = ThresholdFilter
+    appender.HTTP_ACCESS.filter.threshold.level = INFO
+    ```
+
 4. Restart the server.
 
 
 Following is a sample of access log entries which can be monitored via `<API-M_HOME>/repository/logs/http_access_.log` file by default.
 
-```
-- 127.0.0.1 - - [12/Dec/2019:16:53:29 +0530] "POST /token HTTP/1.1" - 125 "-" "-"
-- 127.0.0.1  - [12/Dec/2019:16:53:29 +0530] "- - " 200 - "-" "-"
-- 127.0.0.1 - - [12/Dec/2019:16:53:29 +0530] "POST /oauth2/token HTTP/1.1" - - "-" "Synapse-PT-HttpComponents-NIO"
-- 127.0.0.1  - [12/Dec/2019:16:53:29 +0530] "- - " 200 - "-" "-"
-- 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "OPTIONS /pizzashack/1.0.0/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
-- 127.0.0.1  - [12/Dec/2019:16:54:38 +0530] "- - " 200 - "-" "-"
-- 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /pizzashack/1.0.0/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
-- 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /am/sample/pizzashack/v1/api/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Synapse-PT-HttpComponents-NIO"
-```
+    ```
+    - 127.0.0.1 - - [12/Dec/2019:16:53:29 +0530] "POST /token HTTP/1.1" - 125 "-" "-"
+    - 127.0.0.1  - [12/Dec/2019:16:53:29 +0530] "- - " 200 - "-" "-"
+    - 127.0.0.1 - - [12/Dec/2019:16:53:29 +0530] "POST /oauth2/token HTTP/1.1" - - "-" "Synapse-PT-HttpComponents-NIO"
+    - 127.0.0.1  - [12/Dec/2019:16:53:29 +0530] "- - " 200 - "-" "-"
+    - 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "OPTIONS /pizzashack/1.0.0/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
+    - 127.0.0.1  - [12/Dec/2019:16:54:38 +0530] "- - " 200 - "-" "-"
+    - 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /pizzashack/1.0.0/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
+    - 127.0.0.1 - - [12/Dec/2019:16:54:38 +0530] "GET /am/sample/pizzashack/v1/api/menu HTTP/1.1" - - "https://localhost:9443/devportal/apis/462a90a2-9f2b-423f-9f58-28b95c30a184/test" "Synapse-PT-HttpComponents-NIO"
+    ```
 
 As the runtime of WSO2 API Manager is based on Apache Tomcat, you can use the `Access_Log_Valve` variable in Tomcat as explained below to configure access logs to the HTTP servlet transport.
 


### PR DESCRIPTION
## Purpose                                                                                                                                                                                                     
Resolves #10768                                                                                                                                                                                                
                                                                                                                                                                                                                 
## Goals                                                                                                                                                                                                       
Fix the "Configuring access logs for the HTTP Servlet transport" section of the HTTP access logs monitoring doc, which had incorrect/missing configuration and a broken step list.                             

## Approach                                                                                                                                                                                                    
  - Replaced the incorrect `enabled = true` property with the correct `useLogger = true` under the `[http_access_log]` section in `deployment.toml` (step 2), as `enabled = true` is not required and is on by default.                                                                                                                                                                                                       
  - Fixed indentation of the sub-content under step 3 so it's nested under the ordered list item instead of breaking out into a new block.                                                                           
                                                                                                                                                                                                                 
## Documentation                                                                                                                                                                                               
en/docs/monitoring/observability/monitoring-http-access-logs.md                                                                                                             
 
## Automation tests
N/A - documentation-only change

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - docs-only change
 - Ran FindSecurityBugs plugin and verified report? N/A - docs-only change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment                                                                                                                                                                                            
Verified rendered output locally via `mkdocs serve`, confirming the numbered list now renders steps correctly in sequence.                                                                              