### PR TITLE
Add missing gateway_type configuration step for custom gateway agent

### DIFF
--- a/en/docs/api-gateway/federated-gateways/configure-custom-gateway-agent.md
+++ b/en/docs/api-gateway/federated-gateways/configure-custom-gateway-agent.md
@@ -132,11 +132,41 @@ You need to write a custom Gateway Agent bundle as explained below.
 
 1. Stop the API-M server if it is already running.
 
-2. Copy the JAR file that is generated in the `custom.gw.manager` component target directory, and add it in to the `<API-M Server>/repository/components/dropins/` directory.
+2. Copy the JAR file that is generated in the `custom.gw.manager` component target directory, and add it in to the `<API-M_HOME>/repository/components/dropins/` directory.
 
-3. Start the Server
+## Step 3 - Configure deployment.toml
 
-## Step 3 - Configure the Gateway using the Admin Portal
+Before restarting the API-M server, add your custom gateway type to the
+`gateway_type` allowlist in
+`<API-M_HOME>/repository/conf/deployment.toml`.
+
+Example configuration:
+
+```toml
+[apim]
+gateway_type = "Regular,APK,AWS,Azure,Kong,Envoy,APIPlatform,<YourType>"
+```
+
+!!! note
+
+    The gateway type is case-sensitive and must match exactly in all of the
+    following locations:
+
+    - `gateway_type` in `deployment.toml`
+    - `GatewayAgentConfiguration.getType()`
+    - `GatewayDeployer.getType()`
+    - the top-level key in `GatewayFeatureCatalog.json`
+
+    If these values do not match exactly, the custom gateway type will not be
+    recognized by API Manager. For example, registering `"CUSTOM"` in code
+    while the toml lists `Custom` will cause the type to silently fail to
+    register — the bundle loads fine, but the strings don't match.
+
+With the configuration in place, complete the restart:
+
+3. Restart the API-M server. 
+
+## Step 4 - Configure the Gateway using the Admin Portal
 
 1. Sign in to the Admin Portal using the following URL: `https://<hostname>:9443/admin`
 
@@ -146,7 +176,7 @@ You need to write a custom Gateway Agent bundle as explained below.
 
         [![Add new Gateway Environment]({{base_path}}/assets/img/deploy/add-custom-gateway-environment.png)]({{base_path}}/assets/img/deploy/add-custom-gateway-environment.png)
 
-## Step 4 - Create and Deploy API
+## Step 5 - Create and Deploy API
 
 1. Sign in to the Publisher Portal using the following URL: `https://<hostname>:9443/publisher`
 


### PR DESCRIPTION
## Purpose

Resolves wso2/api-manager#5144

The "Configure a Custom Gateway Agent" guide currently explains how to deploy the custom gateway agent bundle but does not mention adding the custom gateway type to the `gateway_type` allowlist in `deployment.toml` before restarting the API Manager server.

Without this step, the custom gateway type is not recognized by API Manager.

## Goals

- Add the missing `gateway_type` configuration step.
- Clarify that the gateway type must be added to `deployment.toml` before restarting the server.
- Document that the gateway type value is case-sensitive and must match the corresponding implementation.

## Approach

Updated the "Configure a Custom Gateway Agent" documentation by:

- Adding a new step to configure `gateway_type` in `deployment.toml`
- Including an example configuration
- Adding a note about the required case-sensitive matching
- Updating the deployment workflow to restart the server after the configuration step

## User stories

As a user configuring a custom gateway agent, I want the documentation to include all required configuration steps so that my custom gateway type is recognized by API Manager.

## Release note

Updated the documentation for configuring a custom gateway agent to include the required `gateway_type` configuration step.

## Documentation

This PR updates the following documentation page:

`en/docs/api-gateway/federated-gateways/configure-custom-gateway-agent.md`

## Training

N/A

## Certification

N/A – Documentation-only change.

## Marketing

N/A

## Automation tests

- Unit tests: N/A (documentation change)
- Integration tests: N/A (documentation change)

## Security checks

- Followed secure coding standards? N/A (documentation change)
- Ran FindSecurityBugs? N/A (documentation change)
- Confirmed no secrets are committed? Yes

## Samples

N/A

## Related PRs

N/A

## Migrations

N/A

## Test environment

Documentation reviewed for formatting and content.

## Learning

Reviewed the existing documentation and updated the deployment workflow to include the missing configuration step described in issue wso2/api-manager#5144.