### PR TITLE
Add missing checkout to tag v1.3.3 step for Health Checker build (3.1.0)

### DIFF
--- a/en/docs/administer/logging-and-monitoring/monitoring/monitoring-server-health.md
+++ b/en/docs/administer/logging-and-monitoring/monitoring/monitoring-server-health.md
@@ -28,13 +28,15 @@ This section guides you through deploying the Carbon Health Check components in 
  
       `git clone https://github.com/[git-username]/carbon-health-check`
 
-3. Navigate to `<HEALTH_CHECK_HOME>` and build the product.
+3. Checkout to tag `v1.3.3`.
+
+4. Navigate to `<HEALTH_CHECK_HOME>` and build the product.
 
        ```
        mvn clean install
        ```
 
-4. Rename `org.wso2.carbon.healthcheck.api.core-<version-number>-SNAPSHOT.jar`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.core/target` directory, as `org.wso2.carbon.healthcheck.api.core-<version-number>.jar` and paste it in the `<API-M_HOME>/repository/components/dropins` directory.
+5. Rename `org.wso2.carbon.healthcheck.api.core-<version-number>-SNAPSHOT.jar`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.core/target` directory, as `org.wso2.carbon.healthcheck.api.core-<version-number>.jar` and paste it in the `<API-M_HOME>/repository/components/dropins` directory.
 
 5. Copy the webapp `api#health-check#v1.0.war`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.endpoint/target/` directory and paste it in the `<API-M_HOME>/repository/deployment/server/webapps` directory.
 

--- a/en/docs/administer/logging-and-monitoring/monitoring/monitoring-server-health.md
+++ b/en/docs/administer/logging-and-monitoring/monitoring/monitoring-server-health.md
@@ -38,7 +38,7 @@ This section guides you through deploying the Carbon Health Check components in 
 
 5. Rename `org.wso2.carbon.healthcheck.api.core-<version-number>-SNAPSHOT.jar`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.core/target` directory, as `org.wso2.carbon.healthcheck.api.core-<version-number>.jar` and paste it in the `<API-M_HOME>/repository/components/dropins` directory.
 
-5. Copy the webapp `api#health-check#v1.0.war`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.endpoint/target/` directory and paste it in the `<API-M_HOME>/repository/deployment/server/webapps` directory.
+6. Copy the webapp `api#health-check#v1.0.war`, which is found in the `<HEALTH_CHECK_HOME>/components/org.wso2.carbon.healthcheck.api.endpoint/target/` directory and paste it in the `<API-M_HOME>/repository/deployment/server/webapps` directory.
 
 ### Step 2 - Configure the health checker global configurations
 


### PR DESCRIPTION
## Summary

Fixes #11550.

Step 1 of "Deploy the Health Checker" instructs cloning `carbon-health-check` and building it directly with `mvn clean install`, without checking out a specific tag first. Branches 4.1.0 through 4.6.0 already have a "Checkout to tag `v1.3.3`" step; this branch was still missing it.

## Change

Added "Checkout to tag `v1.3.3`" as step 3 (right after cloning, before building), matching the wording already used on the newer branches, and renumbered the remaining steps in the same list accordingly.

## Test plan

- [x] Diffed the change against the unmodified branch to confirm only the numbered list from the insertion point onward changed, nothing else in the file.
- [x] Confirmed the full step sequence renumbers correctly with no duplicate or skipped numbers.
