### PR TITLE
[4.0.0] Fix: Remove unsupported pool_options fields from Redis config catalog

### DIFF
--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -15116,8 +15116,6 @@ connection_timeout = 1000
                     <div class="mb-config-example">
 <pre><code class="toml">[apim.redis_config.pool_options]
 test_on_borrow = true
-test_on_return = true
-test_while_idle = true
 max_total = 80
 max_idle = 50
 min_idle = 10
@@ -15234,48 +15232,6 @@ max_wait_millis = 2000
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>test_on_return</code> </span>
-                                </div>
-                                <div class="param-info">
-                                    <div>
-                                        <p>
-                                            <span class="param-type string"> boolean </span>
-                                            
-                                        </p>
-                                        <div class="param-default">
-                                            <span class="param-default-value">Default: <code>false</code></span>
-                                        </div>
-                                        <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
-                                        </div>
-                                    </div>
-                                    <div class="param-description">
-                                        <p>Indicates whether a connection should be validated when returned to the pool.</p>
-                                    </div>
-                                </div>
-                            </div><div class="param">
-                                <div class="param-name">
-                                  <span class="param-name-wrap"> <code>test_while_idle</code> </span>
-                                </div>
-                                <div class="param-info">
-                                    <div>
-                                        <p>
-                                            <span class="param-type string"> boolean </span>
-                                            
-                                        </p>
-                                        <div class="param-default">
-                                            <span class="param-default-value">Default: <code>true</code></span>
-                                        </div>
-                                        <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>true,false</code></span>
-                                        </div>
-                                    </div>
-                                    <div class="param-description">
-                                        <p>Specifies whether idle connections should be validated periodically during eviction runs.</p>
-                                    </div>
-                                </div>
-                            </div><div class="param">
-                                <div class="param-name">
                                   <span class="param-name-wrap"> <code>block_when_exhausted</code> </span>
                                 </div>
                                 <div class="param-info">
@@ -15331,25 +15287,6 @@ max_wait_millis = 2000
                                     </div>
                                     <div class="param-description">
                                         <p>Time interval (in milliseconds) between idle connection eviction runs. If set to a negative value, eviction will not run.</p>
-                                    </div>
-                                </div>
-                            </div><div class="param">
-                                <div class="param-name">
-                                  <span class="param-name-wrap"> <code>num_tests_per_eviction_run</code> </span>
-                                </div>
-                                <div class="param-info">
-                                    <div>
-                                        <p>
-                                            <span class="param-type string"> integer </span>
-                                            
-                                        </p>
-                                        <div class="param-default">
-                                            <span class="param-default-value">Default: <code>-1</code></span>
-                                        </div>
-                                        
-                                    </div>
-                                    <div class="param-description">
-                                        <p>Number of connections to examine during each eviction run. A negative value means all idle connections will be tested.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/tools/config-catalog-generator/data/apim.redis_config.pool_options.toml
+++ b/en/tools/config-catalog-generator/data/apim.redis_config.pool_options.toml
@@ -1,7 +1,5 @@
 [apim.redis_config.pool_options]
 test_on_borrow = true
-test_on_return = true
-test_while_idle = true
 max_total = 80
 max_idle = 50
 min_idle = 10

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -5689,22 +5689,6 @@
                             "description": "Whether to validate (PING) a connection's health before handing it out from the pool. Enable this in environments with flaky network paths to Redis to avoid handing out dead connections."
                         },
                         {
-                            "name": "test_on_return",
-                            "type": "boolean",
-                            "required": false,
-                            "default": "false",
-                            "possible": "true,false",
-                            "description": "Indicates whether a connection should be validated when returned to the pool."
-                        },
-                        {
-                            "name": "test_while_idle",
-                            "type": "boolean",
-                            "required": false,
-                            "default": "true",
-                            "possible": "true,false",
-                            "description": "Specifies whether idle connections should be validated periodically during eviction runs."
-                        },
-                        {
                             "name": "block_when_exhausted",
                             "type": "boolean",
                             "required": false,
@@ -5727,14 +5711,6 @@
                             "default": "30000",
                             "possible": "",
                             "description": "Time interval (in milliseconds) between idle connection eviction runs. If set to a negative value, eviction will not run."
-                        },
-                        {
-                            "name": "num_tests_per_eviction_run",
-                            "type": "integer",
-                            "required": false,
-                            "default": "-1",
-                            "possible": "",
-                            "description": "Number of connections to examine during each eviction run. A negative value means all idle connections will be tested."
                         }
                     ]
                 }


### PR DESCRIPTION
This pull request removes several configuration options related to Redis connection pool validation and eviction from both the documentation and the configuration generator data. The main goal is to simplify the Redis pool configuration by deprecating less commonly used options.

**Redis pool configuration simplification:**

* Removed `test_on_return` and `test_while_idle` options from the sample configuration and documentation in `en/docs/reference/config-catalog.md` and `en/tools/config-catalog-generator/data/apim.redis_config.pool_options.toml`. [[1]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15119-L15120) [[2]](diffhunk://#diff-d0fafa3783afd54e0744caac4fe59905a67549dfaf56c90bdd3277541bb80740L3-L4)
* Removed the documentation and configuration data for `test_on_return` and `test_while_idle` from the config catalog generator (`configs.json`).
* Removed the `num_tests_per_eviction_run` option from both the documentation and configuration data. [[1]](diffhunk://#diff-7a1ec3bfe7b37aecb0a419c2adb0d7fa9590afd7549a464ec9941a9f0ce2220dL15336-L15354) [[2]](diffhunk://#diff-b26b7e1f01c1d71338a9ec1ace25b50f8019b2aebe8e3d075fe1772f192e2626L5730-L5737)

### Related PR
- https://github.com/wso2/docs-apim/pull/11748

### Related Issue
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/16834