### PR TITLE
Fix incorrect --run flag in Windows quick start command

### DIFF
--- a/en/docs/get-started/api-manager-quick-start-guide.md
+++ b/en/docs/get-started/api-manager-quick-start-guide.md
@@ -35,7 +35,7 @@ Choose a deployment option to start the WSO2 API Manager All-in-one package. Thi
         
         === "On Windows"
             ```bash
-            api-manager.bat --run
+            api-manager.bat
             ```
 
 === "Run on Kubernetes"


### PR DESCRIPTION
The api-manager.bat command in the Quick Start Guide incorrectly includes a --run flag. This flag is not documented in any official WSO2 API Manager release notes (4.0.0 through 4.2.0) or the apim-apps README, both of which show the command without any flag. Verified as unnecessary through local testing - the server starts successfully with just api-manager.bat.

## Purpose
The Windows command in the Quick Start Guide (get-started/api-manager-quick-start-guide.md) includes an incorrect `--run` flag that isn't part of the actual api-manager.bat usage.

## Goals
Remove the incorrect flag so the documented command matches the actual product behavior.

## Approach
Simple one-line text change in the markdown file - no code or UI changes involved.

## Documentation
This PR is itself a documentation fix.