### PR TITLE
Add streaming limitation note for Universal Gateway AI APIs

### DIFF
--- a/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
+++ b/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
@@ -73,7 +73,7 @@ Now, you have successfully created an AI API. Next, [deploy the API]({{base_path
 
 ## Limitations
 
-Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. If an AI backend returns a streaming response (`text/event-stream`), the gateway buffers the complete response and forwards it to the client as a single batch. This is because AI gateway features — token analytics, token-based throttling, and other payload-dependent policies — require the full response payload to be available during mediation.
+Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**.
 
 ## See Also
 

--- a/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
+++ b/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
@@ -71,6 +71,10 @@ The overview page of the newly created API appears.
 
 Now, you have successfully created an AI API. Next, [deploy the API]({{base_path}}/deploy-and-publish/deploy-on-gateway/deploy-api/deploy-an-api/), [test the API]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api/), and finally [publish the API]({{base_path}}/deploy-and-publish/publish-on-dev-portal/publish-an-api).
 
+## Limitations
+
+Streaming AI API responses (SSE / `text/event-stream`) are not streamed chunk-by-chunk to the client when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
+
 ## See Also
 
 Learn more on the concepts that you need to know when creating a REST API:

--- a/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
+++ b/en/docs/design/create-api/create-ai-api/create-an-ai-api.md
@@ -73,7 +73,7 @@ Now, you have successfully created an AI API. Next, [deploy the API]({{base_path
 
 ## Limitations
 
-Streaming AI API responses (SSE / `text/event-stream`) are not streamed chunk-by-chunk to the client when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
+Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. If an AI backend returns a streaming response (`text/event-stream`), the gateway buffers the complete response and forwards it to the client as a single batch. This is because AI gateway features — token analytics, token-based throttling, and other payload-dependent policies — require the full response payload to be available during mediation.
 
 ## See Also
 

--- a/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
+++ b/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
@@ -4,9 +4,6 @@
 
 AI APIs in the WSO2 API Manager use the token based rate limiting policies in subscriptions by way of business plans. These policies allow for granular control of how AI APIs are used by applications.
 
-!!! note
-    Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. As a result, token-based rate limiting is not enforced for streaming requests. See [Limitations]({{base_path}}/design/create-api/create-ai-api/create-an-ai-api/#limitations) for details.
-
 AI API subscription policies can be created and customized based on the following quotas:
 
 - **Request Count** - This quota limits the total number of requests an application can make. Once the specified request count limit is reached, further requests from that application will be throttled, preventing access to the AI API until the quota is reset.

--- a/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
+++ b/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
@@ -4,6 +4,9 @@
 
 AI APIs in the WSO2 API Manager use the token based rate limiting policies in subscriptions by way of business plans. These policies allow for granular control of how AI APIs are used by applications.
 
+!!! note
+    Token-based rate limiting is not enforced for streaming AI API responses (`text/event-stream`) when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, which means token counts are not extracted from streaming responses. See [Limitations]({{base_path}}/design/create-api/create-ai-api/create-an-ai-api/#limitations) for details.
+
 AI API subscription policies can be created and customized based on the following quotas:
 
 - **Request Count** - This quota limits the total number of requests an application can make. Once the specified request count limit is reached, further requests from that application will be throttled, preventing access to the AI API until the quota is reset.

--- a/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
+++ b/en/docs/design/rate-limiting/rate-limiting-for-ai-apis.md
@@ -5,7 +5,7 @@
 AI APIs in the WSO2 API Manager use the token based rate limiting policies in subscriptions by way of business plans. These policies allow for granular control of how AI APIs are used by applications.
 
 !!! note
-    Token-based rate limiting is not enforced for streaming AI API responses (`text/event-stream`) when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, which means token counts are not extracted from streaming responses. See [Limitations]({{base_path}}/design/create-api/create-ai-api/create-an-ai-api/#limitations) for details.
+    Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. As a result, token-based rate limiting is not enforced for streaming requests. See [Limitations]({{base_path}}/design/create-api/create-ai-api/create-an-ai-api/#limitations) for details.
 
 AI API subscription policies can be created and customized based on the following quotas:
 


### PR DESCRIPTION
## Summary

- Documents that streaming is not supported for AI APIs when using the WSO2 API Manager Universal Gateway
- Adds a `## Limitations` section to the AI API overview doc

Relates to: wso2-enterprise/wso2-apim-internal#17986, wso2-enterprise/wso2-apim-internal#11105

🤖 Generated with [Claude Code](https://claude.com/claude-code)