### PR TITLE
Fix typos in Admin API v4 OpenAPI specification

### DIFF
--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -69,8 +69,8 @@ info:
     of this document and scope for each resource is given in **authorizations** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
-    \ -H "Authorization: Basic base64(client_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>" \
+    -H "Authorization: Basic base64(client_id:client_secret)" \
     \ https://<host>:<server_port>/oauth2/token
     ```
     **Sample request**

--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -21,7 +21,7 @@ info:
 
     # Authentication
     The Admin REST API is protected using OAuth2 and access control is achieved through scopes. Before you start invoking
-    the the API you need to obtain an access token with the required scopes. This guide will walk you through the steps
+    the API you need to obtain an access token with the required scopes. This guide will walk you through the steps
     that you will need to follow to obtain an access token.
     First you need to obtain the consumer key/secret key pair by calling the dynamic client registration (DCR) endpoint. You can add your preferred grant types
     in the payload. A sample payload is shown below.
@@ -34,7 +34,7 @@ info:
       "saasApp":true
       }
     ```
-    Create a file (payload.json) with the above sample payload, and use the cURL shown bellow to invoke the DCR endpoint. Authorization header of this should contain the
+    Create a file (payload.json) with the above sample payload, and use the cURL shown below to invoke the DCR endpoint. Authorization header of this should contain the
     base64 encoded admin username and password.
     **Format of the request**
     ```
@@ -69,8 +69,8 @@ info:
     of this document and scope for each resource is given in **authorizations** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd>&scope=<scopes seperated by space>"
-    \ -H "Authorization: Basic base64(cliet_id:client_secret)"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_password>&scope=<scopes separated by space>"
+    \ -H "Authorization: Basic base64(client_id:client_secret)"
     \ https://<host>:<server_port>/oauth2/token
     ```
     **Sample request**
@@ -3257,9 +3257,9 @@ paths:
     get:
       tags:
         - Settings
-      summary: Retreive Admin Settings
+      summary: Retrieve Admin Settings
       description: |
-        Retreive admin settings
+        Retrieve admin settings
       responses:
         '200':
           description: |
@@ -4666,7 +4666,7 @@ paths:
           description: |
             **Search and get all apis in admin portal**.
 
-            You can search by proving a keyword.
+            You can search by providing a keyword.
           schema:
             type: string
         - $ref: '#/components/parameters/If-None-Match'


### PR DESCRIPTION
## Approach

This PR corrects several typographical errors in the Admin API v4 OpenAPI specification.

The following corrections were made:

- Removed the duplicated word in `the the API`
- Corrected `bellow` to `below`
- Corrected `passowrd` to `password`
- Corrected `seperated` to `separated`
- Corrected `cliet_id` to `client_id`
- Corrected `Retreive` to `Retrieve`
- Corrected `proving` to `providing`

Only documentation text and example placeholders were updated. No API field names, schema properties, or functional behavior were changed.

## User stories

N/A — documentation-only correction.

## Release note

N/A — no product behavior change.

## Documentation

Updated:

`en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml`

## Tests

Not applicable. The changes are limited to typographical corrections in the OpenAPI documentation.

## Related PRs

N/A