### PR TITLE
Remove non-functional [apim.webhooks.http] enable config (4.5.0)

### DIFF
--- a/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
+++ b/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
@@ -152,6 +152,11 @@ enable = false
 
 ### Disabling the WebHook Transport
 
+!!! warning
+    The `[apim.webhooks.http] enable = false` configuration has no effect in this version. The backing implementation for this configuration is not present, so the WebSub HTTP inbound endpoint on port 9021 will remain active regardless of this setting.
+
+    **Workaround:** To prevent external access to port 9021, use a firewall rule or configure your load balancer to block inbound traffic on that port. Do not expose port 9021 to the public internet in a production deployment.
+
 Add the following configuration in the `deployment.toml` file (stored in the `<API-M_HOME>/repository/conf` folder).
 
 ```toml

--- a/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
+++ b/en/docs/install-and-setup/setup/security/configuring-transport-level-security.md
@@ -150,20 +150,6 @@ Add the following configuration in the `deployment.toml` file (stored in the `<A
 enable = false
 ```
 
-### Disabling the WebHook Transport
-
-!!! warning
-    The `[apim.webhooks.http] enable = false` configuration has no effect in this version. The backing implementation for this configuration is not present, so the WebSub HTTP inbound endpoint on port 9021 will remain active regardless of this setting.
-
-    **Workaround:** To prevent external access to port 9021, use a firewall rule or configure your load balancer to block inbound traffic on that port. Do not expose port 9021 to the public internet in a production deployment.
-
-Add the following configuration in the `deployment.toml` file (stored in the `<API-M_HOME>/repository/conf` folder).
-
-```toml
-[apim.webhooks.http]
-enable = false
-```
-
 ### Adding Response Headers to Web Applications
 
 You can add response headers to all the web applications that are deployed in the Tomcat instance via a Tomcat filter.


### PR DESCRIPTION
## Summary

- Removes the `### Disabling the WebHook Transport` section from the transport-level security page.
- The `[apim.webhooks.http] enable = false` configuration has no backing implementation in this version: `WebhookServer.xml` (port 9021) is a static file with no j2 template, so the config mapper silently ignores the setting. Documenting it as functional is misleading.

## Related issue

wso2-enterprise/wso2-apim-internal#17871

## Test plan

- [ ] Confirm the section is absent from the rendered 4.5.0 docs page for "Configuring Transport Level Security".