### PR TITLE
Update Jaeger remote tracer port to OTLP port 4317 in OpenTelemetry docs

### DIFF
--- a/en/docs/monitoring/observability/traces/monitoring-with-opentelemetry.md
+++ b/en/docs/monitoring/observability/traces/monitoring-with-opentelemetry.md
@@ -56,7 +56,7 @@ For more information, see [OpenTelemetry Configurations]({{base_path}}/reference
 		remote_tracer.enable = true
 		remote_tracer.name = "jaeger"
 		remote_tracer.hostname = "localhost"
-		remote_tracer.port = 14250
+		remote_tracer.port = 4317
 		```
 
 2. Start the server.


### PR DESCRIPTION
# Purpose

Related Issues : [#4782](https://github.com/wso2/api-manager/issues/4782) | [#4775](https://github.com/wso2/api-manager/issues/4775)

From APIM 4.7, the `jaeger remote tracer` no longer uses Jaeger's native protocol. The OpenTelemetry Java SDK bundled with APIM removed its Jaeger-native exporter (Jaeger itself deprecated the native protocol in favor of OTLP and removed it entirely in Jaeger v2), so the jaeger tracer now exports spans over OTLP gRPC.

The documented port `14250` is Jaeger's legacy native endpoint, which does not accept OTLP. With that configuration, the server starts normally but every span export fails with:

```
Failed to export spans. Server responded with UNIMPLEMENTED.
Full error message: unknown service opentelemetry.proto.collector.trace.v1.TraceService
```
and no traces ever appear in the Jaeger UI.

Port `4317` is Jaeger's OTLP gRPC endpoint. With this change, the sample configuration works as expected.

>This applies to the 4.7/latest documentation only. APIM 4.5 and 4.6 still bundle the Jaeger-native exporter, so port 14250 remains the correct value in those documentation versions.