### PR TITLE
Docs/ai cost management

### DIFF
--- a/en/docs/ai-gateway/ai-cost-management/llm-cost.md
+++ b/en/docs/ai-gateway/ai-cost-management/llm-cost.md
@@ -1,0 +1,133 @@
+# LLM Cost
+
+The **LLM Cost** is a custom Synapse mediator for the **WSO2 API Manager Classic Gateway** that calculates the monetary cost of LLM API calls. It normalizes token usage from OpenAI, Anthropic, Gemini/Vertex AI, and Mistral responses, computes the cost using configurable pricing data, and exposes the cost value as context properties for downstream policy enforcement (such as rate limiting or analytics).
+
+## Features
+
+- Provider-specific token usage normalization for **OpenAI**, **Anthropic**, **Gemini/Vertex AI**, and **Mistral**
+- Context window tiering (128k, 200k, 272k+ token thresholds)
+- Service tier rate selection (priority, flex, batch)
+- Cached input token cost calculation, including Anthropic 5-minute and 1-hour cache write TTLs
+- Reasoning token pricing
+- Audio/image modality cost support, and duration-based audio billing
+- Web search and grounding cost calculation
+- Anthropic geo-routing and `speed` multipliers
+- Fuzzy model name matching with progressive suffix stripping
+- Pricing data loaded from a **remote URL**, a **local file**, or a **bundled default**, with automatic hourly refresh for remote sources
+
+## How to Use
+
+Follow these steps to integrate the **LLM Cost** policy into your AI API:
+
+- Open the **API Publisher Portal** `(https://<host>:<port>/publisher)`
+- Select your AI API
+- Go to **Develop > API Configurations > Policies**
+- Expand **Common Policies** in the **Policy List**
+- Drag and drop the **LLM Cost** policy into **both** the request and response mediation flows
+- Fill in the required policy configuration
+- **Save and Deploy** the AI API
+
+!!! warning "Attach the policy to both flows"
+    The **LLM Cost** policy must be added to **both** the request and response mediation flows.
+
+    The request flow buffers the request payload and URL path. The response flow needs them to read pricing inputs that the provider does not echo back in its response — the Anthropic `speed` flag, `web_search_options.search_context_size`, and the Gemini model name embedded in the request path.
+
+    If the policy is attached only to the response flow it will still run, but those inputs are unavailable and the calculated cost may be **understated**. A warning is logged once per mediator instance when this is detected.
+
+### Policy Configuration
+
+| Field                              | Type    | Required | Default | Description                                                                                                                                                     |
+|------------------------------------|---------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Pricing Remote URL`               | String  | No       | –       | HTTP/HTTPS URL to fetch the model pricing JSON from. Refreshed hourly in the background.                                                                          |
+| `Pricing File Path`                | String  | No       | –       | Path to a local model pricing JSON file, read once at deployment. An `http(s)` value here is treated as a **Pricing Remote URL**.                                 |
+| `Expose Cost in Response Headers`  | Boolean | No       | `false` | When enabled, the calculated cost is also returned to the API consumer as the `x-llm-cost` and `x-llm-cost-status` response headers.                              |
+
+If neither **Pricing Remote URL** nor **Pricing File Path** is configured — or if both fail to load — the mediator falls back to the `model_prices.json` bundled inside the policy JAR, so it always has a usable pricing database.
+
+### Pricing Load and Refresh Behavior
+
+- **Initial load** happens once at deployment, in this order: **Pricing Remote URL** → **Pricing File Path** → bundled resource. The first source that yields a non-empty pricing map is used.
+- **Refresh** applies only when a **Pricing Remote URL** is configured. It runs every hour on a background thread — never on a request thread — so a slow or unreachable pricing endpoint cannot delay API traffic.
+- **A failed refresh keeps the previously loaded prices.** It does not fall back to the bundled resource, which would silently replace up-to-date remote prices with stale ones.
+- Policies configured with the same source **share a single parsed pricing map and one refresh timer** across APIs, rather than each holding its own copy.
+
+### Context Properties
+
+The policy sets the following properties on the Synapse MessageContext:
+
+| Property             | Description                                           | Example Value  |
+|----------------------|-------------------------------------------------------|----------------|
+| `x-llm-cost`         | Total calculated cost in USD, to 10 decimal places    | `0.0000423100` |
+| `x-llm-cost-status`  | Calculation status (`calculated` or `not_calculated`) | `calculated`   |
+
+These values are also returned as response headers of the same names when **Expose Cost in Response Headers** is enabled. It is disabled by default, since the cost of serving a request is operator information. Downstream policies should read the context properties.
+
+!!! note "Always check the status property"
+    `x-llm-cost-status` distinguishes a genuine zero cost from a failed calculation — both report `x-llm-cost` as `0.0000000000`. Downstream policies should check `x-llm-cost-status` before trusting the value.
+
+    A cost of `0` with status `not_calculated` is produced when the response body is empty or is not a JSON object, the pricing database is unavailable, no model name can be determined, the model has no pricing entry, its provider is unsupported, or the response is streamed.
+
+### Supported Providers
+
+| Provider  | Calculator Class      | Response Usage Fields Used                        |
+|-----------|-----------------------|---------------------------------------------------|
+| OpenAI    | `OpenAICalculator`    | `usage.prompt_tokens`, `usage.completion_tokens`, `usage.prompt_tokens_details.cached_tokens`, `usage.completion_tokens_details.reasoning_tokens`, `service_tier` |
+| Anthropic | `AnthropicCalculator` | `usage.input_tokens`, `usage.output_tokens`, `usage.cache_creation_input_tokens`, `usage.cache_read_input_tokens`, `usage.inference_geo`, `usage.server_tool_use` |
+| Gemini    | `GeminiCalculator`    | `usageMetadata.promptTokenCount`, `usageMetadata.candidatesTokenCount`, `usageMetadata.cachedContentTokenCount`, `usageMetadata.thoughtsTokenCount`, `usageMetadata.promptTokensDetails`, `usageMetadata.trafficType`, `candidates[].groundingMetadata` |
+| Mistral   | `MistralCalculator`   | `usage.prompt_tokens`, `usage.completion_tokens`, `usage.prompt_audio_seconds` |
+
+## Limitations
+
+!!! warning "Streaming responses are not supported"
+    Responses with the content type `text/event-stream` are detected and reported as `not_calculated`. They are **not** silently mispriced.
+
+    The Synapse mediator contract delivers a single fully built message rather than a stream of chunks, so token usage spread across server-sent events cannot be accumulated.
+
+    To obtain cost data for an API, disable response streaming on it.
+
+## Example Policy Configuration
+
+??? example "Click to expand configuration steps"
+    Example: Calculate cost for a Gemini model.
+
+    1. Create an AI API using Gemini (Vertex AI).
+    2. Add the **LLM Cost** policy to **both** the request and response mediation flows of the API, with the following configuration:
+
+    | Field                             | Example                                                |
+    |-----------------------------------|--------------------------------------------------------|
+    | `Pricing Remote URL`              | *(leave empty to use the bundled pricing data)*        |
+    | `Pricing File Path`               | `<PRODUCT_HOME>/configs/llm-pricing/model_prices.json` |
+    | `Expose Cost in Response Headers` | `true`                                                 |
+
+    3. Ensure the pricing file contains an entry for the model (e.g., `gemini-2.5-flash`). If you leave both pricing fields empty, the bundled pricing data is used instead.
+    4. Save and re-deploy the API.
+    5. Invoke the API's content generation endpoint:
+
+    ```json
+    {
+      "contents": [
+        {
+          "parts": [
+            {
+              "text": "Hello, how are you?"
+            }
+          ]
+        }
+      ]
+    }
+    ```
+
+    The policy calculates the cost and sets the following Synapse context properties:
+
+    ```
+    x-llm-cost: 0.0021668000
+    x-llm-cost-status: calculated
+    ```
+
+    Because **Expose Cost in Response Headers** was enabled in this example, the same values are also returned as response headers. The cost value is available to downstream policies such as rate limiting or custom analytics through the context property, using `get-property('x-llm-cost')`.
+
+## Notes
+
+- The cost is calculated in **USD** using the rates defined in the active pricing data.
+- The policy does not modify the response body or block requests — it only calculates and exposes the cost.
+- If the model name cannot be determined from the response, the policy falls back to extracting it from the request payload (`$.model`) or the request path (`/models/{name}`). This fallback requires the policy to be attached to the request flow.

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -18408,3 +18408,61 @@ connection_acquisition_timeout = 60
     </section>
 </div>
 
+
+
+## Authentication Policy
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="128" type="checkbox" id="_tab_128">
+                <label class="tab-selector" for="_tab_128"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[authentication_policy]
+disable_account_disable_handler = false</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[authentication_policy]</code>
+                            
+                            <p>
+                                Defines the authentication policy settings for WSO2 API Manager.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>disable_account_disable_handler</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Disables the account disable handler during authentication.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -18423,7 +18423,8 @@ connection_acquisition_timeout = 60
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[authentication_policy]
-disable_account_disable_handler = false</code></pre>
+disable_account_disable_handler = false
+disable_account_confirmation_validation_handler = false</code></pre>
                     </div>
                 </div>
                 <div class="doc-wrapper">
@@ -18455,6 +18456,27 @@ disable_account_disable_handler = false</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>Disables the account disable handler during authentication.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>disable_account_confirmation_validation_handler</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Disables the account confirmation validation handler during authentication.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -550,6 +550,8 @@ nav:
                 - AWS Bedrock Guardrail: ai-gateway/ai-guardrails/aws-bedrock-guardrail.md
                 - Guardrail Error Response: ai-gateway/ai-guardrails/guardrail-error-response.md
             - Semantic Caching: ai-gateway/semantic-caching.md
+            - AI Cost Management:
+                - LLM Cost: ai-gateway/ai-cost-management/llm-cost.md
             - AI APIs via SDKs: ai-gateway/using-proxy-apis-in-sdks.md
             - AI Tools:
                 - Claude Code configuration with AI Gateway: ai-gateway/ai-tools/claude-code-with-ai-gateway.md

--- a/en/tools/config-catalog-generator/data/authentication_policy.toml
+++ b/en/tools/config-catalog-generator/data/authentication_policy.toml
@@ -1,2 +1,3 @@
 [authentication_policy]
 disable_account_disable_handler = false
+disable_account_confirmation_validation_handler = false

--- a/en/tools/config-catalog-generator/data/authentication_policy.toml
+++ b/en/tools/config-catalog-generator/data/authentication_policy.toml
@@ -1,0 +1,2 @@
+[authentication_policy]
+disable_account_disable_handler = false

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6996,6 +6996,14 @@
                             "default": "false",
                             "possible": "true,false",
                             "description": "Disables the account disable handler during authentication."
+                        },
+                        {
+                            "name": "disable_account_confirmation_validation_handler",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true,false",
+                            "description": "Disables the account confirmation validation handler during authentication."
                         }
                     ]
                 }

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6980,7 +6980,28 @@
           }
         ],
         "exampleFile": "apim.aws_lambda.http_client.toml"
-      }
+      },
+        {
+            "title": "Authentication Policy",
+            "options": [
+                {
+                    "name": "authentication_policy",
+                    "required": false,
+                    "description": "Defines the authentication policy settings for WSO2 API Manager.",
+                    "params": [
+                        {
+                            "name": "disable_account_disable_handler",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true,false",
+                            "description": "Disables the account disable handler during authentication."
+                        }
+                    ]
+                }
+            ],
+            "exampleFile": "authentication_policy.toml"
+        }
     ]
 }
 


### PR DESCRIPTION
## Purpose
> Adds documentation for the **LLM Cost** policy, a Synapse mediator for the WSO2 API Manager Classic Gateway that calculates the monetary cost of LLM API calls. This policy previously shipped without corresponding product documentation.
>
> Resolves <!-- issue number(s) here, if any -->

## Goals
> Document how to configure and use the LLM Cost policy, including:
> - How to attach it via the Publisher Portal
> - Its three configuration fields (Pricing Remote URL, Pricing File Path, Expose Cost in Response Headers)
> - Pricing data load/refresh behavior and fallback order
> - The context properties it sets on the message context for downstream policies (rate limiting, analytics)
> - The requirement to attach the policy to both request and response flows, and the cost-understatement risk if it isn't

## Approach
> Added a new page, `ai-gateway/ai-cost-management/llm-cost.md`, and registered it in the navigation under **AI Gateway > AI Cost Management**. No code changes are included in this PR; it documents behavior of the LLM Cost mediator implemented in <!-- link to the carbon-apimgt PR/commit that implements this policy -->.
>
> The doc was revised after an initial pass to match actual policy behavior rather than assumed behavior — correcting the streaming-support claim (streaming responses report `not_calculated`, not a computed cost), documenting two previously-undocumented config fields, correcting the default state of response-header exposure (opt-in, not always-on), fixing the cost value's decimal formatting in the example, and adding the dual-flow attachment warning.

## User stories
> As an API Publisher, I want to understand how to attach and configure the LLM Cost policy so that I can track the cost of LLM-backed APIs and expose or consume that cost in downstream policies.

## Release note
> Added documentation for the LLM Cost policy (AI Gateway > AI Cost Management).

## Documentation
> This PR *is* the documentation change — N/A for a separate doc link.

## Training
> N/A — no training content impact identified.

## Certification
> N/A <!-- confirm: does this warrant a certification question? -->

## Marketing
> N/A <!-- link here if there's a blog post/announcement planned for this feature -->

## Automation tests
 - Unit tests
   > N/A — documentation-only change, no code.
 - Integration tests
   > N/A — documentation-only change, no code.

## Security checks
 - Followed secure coding standards: N/A (docs-only change)
 - Ran FindSecurityBugs plugin: N/A (docs-only change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> <!-- link to the carbon-apimgt PR/commit implementing the LLM Cost mediator -->

## Migrations (if applicable)
> N/A

## Test environment
> Rendered and verified locally with `mkdocs serve` (Python, MkDocs Material).

## Learning
> Reviewed the LLM Cost mediator's actual runtime behavior (pricing fallback order, refresh semantics, context properties, streaming handling) to correct assumptions made in the first draft of this documentation.
