### PR TITLE
Add streaming limitation note for Universal Gateway AI APIs

### DIFF
--- a/en/docs/ai-gateway/ai-gateway-overview.md
+++ b/en/docs/ai-gateway/ai-gateway-overview.md
@@ -144,7 +144,7 @@ Implement [smart routing]({{base_path}}/ai-gateway/multi-model-routing/overview/
 
 ## Limitations
 
-Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. If an AI backend returns a streaming response (`text/event-stream`), the gateway buffers the complete response and forwards it to the client as a single batch. This is because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
+Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**.
 
 ## Next Steps
 

--- a/en/docs/ai-gateway/ai-gateway-overview.md
+++ b/en/docs/ai-gateway/ai-gateway-overview.md
@@ -142,6 +142,10 @@ If building AI agents that need to interact with your business systems, implemen
 ### Use Smart Routing for Production
 Implement [smart routing]({{base_path}}/ai-gateway/multi-model-routing/overview/) to balance cost and performance. Route simple queries to cost-effective models and complex reasoning tasks to premium models. Set up automated failover between providers to maintain availability.
 
+## Limitations
+
+Streaming AI API responses (SSE / `text/event-stream`) are not streamed chunk-by-chunk to the client when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
+
 ## Next Steps
 
 Choose your path based on your use case:

--- a/en/docs/ai-gateway/ai-gateway-overview.md
+++ b/en/docs/ai-gateway/ai-gateway-overview.md
@@ -144,7 +144,7 @@ Implement [smart routing]({{base_path}}/ai-gateway/multi-model-routing/overview/
 
 ## Limitations
 
-Streaming AI API responses (SSE / `text/event-stream`) are not streamed chunk-by-chunk to the client when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
+Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. If an AI backend returns a streaming response (`text/event-stream`), the gateway buffers the complete response and forwards it to the client as a single batch. This is because AI gateway features — token analytics, token-based throttling, guardrails, and other payload-dependent policies — require the full response payload to be available during mediation.
 
 ## Next Steps
 

--- a/en/docs/ai-gateway/ai-gateway-overview.md
+++ b/en/docs/ai-gateway/ai-gateway-overview.md
@@ -144,7 +144,7 @@ Implement [smart routing]({{base_path}}/ai-gateway/multi-model-routing/overview/
 
 ## Limitations
 
-Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**.
+Streaming is not supported for AI APIs when using the **WSO2 API Manager Classic Gateway**.
 
 ## Next Steps
 

--- a/en/docs/ai-gateway/rate-limiting.md
+++ b/en/docs/ai-gateway/rate-limiting.md
@@ -8,7 +8,6 @@ By enforcing rate limits, you can:
 - Optimize performance by ensuring fair resource distribution.
 - Protect AI backends from overuse and service degradation.
 
-
 ## Subscription-Level Rate Limiting
 
 Subscription-level rate limiting applies different quotas based on business plans, allowing API providers to enforce request-based or token-based limits on API subscribers.

--- a/en/docs/ai-gateway/rate-limiting.md
+++ b/en/docs/ai-gateway/rate-limiting.md
@@ -9,7 +9,7 @@ By enforcing rate limits, you can:
 - Protect AI backends from overuse and service degradation.
 
 !!! note
-    Token-based rate limiting is not enforced for streaming AI API responses (`text/event-stream`) when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, which means token counts are not extracted from streaming responses. See [Limitations]({{base_path}}/ai-gateway/ai-gateway-overview/#limitations) for details.
+    Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. As a result, token-based rate limiting is not enforced for streaming requests. See [Limitations]({{base_path}}/ai-gateway/ai-gateway-overview/#limitations) for details.
 
 ## Subscription-Level Rate Limiting
 

--- a/en/docs/ai-gateway/rate-limiting.md
+++ b/en/docs/ai-gateway/rate-limiting.md
@@ -8,6 +8,9 @@ By enforcing rate limits, you can:
 - Optimize performance by ensuring fair resource distribution.
 - Protect AI backends from overuse and service degradation.
 
+!!! note
+    Token-based rate limiting is not enforced for streaming AI API responses (`text/event-stream`) when using the **WSO2 API Manager Universal Gateway**. The gateway buffers the complete response before forwarding it, which means token counts are not extracted from streaming responses. See [Limitations]({{base_path}}/ai-gateway/ai-gateway-overview/#limitations) for details.
+
 ## Subscription-Level Rate Limiting
 
 Subscription-level rate limiting applies different quotas based on business plans, allowing API providers to enforce request-based or token-based limits on API subscribers.

--- a/en/docs/ai-gateway/rate-limiting.md
+++ b/en/docs/ai-gateway/rate-limiting.md
@@ -8,8 +8,6 @@ By enforcing rate limits, you can:
 - Optimize performance by ensuring fair resource distribution.
 - Protect AI backends from overuse and service degradation.
 
-!!! note
-    Streaming is not supported for AI APIs when using the **WSO2 API Manager Universal Gateway**. As a result, token-based rate limiting is not enforced for streaming requests. See [Limitations]({{base_path}}/ai-gateway/ai-gateway-overview/#limitations) for details.
 
 ## Subscription-Level Rate Limiting
 


### PR DESCRIPTION
## Summary

- Documents that streaming is not supported for AI APIs when using the WSO2 API Manager Universal Gateway
- Adds a `## Limitations` section to the AI API overview doc

Relates to: wso2-enterprise/wso2-apim-internal#17986, wso2-enterprise/wso2-apim-internal#11105

🤖 Generated with [Claude Code](https://claude.com/claude-code)