### PR TITLE
Add minimum node CPU/memory requirements to k8s deployment patterns

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -6,14 +6,14 @@ This pattern deploys all WSO2 API Manager components — Control Plane, Gateway,
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory the node must provide, based on the default `resources` block in the pattern's Helm chart values.
+The table below lists the minimum CPU and memory the node must provide, based on the default `resources.requests` block in the pattern's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the chart's `default_values.yaml`. The node must have at least the requested CPU and memory free for the pod to be scheduled.
+    These are the default resource requests defined in the chart's `default_values.yaml`. The node must have at least this much CPU and memory free for the pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-0-all-in-one.md
@@ -4,6 +4,17 @@ This pattern deploys all WSO2 API Manager components — Control Plane, Gateway,
 
 <a href="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png"><img src="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png" alt="single-node api-m deployment" width="60%"></a>
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory the node must provide, based on the default `resources` block in the pattern's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the chart's `default_values.yaml`. The node must have at least the requested CPU and memory free for the pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -20,6 +20,17 @@ This pattern deploys WSO2 API Manager as a highly available active-active cluste
     2. **A custom Docker image** — the default WSO2 image does not include JDBC drivers. Build and push a custom image before deploying.
     3. **Database schema initialised** — run the WSO2 schema scripts against both databases before the pods start.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources` block in the pattern's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least the requested CPU and memory free for the pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-1-all-in-one-ha.md
@@ -22,14 +22,14 @@ This pattern deploys WSO2 API Manager as a highly available active-active cluste
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources` block in the pattern's Helm chart values.
+The table below lists the minimum CPU and memory each of the two nodes must provide, based on the default `resources.requests` block in the pattern's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least the requested CPU and memory free for the pod to be scheduled.
+    These are the default resource requests defined in the chart's `default_values.yaml`, and apply to **each** of the two active-active nodes. Each node must have at least this much CPU and memory free for the pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -22,15 +22,15 @@ This pattern deploys a dedicated Universal Gateway alongside the All-in-One node
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| Universal Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -30,7 +30,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Universal Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-2-all-in-one-gw.md
@@ -20,6 +20,18 @@ This pattern deploys a dedicated Universal Gateway alongside the All-in-One node
     2. **Two custom Docker images** — one for the All-in-One node and one for the Universal Gateway, both with the JDBC driver for your database.
     3. **Database schema initialised** — run the WSO2 schema scripts against both databases before the pods start.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -22,16 +22,16 @@ This pattern deploys dedicated nodes for the API Control Plane, Traffic Manager,
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
-| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
-| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+| API Control Plane (ACP) | 2 | 2Gi |
+| Traffic Manager (TM) | 2 | 2Gi |
+| Universal Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -31,7 +31,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Universal Gateway | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-3-acp-tm-gw.md
@@ -20,6 +20,19 @@ This pattern deploys dedicated nodes for the API Control Plane, Traffic Manager,
     2. **Three custom Docker images** — for the API Control Plane, Traffic Manager, and Universal Gateway, all with the JDBC driver for your database.
     3. **Database schema initialised** — run the WSO2 schema scripts against both databases before the pods start.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
+| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
+| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -26,17 +26,17 @@ This pattern adds a dedicated Key Manager to the Pattern 3 setup, separating tok
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
-| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
-| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
-| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+| API Control Plane (ACP) | 2 | 2Gi |
+| Traffic Manager (TM) | 2 | 2Gi |
+| Universal Gateway | 2 | 2Gi |
+| Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -36,7 +36,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-4-acp-tm-gw-km.md
@@ -24,6 +24,20 @@ This pattern adds a dedicated Key Manager to the Pattern 3 setup, separating tok
     2. **Three custom Docker images** — for the API Control Plane, Traffic Manager, and Universal Gateway, all with the JDBC driver for your database. The Key Manager reuses the ACP image.
     3. **Database schema initialised** — run the WSO2 schema scripts against both databases before the pods start.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Control Plane (ACP) | 2 / 3 | 2Gi / 5Gi |
+| Traffic Manager (TM) | 2 / 3 | 2Gi / 3Gi |
+| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -34,7 +34,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -23,6 +23,19 @@ This pattern extends Pattern 2 by adding a dedicated Key Manager alongside the A
     2. **Three custom Docker images** — for the All-in-One, the Universal Gateway, and the ACP (shared with the Key Manager), all with the JDBC driver for your database.
     3. **Database schema initialised** — run the WSO2 schema scripts against both databases before the pods start.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
+| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+
+!!! note
+    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-5-all-in-one-gw-km.md
@@ -25,16 +25,16 @@ This pattern extends Pattern 2 by adding a dedicated Key Manager alongside the A
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in each component's Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in each component's Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| Universal Gateway | 2 / 3 | 2Gi / 3Gi |
-| Key Manager (KM) | 2 / 3 | 2Gi / 3Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| Universal Gateway | 2 | 2Gi |
+| Key Manager (KM) | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in each component's `default_values.yaml`. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in each component's `default_values.yaml`. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -33,7 +33,7 @@ The table below lists the minimum CPU and memory each node must provide, based o
 | WSO2 Identity Server | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled. This assumes each component runs on its own dedicated node, as described above — if you co-locate multiple components on a shared node, that node needs the sum of their requests.
 
 ---
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -23,6 +23,18 @@ This pattern deploys WSO2 API Manager as a single All-in-One node with WSO2 Iden
 
     1. **One custom Docker image** — for WSO2 Identity Server, with the APIM notification event handler JAR included.
 
+## Minimum Node Requirements
+
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in the respective Helm chart values.
+
+| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+|---|---|---|
+| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
+| WSO2 Identity Server | 2 / 3 | 2Gi / 4Gi |
+
+!!! note
+    These are the default resource requests and limits defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+
 ---
 
 ## Quick Start

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/kubernetes/am-pattern-6-all-in-one-is-as-km.md
@@ -25,15 +25,15 @@ This pattern deploys WSO2 API Manager as a single All-in-One node with WSO2 Iden
 
 ## Minimum Node Requirements
 
-The table below lists the minimum CPU and memory each node must provide, based on the default `resources` block in the respective Helm chart values.
+The table below lists the minimum CPU and memory each node must provide, based on the default `resources.requests` block in the respective Helm chart values.
 
-| Component | CPU cores (Request / Limit) | Memory (Request / Limit) |
+| Component | Minimum CPU (cores) | Minimum Memory |
 |---|---|---|
-| API Manager (All-in-One) | 2 / 3 | 2Gi / 3Gi |
-| WSO2 Identity Server | 2 / 3 | 2Gi / 4Gi |
+| API Manager (All-in-One) | 2 | 2Gi |
+| WSO2 Identity Server | 2 | 2Gi |
 
 !!! note
-    These are the default resource requests and limits defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least the requested CPU and memory free for that component's pod to be scheduled.
+    These are the default resource requests defined in the `wso2am-all-in-one` and `identity-server` Helm charts. Each node must have at least this much CPU and memory free for that component's pod to be scheduled.
 
 ---
 


### PR DESCRIPTION
## Purpose
The k8s deployment pattern docs (Patterns 0-6) didn't state the minimum CPU/memory a node needs before deploying.

## Changes
Added a "Minimum Node Requirements" table to each pattern doc, listing the minimum CPU and memory per component — taken from `resources.requests` in each component's Helm chart (`helm-apim`, plus `identity-server` for Pattern 6's WSO2 IS component).

## Validation
Cross-checked every value against the chart's default `values.yaml`.