### PR TITLE
Add minimum node CPU/memory requirements to k8s deployment patterns

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -6,14 +6,14 @@ This pattern deploys all WSO2 API Manager components — Control Plane, Gateway,
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory the node must provide, based on the default `resources` block in the pattern's Helm chart values.
+The table below lists the minimum CPU and memory the node must provide, based on the default `resources.requests` block in the pattern's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the chart's `default_values.yaml`. The node must have at least the requested CPU and memory free for the pod to be scheduled.
+    These are the default resource requests defined in the chart's `default_values.yaml`. The node must have at least this much CPU and memory free for the pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -4,6 +4,17 @@ This pattern deploys all WSO2 API Manager components — Control Plane, Gateway,
 
 <a href="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png"><img src="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png" alt="single-node api-m deployment" width="60%"></a>
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory the node must provide, based on the default `resources` block in the pattern's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the chart's `default_values.yaml`. The node must have at least the requested CPU and memory free for the pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -22,6 +22,17 @@ This pattern deploys WSO2 API Manager as a highly available active-active cluste
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources` block in the pattern's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least the requested CPU and memory free for the pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -24,14 +24,14 @@ This pattern deploys WSO2 API Manager as a highly available active-active cluste
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources` block in the pattern's Helm chart values.
+The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources.requests` block in the pattern's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least the requested CPU and memory free for the pod to be scheduled.
+    These are the default resource requests defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least this much CPU and memory free for the pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -32,7 +32,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Classic Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -24,15 +24,15 @@ This pattern deploys a dedicated Classic Gateway alongside the All-in-One node, 
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| Classic Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -22,6 +22,18 @@ This pattern deploys a dedicated Classic Gateway alongside the All-in-One node, 
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -24,16 +24,16 @@ This pattern deploys dedicated nodes for the API Control Plane, Traffic Manager,
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
-| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
-| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+| API Control Plane (ACP) | 2 | 2Gi |
+| Traffic Manager (TM) | 2 | 2Gi |
+| Classic Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -22,6 +22,19 @@ This pattern deploys dedicated nodes for the API Control Plane, Traffic Manager,
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
+| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
+| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -33,7 +33,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Classic Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -26,6 +26,20 @@ This pattern adds a dedicated Key Manager to the Pattern 3 setup, separating tok
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
+| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
+| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -38,7 +38,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -28,17 +28,17 @@ This pattern adds a dedicated Key Manager to the Pattern 3 setup, separating tok
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
-| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
-| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
-| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+| API Control Plane (ACP) | 2 | 2Gi |
+| Traffic Manager (TM) | 2 | 2Gi |
+| Classic Gateway | 2 | 2Gi |
+| Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -27,16 +27,16 @@ This pattern extends Pattern 2 by adding a dedicated Key Manager alongside the A
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
-| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| Classic Gateway | 2 | 2Gi |
+| Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -36,7 +36,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -25,6 +25,19 @@ This pattern extends Pattern 2 by adding a dedicated Key Manager alongside the A
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| Classic Gateway | 2 / 3 | 2Gi / 3Gi |
+| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -37,7 +37,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | WSO2 Identity Server | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -29,15 +29,15 @@ This pattern deploys WSO2 API Manager as a single All-in-One node with WSO2 Iden
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in the respective Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in the respective Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| WSO2 Identity Server | 2 / 3 | 2Gi / 4Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| WSO2 Identity Server | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -27,6 +27,18 @@ This pattern deploys WSO2 API Manager as a single All-in-One node with WSO2 Iden
 
     Detailed steps for each of the above are explained in the sections below.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in the respective Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| WSO2 Identity Server | 2 / 3 | 2Gi / 4Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Purpose
The k8s deployment pattern docs (Patterns 0-6) didn't state the minimum CPU/memory a node needs before deploying.

## Changes
Added a "Minimum Node Requirements" table to each pattern doc, listing the minimum CPU and memory per component — taken from `resources.requests` in each component's Helm chart (`helm-apim`, plus `identity-server` for Pattern 6's WSO2 IS component).

## Validation
Cross-checked every value against the chart's default `values.yaml`.