### PR TITLE
[4.7.0] Update APICTL secret creation related docs

### DIFF
--- a/en/docs/apiops/cli/encrypting-secrets-with-ctl.md
+++ b/en/docs/apiops/cli/encrypting-secrets-with-ctl.md
@@ -21,7 +21,7 @@
     </tr>
     <tr>
         <td>Symmetric</td>
-        <td>When the target runtime is configured to use AES-based secret encryption.</td>
+        <td>When the target runtime is configured to use AES-based secret encryption. Choose a ciphertext format &mdash; normal, <code>internal</code> or <code>external</code> &mdash; to match how the target runtime reads the value back; see <a href="#choose-a-ciphertext-format">Choose a ciphertext format</a>.</td>
         <td>Requires <code>apictl secret init symmetric</code>.</td>
         <td>Defaults to <code>AES/GCM/NoPadding</code>. <code>AES256</code> is also accepted as an alias.</td>
     </tr>
@@ -47,18 +47,51 @@ Symmetric encryption uses an AES-256 encryption key that must be initialized bef
     openssl rand -hex 32
     ```
 
-Run the following commands for symmetric encryption:
-
 -   **Initialization**
 
     ```bash
     apictl secret init symmetric
     ```
 
+### Choose a ciphertext format
+
+`apictl secret create symmetric` accepts an optional second argument that selects the shape of the
+encrypted value, depending on which system will read it back. All three use the exact same
+AES-256 key initialized above &mdash; only the wrapping around the ciphertext changes.
+
+<table>
+    <tr>
+        <th>Sub-mode</th>
+        <th>Command</th>
+        <th>Ciphertext shape</th>
+        <th>Use when</th>
+    </tr>
+    <tr>
+        <td>Normal (default)</td>
+        <td><code>apictl secret create symmetric</code></td>
+        <td>A single opaque base64 value &mdash; no JSON envelope</td>
+        <td>The value is only ever consumed by apictl or your own tooling, not decrypted by a WSO2 runtime's own secret-handling code</td>
+    </tr>
+    <tr>
+        <td>Internal</td>
+        <td><code>apictl secret create symmetric internal</code></td>
+        <td><code>{"c": "&lt;base64 inner&gt;", "t": "AES/GCM/NoPadding", "iv": "..."}</code>, where the inner value decodes to <code>{"cipher", "initializationVector", "keyId"}</code></td>
+        <td>The target runtime decrypts secrets via carbon-crypto-service (self-contained ciphertext format)</td>
+    </tr>
+    <tr>
+        <td>External</td>
+        <td><code>apictl secret create symmetric external</code></td>
+        <td><code>{"cipherText": "...", "iv": "..."}</code></td>
+        <td>The target runtime decrypts secrets via cipher-tool, carbon-secvault, or the current carbon-mediation secure vault</td>
+    </tr>
+</table>
+
 -   **Create encrypted secrets**
 
     ```bash
     apictl secret create symmetric
+    apictl secret create symmetric internal
+    apictl secret create symmetric external
     ```
 
     !!! info
@@ -80,12 +113,38 @@ Run the following commands for symmetric encryption:
             Repeat plain text secret:
             ```
 
-    -   Encrypt secrets defined in a properties file
+        -   Response
+
+            ```text
+            db_password : FZgqm4+P1MzURwMO0yAlQyrvKICRVuPufpGu1IYeJ1U45sb+03mY7aJl
+            ```
+
+    -   Encrypt secrets defined in a properties file, in the internal (carbon-crypto-service) format
 
         !!! example
 
             ```bash
-            apictl secret create symmetric -f ./keys/secrets.properties
+            apictl secret create symmetric internal -f ./keys/secrets.properties
+            ```
+
+        -   Response (decoded)
+
+            ```json
+            {"c":"<base64 inner>","t":"AES/GCM/NoPadding","iv":"..."}
+            ```
+
+    -   Encrypt secrets defined in a properties file, in the external (cipher-tool/carbon-secvault/carbon-mediation) format
+
+        !!! example
+
+            ```bash
+            apictl secret create symmetric external -f ./keys/secrets.properties
+            ```
+
+        -   Response (decoded)
+
+            ```json
+            {"cipherText":"...","iv":"..."}
             ```
 
     -   Encrypt secrets defined in a properties file and get a `.properties` file
@@ -93,7 +152,7 @@ Run the following commands for symmetric encryption:
         !!! example
 
             ```bash
-            apictl secret create symmetric -o file -f ./keys/secrets.properties
+            apictl secret create symmetric internal -o file -f ./keys/secrets.properties
             ```
 
     -   Encrypt secrets defined in a properties file and get a `.yaml` file
@@ -101,7 +160,7 @@ Run the following commands for symmetric encryption:
         !!! example
 
             ```bash
-            apictl secret create symmetric -o k8 -f ./keys/secrets.properties
+            apictl secret create symmetric internal -o k8 -f ./keys/secrets.properties
             ```
 
 -   **Response**

--- a/en/docs/apiops/cli/encrypting-secrets-with-ctl.md
+++ b/en/docs/apiops/cli/encrypting-secrets-with-ctl.md
@@ -56,8 +56,10 @@ Symmetric encryption uses an AES-256 encryption key that must be initialized bef
 ### Choose a ciphertext format
 
 `apictl secret create symmetric` accepts an optional second argument that selects the shape of the
-encrypted value, depending on which system will read it back. All three use the exact same
-AES-256 key initialized above &mdash; only the wrapping around the ciphertext changes.
+encrypted value, depending on which system will read it back. In every sub-mode, apictl prints (or
+writes to a file) a single base64-encoded string; for `internal` and `external`, that string decodes
+to the JSON shown below. All three sub-modes use the exact same AES-256 key initialized above
+&mdash; only the wrapping around the ciphertext changes.
 
 <table>
     <tr>
@@ -75,7 +77,7 @@ AES-256 key initialized above &mdash; only the wrapping around the ciphertext ch
     <tr>
         <td>Internal</td>
         <td><code>apictl secret create symmetric internal</code></td>
-        <td><code>{"c": "&lt;base64 inner&gt;", "t": "AES/GCM/NoPadding", "iv": "..."}</code>, where the inner value decodes to <code>{"cipher", "initializationVector", "keyId"}</code></td>
+        <td><code>{"c": "&lt;base64 inner&gt;", "t": "AES/GCM/NoPadding", "iv": "..."}</code>, where the base64-decoded inner value is <code>{"cipher": "...", "initializationVector": "...", "keyId": "..."}</code></td>
         <td>The target runtime decrypts secrets via carbon-crypto-service (self-contained ciphertext format)</td>
     </tr>
     <tr>

--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
@@ -96,10 +96,6 @@ While you are able to encrypt passwords using symmetric or asymmetric encryption
 
                 openssl rand -hex 32
 
-        !!! warning "Important"
-
-            When [encrypting secured endpoint passwords]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/#encrypting-secured-endpoint-passwords) to enable backend security encryption using this configuration, or if you have written custom mediation sequences that use secure vault lookup (`vault-lookup()`), you must use the same key for the Cipher Tool as the key configured in the `deployment.toml` file. For instructions on generating and configuring this key, see [Generate a secret key]({{base_path}}/install-and-setup/setup/security/encryption/symmetric-encryption/#generate-a-secret-key).
-
         - **For Linux**: `./ciphertool.sh -Dconfigure -Dsymmetric -Dkey.based.encryption`
 
         - **For Windows**: `ciphertool.bat -Dconfigure -Dsymmetric -Dkey.based.encryption`

--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
@@ -96,6 +96,10 @@ While you are able to encrypt passwords using symmetric or asymmetric encryption
 
                 openssl rand -hex 32
 
+        !!! warning "Important"
+
+            When [encrypting secured endpoint passwords]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/#encrypting-secured-endpoint-passwords) to enable backend security encryption using this configuration, or if you have written custom mediation sequences that use secure vault lookup (`vault-lookup()`), you must use the same key for the Cipher Tool as the key configured in the `deployment.toml` file. For instructions on generating and configuring this key, see [Generate a secret key]({{base_path}}/install-and-setup/setup/security/encryption/symmetric-encryption/#generate-a-secret-key).
+
         - **For Linux**: `./ciphertool.sh -Dconfigure -Dsymmetric -Dkey.based.encryption`
 
         - **For Windows**: `ciphertool.bat -Dconfigure -Dsymmetric -Dkey.based.encryption`


### PR DESCRIPTION
## Purpose

This pull request updates the documentation for symmetric secret encryption with `apictl`, clarifying how to select and use different ciphertext formats depending on the target runtime. The changes provide detailed guidance and examples for using the new `internal` and `external` sub-modes for secret creation.

**Documentation improvements for symmetric encryption:**

* Expanded the description of symmetric encryption in the feature comparison table to mention the choice of ciphertext format (`normal`, `internal`, or `external`) and linked to a new section explaining this choice.
* Added a new section, "Choose a ciphertext format," detailing the `normal`, `internal`, and `external` modes, their command-line usage, ciphertext shapes, and when to use each based on the target runtime's decryption method.

**Command usage and examples:**

* Updated and expanded command examples to show how to create secrets in each format, including file-based usage, expected responses, and output formats for both JSON and properties files.

### Related to
- https://github.com/wso2/product-apim-tooling/pull/1366