### PR TITLE
Fix JDK version and clarify download instructions

### DIFF
--- a/en/docs/install-and-setup/install/installation-prerequisites.md
+++ b/en/docs/install-and-setup/install/installation-prerequisites.md
@@ -16,7 +16,7 @@ Databases</p>
 <td>
 <ul>
 <li>
-<p>Install a JDK version that is <a href="{{base_path}}/install-and-setup/setup/reference/product-compatibility/#tested-operating-systems-and-jdks">compatible with this product version</a>.</p>
+<p>Install a JDK version that is <a href="{{base_path}}/install-and-setup/setup/reference/product-compatibility/#tested-operating-systems-and-jdks">compatible with this product version.</a> For WSO2 API Manager 4.7.0, this is **JDK 21 or JDK 25** (Temurin OpenJDK). Using an incompatible version - including newer versions such as JDK 22+ will prevent the server from starting, with an error similar to: `CARBON is supported only between JDK 21 and JDK 25`.</p>
 </li>
 <li><p>All WSO2 Carbon-based products are generally compatible with most common DBMSs. The embedded H2 database is suitable for development, testing, and some production environments. However, for most enterprise production environments, WSO2 recommends that you use an industry-standard RDBMS such as Oracle, PostgreSQL, MySQL, MS SQL, etc. For more information, see <a href="{{base_path}}/install-and-setup/setup/setting-up-databases/overview/">Working with Databases</a>. Additionally, WSO2 does not recommend the H2 database as a user store.</p>
 </li>

--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-runtime.md
@@ -13,7 +13,8 @@ Java Development Kit (JDK) is essential to run the product.
 2.  Extract the archive file to a dedicated directory for the API Manager, which will hereafter be referred to as `<API-M_HOME>`.
 
 !!! note
-    If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
+    - If you want to install and setup the **Enterprise package** of WSO2 API Manager, download the package from the [WSO2 API Manager website](https://wso2.com/api-manager/) and follow the instructions in [Configure a Distributed API-M Deployment]({{base_path}}/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/) to setup a simple scalable deployment of WSO2 API Manager.
+    - If you have trouble locating the download link on the website, you can alternatively download the distribution directly from the [GitHub releases page](https://github.com/wso2/product-apim/releases).
 
 ## Setting up JAVA_HOME
 
@@ -104,6 +105,9 @@ You must set your `JAVA_HOME` environment variable to point to the directory whe
     4.  Enter the following information:
         -   In the **Variable name** field, enter: `JAVA_HOME`
         -   In the **Variable value** field, enter the installation path of the Java Development Kit, such as: `c:/Program Files/Java/jdk-21         `
+
+    !!! warning
+        Do not wrap the path in quotation marks when entering the Variable value (e.g. use `c:/Program Files/Java/jdk-21`, not `"c:/Program Files/Java/jdk-21"`). A stray quotation mark will cause errors such as `<path> was unexpected at this time` when starting the server.
 
     The `JAVA_HOME` variable is now set and will apply to any subsequent command prompt windows you open. If you have existing command prompt windows running, you must close and reopen them for the `JAVA_HOME` variable to take effect, or manually set the `JAVA_HOME` variable in those command prompt windows as described in the next section. To verify that the `JAVA_HOME` variable is set correctly, open a command window (from the **Start** menu, click **Run**, and then type `CMD` and click **Enter**) and execute the following command:
 


### PR DESCRIPTION
## Purpose
The installation prerequisites page only linked to the JDK compatibility page without stating the actual required JDK version for this release, so users installing WSO2 API Manager 4.7.0 had no direct way to know which JDK to install without navigating away. Using an incompatible version - such as JDK 22 or newer - causes a server startup failure with an unclear error message.

## Goals
Added the specific JDK version required for API Manager 4.7.0 (JDK 21 or JDK 25, Temurin OpenJDK) directly on the prerequisites page, along with a note on the error that appears if an incompatible version is used. Also clarified the download instructions for the Enterprise package on the installing-api-m-runtime page.

## Approach
Directly edited the two affected Markdown files to add the missing version detail and clarify the download note, keeping the existing formatting and style of the surrounding content.

## Release note
Clarified JDK version requirements and Enterprise package download instructions in the WSO2 API Manager 4.7.0 installation docs.

## User stories
>N/A — this is a documentation clarification, not a feature.

## Documentation
>N/A — this PR is the documentation update.

## Training
>N/A — no training content is affected by this change.

## Certification
>N/A — this change does not affect certification exam content.

## Marketing
>N/A — no marketing content is affected by this change.

## Automation tests
>N/A — this is a documentation-only change; no code or tests are affected.

## Security checks
- Followed secure coding standards: N/A (documentation-only change)
- Ran FindSecurityBugs plugin and verified report: N/A (documentation-only change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
>N/A — no samples are affected by this change.

## Migrations
>N/A — no migration steps required.

## Test environment
Verified the rendered documentation locally using `mkdocs serve` on Windows.

## Learning
Identified the JDK version requirement and download page ambiguity while setting up WSO2 API Manager 4.7.0 locally, and confirmed the correct JDK versions against the product compatibility page before submitting this fix.