### PR TITLE
Add HTTP header size guideline to production deployment checklist

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -119,13 +119,36 @@ Given below is a checklist that will guide you to set up your production environ
          </td>
       </tr>
       <tr class="odd">
+         <td>HTTP header size</td>
+         <td>
+            <div class="content-wrapper">
+               <p>Starting from U2 update level 35, the default value of <code>maxHttpHeaderSize</code> on both the HTTP and HTTPS connectors in <code>&lt;APIM_HOME&gt;/repository/conf/tomcat/catalina-server.xml</code> is <strong>32 KB (32768 bytes)</strong>, increased from the previous default of 8 KB (8192 bytes).</p>
+               <p>This value <strong>must not be set to less than 32 KB (32768 bytes)</strong>, specifically on the <strong>API Control Plane (ACP) node</strong> in a distributed deployment (or on the single node in an all-in-one deployment), if <strong>Multi-Option Authentication</strong> is used for portal (Publisher, DevPortal, Admin) logins in federated authentication flows.</p>
+               <p>If set lower, the <code>/commonauth</code> redirect from the external Identity Provider carries the full OAuth scope list in the request URI, and the combined size of the request line and headers exceeds the buffer. Tomcat then rejects the request with a <code>400 Bad Request</code> or <code>414 Request-URI Too Long</code> error, breaking the federated login flow.</p>
+               <p>If you need to override the value via <code>deployment.toml</code>, keep it at or above the default:</p>
+               <div class="code panel pdl" style="border-width: 1px;">
+                  <div class="codeContent panelContent pdl">
+                     <div class="sourceCode" id="cb2" data-syntaxhighlighter-params="brush: text; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: text; gutter: false; theme: Confluence">
+                        <pre class="sourceCode text"><code class="sourceCode text">[transport.http.properties]
+maxHttpHeaderSize = 32768
+
+[transport.https.properties]
+maxHttpHeaderSize = 32768</code></pre>
+                     </div>
+                  </div>
+               </div>
+               <p>If a reverse proxy, load balancer, ingress controller, or CDN is deployed in front of APIM, ensure its header and URL size limits are also aligned to at least 32 KB — otherwise the request will be rejected at the front tier before it reaches APIM.</p>
+            </div>
+         </td>
+      </tr>
+      <tr class="even">
          <td>High availability</td>
          <td>
             <p>Configure your deployment with high availability. Refer the <a href="{{base_path}}/install-and-setup/setup/deployment-overview">recommended deployment patterns</a> and select an option that fits your requirements.</p>
             <p>In the cloud native deployment, high availability should be achieved via the container orchestration system (Kubernetes).</p>
          </td>
       </tr>
-      <tr class="even">
+      <tr class="odd">
          <td>Data backup and archiving</td>
          <td>Implement a <a href="{{base_path}}/install-and-setup/setup/deployment-best-practices/backup-recovery">backup and recovery strategy</a> for your system.</td>
       </tr>

--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -122,7 +122,7 @@ Given below is a checklist that will guide you to set up your production environ
          <td>HTTP header size</td>
          <td>
             <div class="content-wrapper">
-               <p>Starting from U2 update level 35, the default value of <code>maxHttpHeaderSize</code> on both the HTTP and HTTPS connectors in <code>&lt;APIM_HOME&gt;/repository/conf/tomcat/catalina-server.xml</code> is <strong>32 KB (32768 bytes)</strong>, increased from the previous default of 8 KB (8192 bytes).</p>
+               <p>Starting from U2 update level 35, the default value of <code>maxHttpHeaderSize</code> on both the HTTP and HTTPS connectors in <code>&lt;API-M_HOME&gt;/repository/conf/tomcat/catalina-server.xml</code> is <strong>32 KB (32768 bytes)</strong>, increased from the previous default of 8 KB (8192 bytes).</p>
                <p>This value <strong>must not be set to less than 32 KB (32768 bytes)</strong>, specifically on the <strong>API Control Plane (ACP) node</strong> in a distributed deployment (or on the single node in an all-in-one deployment), if <strong>Multi-Option Authentication</strong> is used for portal (Publisher, DevPortal, Admin) logins in federated authentication flows.</p>
                <p>If set lower, the <code>/commonauth</code> redirect from the external Identity Provider carries the full OAuth scope list in the request URI, and the combined size of the request line and headers exceeds the buffer. Tomcat then rejects the request with a <code>400 Bad Request</code> or <code>414 Request-URI Too Long</code> error, breaking the federated login flow.</p>
                <p>If you need to override the value via <code>deployment.toml</code>, keep it at or above the default:</p>
@@ -137,7 +137,7 @@ maxHttpHeaderSize = 32768</code></pre>
                      </div>
                   </div>
                </div>
-               <p>If a reverse proxy, load balancer, ingress controller, or CDN is deployed in front of APIM, ensure its header and URL size limits are also aligned to at least 32 KB — otherwise the request will be rejected at the front tier before it reaches APIM.</p>
+               <p>If a reverse proxy, load balancer, ingress controller, or CDN is deployed in front of API-M, ensure its header and URL size limits are also aligned to at least 32 KB — otherwise the request will be rejected at the front tier before it reaches API-M.</p>
             </div>
          </td>
       </tr>

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -9064,7 +9064,7 @@ re_indexing = 1</code></pre>
 port = "9763"
 redirectPort = "9443"
 bindOnInit = "false"
-maxHttpHeaderSize = "8192"
+maxHttpHeaderSize = "32768"
 acceptorThreadCount = "2"
 maxThreads = "250"
 minSpareThreads = "50"
@@ -9143,14 +9143,14 @@ URIEncoding = "UTF-8"</code></pre>
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>8192</code></span>
+                                            <span class="param-default-value">Default: <code>32768</code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p></p>
+                                        <p>Maximum size in bytes of the HTTP request line and headers that Tomcat will accept. The default was raised from 8192 to 32768 starting from U2 update level 35. Keep this value at 32768 (32 KB) or higher, especially on the API Control Plane (ACP) node when Multi-Option Authentication is used for federated portal logins. A lower value can cause /commonauth requests to be rejected with a 400 Bad Request or 414 Request-URI Too Long error.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -9474,7 +9474,7 @@ URIEncoding = "UTF-8"</code></pre>
 port = "9763"
 redirectPort = "9443"
 bindOnInit = "false"
-maxHttpHeaderSize = "8192"
+maxHttpHeaderSize = "32768"
 acceptorThreadCount = "2"
 maxThreads = "250"
 minSpareThreads = "50"
@@ -9557,14 +9557,14 @@ SSLEnabled = "true"</code></pre>
                                             <span class="badge-required">Required</span>
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code>8192</code></span>
+                                            <span class="param-default-value">Default: <code>32768</code></span>
                                         </div>
                                         <div class="param-possible">
                                             <span class="param-possible-values">Possible Values: <code>-</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p></p>
+                                        <p>Maximum size in bytes of the HTTP request line and headers that Tomcat will accept. The default was raised from 8192 to 32768 starting from U2 update level 35. Keep this value at 32768 (32 KB) or higher, especially on the API Control Plane (ACP) node when Multi-Option Authentication is used for federated portal logins. A lower value can cause /commonauth requests to be rejected with a 400 Bad Request or 414 Request-URI Too Long error.</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/tools/config-catalog-generator/data/_http-transport.toml
+++ b/en/tools/config-catalog-generator/data/_http-transport.toml
@@ -2,7 +2,7 @@
 port = "9763"
 redirectPort = "9443"
 bindOnInit = "false"
-maxHttpHeaderSize = "8192"
+maxHttpHeaderSize = "32768"
 acceptorThreadCount = "2"
 maxThreads = "250"
 minSpareThreads = "50"

--- a/en/tools/config-catalog-generator/data/_https-transport.toml
+++ b/en/tools/config-catalog-generator/data/_https-transport.toml
@@ -2,7 +2,7 @@
 port = "9763"
 redirectPort = "9443"
 bindOnInit = "false"
-maxHttpHeaderSize = "8192"
+maxHttpHeaderSize = "32768"
 acceptorThreadCount = "2"
 maxThreads = "250"
 minSpareThreads = "50"

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -3464,9 +3464,9 @@
                             "name": "maxHttpHeaderSize",
                             "type": "integer",
                             "required": true,
-                            "default": "8192",
+                            "default": "32768",
                             "possible": "-",
-                            "description": ""
+                            "description": "Maximum size in bytes of the HTTP request line and headers that Tomcat will accept. The default was raised from 8192 to 32768 starting from U2 update level 35. Keep this value at 32768 (32 KB) or higher, especially on the API Control Plane (ACP) node when Multi-Option Authentication is used for federated portal logins. A lower value can cause /commonauth requests to be rejected with a 400 Bad Request or 414 Request-URI Too Long error."
                         },
                         {
                             "name": "acceptorThreadCount",
@@ -3613,9 +3613,9 @@
                             "name": "maxHttpHeaderSize",
                             "type": "integer",
                             "required": true,
-                            "default": "8192",
+                            "default": "32768",
                             "possible": "-",
-                            "description": ""
+                            "description": "Maximum size in bytes of the HTTP request line and headers that Tomcat will accept. The default was raised from 8192 to 32768 starting from U2 update level 35. Keep this value at 32768 (32 KB) or higher, especially on the API Control Plane (ACP) node when Multi-Option Authentication is used for federated portal logins. A lower value can cause /commonauth requests to be rejected with a 400 Bad Request or 414 Request-URI Too Long error."
                         },
                         {
                             "name": "acceptorThreadCount",


### PR DESCRIPTION
## Summary
- Adds a new **HTTP header size** row to the production deployment checklist in `en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md`.
- Documents that the default `maxHttpHeaderSize` on the HTTP/HTTPS Tomcat connectors is being raised from 8 KB to **32 KB** starting from **U2 update level 35**.
- Calls out that customers **must not** set the value lower than 32 KB — specifically on the **API Control Plane (ACP)** node in a distributed deployment (or on the single node in an all-in-one deployment) — when **Multi-Option Authentication** is used for federated portal logins.
- Includes the `deployment.toml` override snippet and a note to align upstream reverse proxy / load balancer / ingress / CDN header limits to at least 32 KB.

## Related



## Test plan
- [x] \`mkdocs build\` runs cleanly on the branch.
- [x] The new row renders correctly in \`mkdocs serve\` at the target page, with zebra striping preserved on subsequent rows.
- [ ] Verify rendering in staged docs site once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)