### PR TITLE
[4.6.0] Document config apim.mcp.enforce_auth_for_all_mcp_methods

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3331,6 +3331,7 @@ default_request_timeout = 30</code></pre>
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.mcp]
 enable = true
+enforce_auth_for_all_mcp_methods = false
 </code></pre>
                     </div>
                 </div>
@@ -3363,6 +3364,27 @@ enable = true
                                     </div>
                                     <div class="param-description">
                                         <p>Enable the MCP features.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>enforce_auth_for_all_mcp_methods</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>By default, all MCP requests except &#39;tools/call&#39; requests are unauthenticated. If this option is set to true, authentication will be required for all MCP requests. For improved security, it is recommended to enable this option.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator/data/apim.mcp.toml
+++ b/en/tools/config-catalog-generator/data/apim.mcp.toml
@@ -1,2 +1,3 @@
 [apim.mcp]
 enable = true
+enforce_auth_for_all_mcp_methods = false

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1256,6 +1256,14 @@
                             "default": "true",
                             "possible": "true,false",
                             "description": "Enable the MCP features."
+                        },
+                        {
+                            "name": "enforce_auth_for_all_mcp_methods",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true,false",
+                            "description": "By default, all MCP requests except tools/call requests are unauthenticated. If this option is set to true, authentication will be required for all MCP requests. For improved security, it is recommended to enable this option."
                         }
                     ]
                 }


### PR DESCRIPTION
## Purpose
Documents below config

```
[apim.mcp]
enforce_auth_for_all_mcp_methods = true
```

<img width="824" height="757" alt="Screenshot 2026-07-16 at 11 09 16" src="https://github.com/user-attachments/assets/0e273e78-c57d-4c14-ac84-570b0e9e9306" />
