### PR TITLE
docs: replace outdated Integration Studio reference with MI for VS Code

### DIFF
--- a/en/docs/get-started/apim-architecture.md
+++ b/en/docs/get-started/apim-architecture.md
@@ -28,7 +28,7 @@ The Developer Portal is a state-of-the-art web interface that allows API publish
 
 WSO2 API Control Plane includes a Service Catalog where developers can register their services in a RESTful manner. Service Catalog is one of the main attributes that enable the API-first Integration in WSO2 API Manager. Through the Service Catalog, integration services are made discoverable to the API Management layer so that API proxies can directly be created using them. 
 
-These integration services can be created using WSO2 Integration Studio and a variety of other platforms. For an Integration Studio user, the service registration happens automatically when exporting the project as a composite application (CApp).
+These integration services can be created using WSO2 Integrator: MI for VS Code and a variety of other platforms. For users of WSO2 Integrator: MI for VS Code, the service registration happens automatically when exporting the project as a composite application (CApp).
 
 #### Key Manager
  


### PR DESCRIPTION
## Purpose

Resolves #9272.

## Description

This PR updates the API Architecture documentation by replacing the outdated **WSO2 Integration Studio** reference with **WSO2 Integrator: MI for VS Code** to reflect the current recommended development tooling and avoid confusion for users.

## Files Changed

- `en/docs/get-started/apim-architecture.md`

## Testing

- Documentation-only change.
- Verified the Markdown renders correctly.