### PR TITLE
Add custom error response formatting for AI APIs

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3009,6 +3009,7 @@ enable = true
 token = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 endpoint = "https://e95488c8-8511-4882-967f-ec3ae2a0f86f-prod.e1-us-east-azure.choreoapis.dev/lgpt/interceptor-service/interceptor-service-be2/v1.0"
 default_request_timeout = 30
+custom_error_response_sequence = "openai_error_response_formatter"
 
 [apim.ai.failover_configurations]
 failover_endpoints_limit = 10
@@ -3101,6 +3102,27 @@ default_request_timeout = 30</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>The default timeout (in seconds) for AI API requests</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>custom_error_response_sequence</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>openai_error_response_formatter</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The name of the Synapse sequence used to format gateway error responses for AI APIs. Applies only to AI APIs. If not set, AI APIs use the default error response format.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/docs/reference/troubleshooting/error-handling.md
+++ b/en/docs/reference/troubleshooting/error-handling.md
@@ -461,3 +461,49 @@ message's HTTP status code as a custom error message:
         {"fault":{"code":900901,"type":"Status report","message":"Runtime Error","description":"Invalid Credentials"}}   
         ```
 
+## Customize Error Responses for AI APIs
+
+To enable custom error response formatting for AI APIs, add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file. For more information, see the [Configuration Catalog]({{base_path}}/reference/config-catalog/).
+
+```toml
+[apim.ai]
+custom_error_response_sequence = "openai_error_response_formatter"
+```
+
+!!! info
+
+    In a distributed deployment, add this configuration to the `deployment.toml` file of both the **API Control Plane (ACP)** node (`<ACP_HOME>/repository/conf/deployment.toml`) and the **Universal Gateway** node (`<UNIVERSAL-GW_HOME>/repository/conf/deployment.toml`).
+
+When this configuration is enabled, gateway error responses for AI APIs are formatted using the `<API-M_HOME>/repository/deployment/server/synapse-configs/default/sequences/openai_error_response_formatter.xml` Synapse sequence:
+
+By default, this sequence produces the following OpenAI-compatible error response:
+
+```json
+{
+  "error": {
+    "code": "<error code>",
+    "type": "<error type>",
+    "message": "<error description>"
+  }
+}
+```
+
+To customize the error response format, modify the `openai_error_response_formatter.xml` sequence.
+
+!!! note
+
+    This configuration applies only to AI APIs. Non-AI APIs, and AI APIs when `custom_error_response_sequence` is not configured, continue to use the default error response format.
+
+!!! info
+
+    This configuration is available in wso2am-4.6.0 starting from update level 39 and wso2am-universal-gw-4.6.0 starting from update level 38.
+
+!!! info
+
+    For the customization to take effect on **tenants that existed before this update was applied**, copy the following files from the `<API-M_HOME>/repository/resources/apim-synapse-config` directory to the `<API-M_HOME>/repository/tenants/<tenant-id>/synapse-configs/default/sequences` directory:
+
+    - `_sandbox_key_error_.xml`
+    - `guardrail_fault.xml`
+
+    Tenants created after applying this update receive these files automatically during tenant creation. Therefore, no manual copying is required.
+

--- a/en/tools/config-catalog-generator/data/apim.ai.toml
+++ b/en/tools/config-catalog-generator/data/apim.ai.toml
@@ -3,6 +3,7 @@ enable = true
 token = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 endpoint = "https://e95488c8-8511-4882-967f-ec3ae2a0f86f-prod.e1-us-east-azure.choreoapis.dev/lgpt/interceptor-service/interceptor-service-be2/v1.0"
 default_request_timeout = 30
+custom_error_response_sequence = "openai_error_response_formatter"
 
 [apim.ai.failover_configurations]
 failover_endpoints_limit = 10

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -1151,6 +1151,14 @@
                             "default": "30",
                             "possible": "",
                             "description": "The default timeout (in seconds) for AI API requests"
+                        },
+                        {
+                            "name": "custom_error_response_sequence",
+                            "type": "string",
+                            "required": false,
+                            "default": "",
+                            "possible": "openai_error_response_formatter",
+                            "description": "The name of the Synapse sequence used to format gateway error responses for AI APIs. Applies only to AI APIs. If not set, AI APIs use the default error response format."
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

- Documents the new `apim.ai.custom_error_response_sequence` configuration, which lets users format gateway error responses for AI APIs using a custom Synapse sequence.
- Explains the default `openai_error_response_formatter` sequence and the OpenAI-compatible error response it produces, and how to customize it.
- Notes that this configuration applies only to AI APIs (non-AI APIs and AI APIs without this configured continue to use the default error response format)
- Adds a note that in a distributed deployment, this configuration must be added to both the API Control Plane (ACP) and the Universal Gateway nodes.
- Adds `custom_error_response_sequence` to the Config Catalog under **API-M AI configurations**.

- Related Issue: https://github.com/wso2/api-manager/issues/4993 