### PR TITLE
[4.3.0] Update apictl links to 4.3.4 and document scope/operation import behavior

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
+++ b/en/docs/install-and-setup/setup/api-controller/getting-started-with-wso2-api-controller.md
@@ -6,13 +6,13 @@
 
 1.  Download **apictl** based on your preferred platform (i.e., Mac, Windows, Linux).
 
-    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-darwin-amd64.tar.gz)
-    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-darwin-arm64.tar.gz)
-    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-linux-i586.tar.gz)
-    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-linux-amd64.tar.gz)
-    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-linux-arm64.tar.gz)
-    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-windows-i586.zip)
-    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.3/apictl-4.3.3-windows-x64.zip)
+    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-darwin-amd64.tar.gz)
+    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-darwin-arm64.tar.gz)
+    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-linux-i586.tar.gz)
+    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-linux-amd64.tar.gz)
+    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-linux-arm64.tar.gz)
+    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-windows-i586.zip)
+    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.3.4/apictl-4.3.4-windows-x64.zip)
 
 2.  Extract the downloaded archive of the apictl to the desired location.
 3.  Navigate to the working directory where the executable apictl resides.

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach.md
@@ -143,6 +143,9 @@
 
             Make sure to set the security type as **`oauth2`** when defining the scopes. Also when defining the roles under a particular scope, put them under **x-scopes-bindings:**  as a scope name and roles mapping.        
 
+            !!! warning
+                For scopes and operations, the API definition (Swagger2/OpenAPI3 specification) is the source of truth during an API import. If scopes and operations are added to the `api.yaml` file instead of the API definition, they will be silently dropped during the import.
+
             
         !!! note
             You can define WSO2 API-M supported open API extensions for an API when defining a Swagger2 or OpenAPI3 specification to generate an API. These extensions can be used to define endpoint configurations, runtime configurations, resource level throttling, and API level throttling, transport-level security, CORS configurations and response cache configurations. The list of APIM supported OpenAPI extensions is as follows.

--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-apis-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-apis-to-different-environments.md
@@ -490,6 +490,9 @@ mentioned gateway environments. If the **deployment environments are not provide
 !!! info
     Tiers and sequences are provider-specific. If an exported tier is not already available in the importing environment, that tier is not added to the new environment. However, if an exported API sequence is not available in the importing environment, it is added.
 
+!!! warning
+    For scopes and operations, the API definition file (e.g., `swagger.yaml` in the `Definitions` directory) is the source of truth during an API import. If scopes and operations are added to the `api.yaml` file instead of the API definition, they will be silently dropped during the import.
+
 !!! tip
     **Troubleshooting**  
     


### PR DESCRIPTION
## Purpose
This pull request updates the documentation for the WSO2 API Controller to clarify the source of truth for scopes and operations during API import and to update download links for the latest `apictl` release.

**Documentation updates:**

* Clarified that for scopes and operations, the API definition file (e.g., `swagger.yaml` or Swagger2/OpenAPI3 spec) is the source of truth during API import. If these are added to `api.yaml` instead, they will be silently dropped. This warning was added to both the "Importing APIs via Dev First Approach" and "Migrating APIs to Different Environments" guides. [[1]](diffhunk://#diff-f3ccf2308ece82c0165307fbfbb991bf682587e3ace4095f0996d0988ebfe713R146-R148) [[2]](diffhunk://#diff-6769fdd5e957b94261c3b3efa27afa1b95fb65369594227cd8ec706b2b210bbaR493-R495)

**Download links update:**

* Updated all platform-specific download links in `getting-started-with-wso2-api-controller.md` to reference `apictl` version 4.3.4 instead of 4.3.3.

### api-controller/managing-apis-api-products/importing-apis-via-dev-first-approach/
<img width="1195" height="848" alt="image" src="https://github.com/user-attachments/assets/0aafb809-6370-4b96-b299-1bbbd9a4b5ab" />

### api-controller/managing-apis-api-products/migrating-apis-to-different-environments
<img width="1232" height="813" alt="image" src="https://github.com/user-attachments/assets/93dd5125-e112-4dca-9333-9e063ab29919" />
