### PR TITLE
Fix inconsistent See Also URL scheme in Create a REST API page

### DIFF
--- a/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
+++ b/en/docs/api-design-manage/design/create-api/create-rest-api/create-a-rest-api.md
@@ -177,11 +177,11 @@ Now, you have successfully created and configured a REST API. Next, [deploy the 
 
 Learn more on the concepts that you need to know when creating a REST API:
 
--   [Endpoints]({{base_path}}/manage-apis/design/endpoints/endpoint-types/)
--   [API Security]({{base_path}}/manage-apis/design/api-security/api-authentication/secure-apis-using-oauth2-tokens/)
--   [Rate Limiting]({{base_path}}/manage-apis/design/rate-limiting/introducing-throttling-use-cases/)
--   [Life Cycle Management]({{base_path}}/manage-apis/design/lifecycle-management/api-lifecycle/)
--   [API Monetization]({{base_path}}/manage-apis/design/api-monetization/monetizing-an-api/)
--   [API Visibility]({{base_path}}/manage-apis/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/)
--   [API Documentation]({{base_path}}/manage-apis/design/api-documentation/add-api-documentation/)
--   [Custom Properties]({{base_path}}/manage-apis/design/create-api/adding-custom-properties-to-apis/)
+-   [Endpoints]({{base_path}}/api-design-manage/design/endpoints/endpoint-types/)
+-   [API Security]({{base_path}}/api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens/)
+-   [Rate Limiting]({{base_path}}/api-design-manage/design/rate-limiting/set-api-level-throttling/)
+-   [Life Cycle Management]({{base_path}}/api-design-manage/design/lifecycle-management/api-lifecycle/)
+-   [API Monetization]({{base_path}}/monitoring/api-monetization/monetizing-an-api/)
+-   [API Visibility]({{base_path}}/api-design-manage/design/advanced-topics/control-api-visibility-and-subscription-availability-in-developer-portal/)
+-   [API Documentation]({{base_path}}/api-design-manage/design/api-documentation/add-api-documentation/)
+-   [Custom Properties]({{base_path}}/api-design-manage/design/create-api/adding-custom-properties-to-apis/)


### PR DESCRIPTION
## Summary

Fixes #11444.

The "See Also" section on `create-a-rest-api.md` used the old `manage-apis/` URL prefix for all 8 links, while the rest of the page uses `api-design-manage/`, per the partial migration in #10492.

## Change

Verified each of the 8 links individually against `en/redirects.yml` (the site's own old-to-new URL mapping) rather than assuming a blanket prefix swap, since 3 of them don't actually follow the simple `manage-apis/` -> `api-design-manage/` rename:

- **Endpoints**, **Life Cycle Management**, **API Visibility**, **API Documentation**, **Custom Properties** -> corrected to `api-design-manage/...` (simple prefix swap, confirmed against `redirects.yml`).
- **API Security** -> corrected to `api-security/runtime/api-authentication/secure-apis-using-oauth2-tokens/` (different top-level section entirely).
- **Rate Limiting** -> corrected to `api-design-manage/design/rate-limiting/set-api-level-throttling/` (the page itself was renamed from `introducing-throttling-use-cases`, not just moved).
- **API Monetization** -> corrected to `monitoring/api-monetization/monetizing-an-api/` (different top-level section entirely).

## Test plan

- [x] Cross-referenced each of the 8 target paths against `en/redirects.yml` to confirm the exact current location of each page.
- [x] Confirmed no `manage-apis/` references remain in the file after the fix.
