### PR TITLE
[4.3.0] Add update level note to authentication policy config

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -15910,7 +15910,7 @@ disable_account_disable_handler = false</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Disables the account disable handler during authentication.</p>
+                                        <p>Disables the account disable handler during authentication. Note that this configuration is supported from update level 120 onwards.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -5906,7 +5906,7 @@
                             "required": false,
                             "default": "false",
                             "possible": "true,false",
-                            "description": "Disables the account disable handler during authentication."
+                            "description": "Disables the account disable handler during authentication. Note that this configuration is supported from update level 120 onwards."
                         }
                     ]
                 }


### PR DESCRIPTION
## Purpose 

Follow-up to #11468 — adds the missing update level note to `disable_account_disable_handler`