### PR TITLE
Document declarative Platform Gateway onboarding via deployment.toml

### DIFF
--- a/en/docs/api-gateway/platform-gateway/adding-and-managing-policies.md
+++ b/en/docs/api-gateway/platform-gateway/adding-and-managing-policies.md
@@ -38,3 +38,4 @@ See [Policy Hub](https://wso2.com/api-platform/policy-hub) for available policie
 ## What's next
 
 - Return to [Getting Started]({{base_path}}/api-gateway/platform-gateway/getting-started/) to test API invocation with and without API-key-based authentication.
+- See [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/) to onboard a gateway declaratively instead of through the Admin Portal.

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -18,8 +18,6 @@ Before you begin, ensure that you have the following:
 
 ## Create a Platform Gateway in the Admin Portal
 
-You can create a Platform Gateway from the Admin Portal (below), or declare it directly in `deployment.toml` without using the Admin Portal at all (see [Register a Platform Gateway via deployment.toml](#register-a-platform-gateway-via-deploymenttoml)).
-
 1. Sign in to the **Admin Portal**.
 2. Go to the **Gateways** section from the left navigation panel.
 3. In the **WSO2 Gateways** section, click **Add WSO2 Gateways**.
@@ -47,42 +45,6 @@ You can create a Platform Gateway from the Admin Portal (below), or declare it d
     ![Gateway Add](../../assets/img/api-gateway/platform-gateway/gateway-add.png)
 
 6. Click **Add**.
-
-## Register a Platform Gateway via deployment.toml
-
-!!! note
-    This feature is available in WSO2 API Manager 4.7.0 starting from update level 7.
-
-As an alternative to the Admin Portal, you can declare a Platform Gateway directly in `<API-M_HOME>/repository/conf/deployment.toml`. This lets you onboard a gateway purely through configuration, for example to automate provisioning with GitOps. The gateway record is not created at Control Plane startup - it is created the first time the gateway connects, using the details below.
-
-1. Add a `[[apim.platform_gateway.connect]]` entry in `deployment.toml`:
-
-    ```toml
-    [[apim.platform_gateway.connect]]
-    registration_token = "$env{PLATFORM_GW_1_REGISTRATION_TOKEN}"
-    name = "platform-gw-1"
-    display_name = "Production Platform Gateway"
-    description = "Platform Gateway for production traffic"
-    url = "https://<gateway-host>:<gateway-port>"
-    organization = "carbon.super"
-    ```
-
-    | Parameter | Required | Description |
-    |---|---|---|
-    | `registration_token` | Yes | The gateway's registration token, in `<token-id>.<plain-token>` format. Choose any value for `<token-id>` (for example a UUID) and `<plain-token>` (for example a random string) - you are defining the token, not copying one from the Admin Portal. Use this same value as `GATEWAY_REGISTRATION_TOKEN` when you configure the gateway in [Step 2: Configure the Gateway](#step-2-configure-the-gateway). Reference it with WSO2's `$env{...}` syntax (as shown above) instead of a literal value, especially if `deployment.toml` is checked into version control (for example under GitOps). |
-    | `url` | Yes | The URL where the gateway will be accessible, for example `https://<gateway-host>:<gateway-port>`. |
-    | `name` | No | Environment name shown in the Control Plane. Defaults to an ID derived from `registration_token`. |
-    | `display_name` | No | Display name shown in the Admin Portal and Publisher Portal. Defaults to `name`. |
-    | `description` | No | Optional description of the gateway. |
-    | `organization` | No | Tenant organization that owns the gateway. Defaults to `carbon.super`. A Platform Gateway is always scoped to a single tenant; `WSO2-ALL-TENANTS` is not supported here. |
-
-    You can repeat the `[[apim.platform_gateway.connect]]` block to declare multiple gateways. For the full parameter reference, see [apim.platform_gateway.connect]({{base_path}}/reference/config-catalog/#api-m-platform-gateway-connect-configurations) in the Configuration Catalog.
-
-2. Restart API Manager. `registration_token` and `url` are validated for every entry at startup; fix and restart if the server logs a configuration error.
-3. Continue from [Setup the Gateway](#setup-the-gateway) below to download, configure, and start the gateway. In [Step 2: Configure the Gateway](#step-2-configure-the-gateway), set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port as usual. The gateway is registered automatically the moment it connects - no Admin Portal step is required.
-
-!!! note
-    If you later regenerate this gateway's token from the Admin Portal, update `registration_token` in `deployment.toml` to match. Once a gateway has connected, its stored token is authoritative, so a stale value in `deployment.toml` will fail to authenticate.
 
 ## Setup the Gateway
 
@@ -113,7 +75,7 @@ GATEWAY_REGISTRATION_TOKEN=<your-gateway-token>
 ENVFILE
 ```
 
-When you copy this command from the UI, the placeholder values are populated automatically. If you registered the gateway via `deployment.toml`, set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port, and set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured in `deployment.toml`.
+When you copy this command from the UI, the placeholder values are populated automatically.
 
 ### Step 3: Start the Gateway
 
@@ -246,3 +208,4 @@ If authentication fails, confirm the policy is deployed, the header names match 
 
 - [Setting Up Platform Gateway]({{base_path}}/api-gateway/platform-gateway/setting-up/)
 - [Adding and Managing Policies]({{base_path}}/api-gateway/platform-gateway/adding-and-managing-policies/)
+- [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/)

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -55,12 +55,9 @@ You can create a Platform Gateway from the Admin Portal (below), or declare it d
 
 As an alternative to the Admin Portal, you can declare a Platform Gateway directly in `<API-M_HOME>/repository/conf/deployment.toml`. This lets you onboard a gateway purely through configuration, for example to automate provisioning with GitOps. The gateway record is not created at Control Plane startup - it is created the first time the gateway connects, using the details below.
 
-1. Add a `[[apim.platform_gateway.connect]]` entry under `[apim.platform_gateway]` in `deployment.toml`:
+1. Add a `[[apim.platform_gateway.connect]]` entry in `deployment.toml`:
 
     ```toml
-    [apim.platform_gateway]
-    versions = ["1.0.0"]
-
     [[apim.platform_gateway.connect]]
     registration_token = "$env{PLATFORM_GW_1_REGISTRATION_TOKEN}"
     name = "platform-gw-1"
@@ -98,7 +95,7 @@ As an alternative to the Admin Portal, you can declare a Platform Gateway direct
 
 ### Step 1: Download the Gateway
 
-Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`). If you registered the gateway via `deployment.toml`, use one of the versions listed in `apim.platform_gateway.versions` (the Admin Portal has no generated command until the gateway connects for the first time).
+Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`).
 
 ```bash
 curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/<gateway-version>/wso2apip-api-gateway-<gateway-version>.zip && \

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -18,6 +18,8 @@ Before you begin, ensure that you have the following:
 
 ## Create a Platform Gateway in the Admin Portal
 
+You can create a Platform Gateway from the Admin Portal (below), or declare it directly in `deployment.toml` without using the Admin Portal at all (see [Register a Platform Gateway via deployment.toml](#register-a-platform-gateway-via-deploymenttoml)).
+
 1. Sign in to the **Admin Portal**.
 2. Go to the **Gateways** section from the left navigation panel.
 3. In the **WSO2 Gateways** section, click **Add WSO2 Gateways**.
@@ -46,6 +48,44 @@ Before you begin, ensure that you have the following:
 
 6. Click **Add**.
 
+## Register a Platform Gateway via deployment.toml
+
+!!! note
+    This feature is available in WSO2 API Manager 4.7.0 starting from update level 7.
+
+As an alternative to the Admin Portal, you can declare a Platform Gateway directly in `<API-M_HOME>/repository/conf/deployment.toml`. This lets you onboard a gateway purely through configuration, for example to automate provisioning with GitOps. The gateway record is not created at Control Plane startup - it is created the first time the gateway connects, using the details below.
+
+1. Add a `[[apim.platform_gateway.connect]]` entry under `[apim.platform_gateway]` in `deployment.toml`:
+
+    ```toml
+    [apim.platform_gateway]
+    versions = ["1.0.0"]
+
+    [[apim.platform_gateway.connect]]
+    registration_token = "<token-id>.<plain-token>"
+    name = "platform-gw-1"
+    display_name = "Production Platform Gateway"
+    description = "Platform Gateway for production traffic"
+    url = "https://<gateway-host>:<gateway-port>"
+    organization = "carbon.super"
+    ```
+
+    | Parameter | Required | Description |
+    |---|---|---|
+    | `registration_token` | Yes | The gateway's registration token, in `<token-id>.<plain-token>` format. Choose any value for `<token-id>` (for example a UUID) and `<plain-token>` (for example a random string) - you are defining the token, not copying one from the Admin Portal. Use this same value as `GATEWAY_REGISTRATION_TOKEN` when you configure the gateway in [Step 2: Configure the Gateway](#step-2-configure-the-gateway). |
+    | `url` | Yes | The URL where the gateway will be accessible, for example `https://<gateway-host>:<gateway-port>`. |
+    | `name` | No | Environment name shown in the Control Plane. Defaults to an ID derived from `registration_token`. |
+    | `display_name` | No | Display name shown in the Admin Portal and Publisher Portal. Defaults to `name`. |
+    | `organization` | No | Tenant organization that owns the gateway. Defaults to `carbon.super`. A Platform Gateway is always scoped to a single tenant; `WSO2-ALL-TENANTS` is not supported here. |
+
+    You can repeat the `[[apim.platform_gateway.connect]]` block to declare multiple gateways. For the full parameter reference, see [apim.platform_gateway.connect]({{base_path}}/reference/config-catalog/#api-m-platform-gateway-connect-configurations) in the Configuration Catalog.
+
+2. Restart API Manager. `registration_token` and `url` are validated for every entry at startup; fix and restart if the server logs a configuration error.
+3. Continue from [Setup the Gateway](#setup-the-gateway) below to download, configure, and start the gateway. In [Step 2: Configure the Gateway](#step-2-configure-the-gateway), set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port as usual. The gateway is registered automatically the moment it connects - no Admin Portal step is required.
+
+!!! note
+    If you later regenerate this gateway's token from the Admin Portal, update `registration_token` in `deployment.toml` to match. Once a gateway has connected, its stored token is authoritative, so a stale value in `deployment.toml` will fail to authenticate.
+
 ## Setup the Gateway
 
 1. Next, download, configure, and start the gateway on your machine by following the steps in the **Quick Start** section or the detailed instructions below (Steps 1-4).
@@ -57,7 +97,7 @@ Before you begin, ensure that you have the following:
 
 ### Step 1: Download the Gateway
 
-Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`):
+Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`). If you registered the gateway via `deployment.toml`, use one of the versions listed in `apim.platform_gateway.versions` (the Admin Portal has no generated command until the gateway connects for the first time).
 
 ```bash
 curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/<gateway-version>/wso2apip-api-gateway-<gateway-version>.zip && \
@@ -75,7 +115,7 @@ GATEWAY_REGISTRATION_TOKEN=<your-gateway-token>
 ENVFILE
 ```
 
-When you copy this command from the UI, the placeholder values are populated automatically.
+When you copy this command from the UI, the placeholder values are populated automatically. If you registered the gateway via `deployment.toml`, set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port, and set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured in `deployment.toml`.
 
 ### Step 3: Start the Gateway
 

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -62,7 +62,7 @@ As an alternative to the Admin Portal, you can declare a Platform Gateway direct
     versions = ["1.0.0"]
 
     [[apim.platform_gateway.connect]]
-    registration_token = "<token-id>.<plain-token>"
+    registration_token = "$env{PLATFORM_GW_1_REGISTRATION_TOKEN}"
     name = "platform-gw-1"
     display_name = "Production Platform Gateway"
     description = "Platform Gateway for production traffic"
@@ -72,10 +72,11 @@ As an alternative to the Admin Portal, you can declare a Platform Gateway direct
 
     | Parameter | Required | Description |
     |---|---|---|
-    | `registration_token` | Yes | The gateway's registration token, in `<token-id>.<plain-token>` format. Choose any value for `<token-id>` (for example a UUID) and `<plain-token>` (for example a random string) - you are defining the token, not copying one from the Admin Portal. Use this same value as `GATEWAY_REGISTRATION_TOKEN` when you configure the gateway in [Step 2: Configure the Gateway](#step-2-configure-the-gateway). |
+    | `registration_token` | Yes | The gateway's registration token, in `<token-id>.<plain-token>` format. Choose any value for `<token-id>` (for example a UUID) and `<plain-token>` (for example a random string) - you are defining the token, not copying one from the Admin Portal. Use this same value as `GATEWAY_REGISTRATION_TOKEN` when you configure the gateway in [Step 2: Configure the Gateway](#step-2-configure-the-gateway). Reference it with WSO2's `$env{...}` syntax (as shown above) instead of a literal value, especially if `deployment.toml` is checked into version control (for example under GitOps). |
     | `url` | Yes | The URL where the gateway will be accessible, for example `https://<gateway-host>:<gateway-port>`. |
     | `name` | No | Environment name shown in the Control Plane. Defaults to an ID derived from `registration_token`. |
     | `display_name` | No | Display name shown in the Admin Portal and Publisher Portal. Defaults to `name`. |
+    | `description` | No | Optional description of the gateway. |
     | `organization` | No | Tenant organization that owns the gateway. Defaults to `carbon.super`. A Platform Gateway is always scoped to a single tenant; `WSO2-ALL-TENANTS` is not supported here. |
 
     You can repeat the `[[apim.platform_gateway.connect]]` block to declare multiple gateways. For the full parameter reference, see [apim.platform_gateway.connect]({{base_path}}/reference/config-catalog/#api-m-platform-gateway-connect-configurations) in the Configuration Catalog.

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -57,7 +57,7 @@ Before you begin, ensure that you have the following:
 
 ### Step 1: Download the Gateway
 
-Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`).
+Prefer the download command shown in the Admin Portal for your gateway so the release version always matches the connector. Alternatively, replace `<gateway-version>` in the following example with that release tag (for example, `v1.0.0`):
 
 ```bash
 curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/<gateway-version>/wso2apip-api-gateway-<gateway-version>.zip && \

--- a/en/docs/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
+++ b/en/docs/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
@@ -33,10 +33,10 @@ As an alternative to the Admin Portal, you can declare a Platform Gateway direct
 2. Restart API Manager. `registration_token` and `url` are validated for every entry at startup; fix and restart if the server logs a configuration error.
 
 !!! note
-    If you later regenerate this gateway's token from the Admin Portal, update `registration_token` in `deployment.toml` to match. Once a gateway has connected, its stored token is authoritative, so a stale value in `deployment.toml` will fail to authenticate.
+    If you later regenerate this gateway's token from the Admin Portal, update the environment variable or secret referenced by `PLATFORM_GW_1_REGISTRATION_TOKEN` and the gateway runtime's `GATEWAY_REGISTRATION_TOKEN` together - don't replace the `$env{...}` reference in `deployment.toml` with the literal token. Once a gateway has connected, its stored token is authoritative, so a stale value on either side will fail to authenticate.
 
 ## Start the gateway
 
-Continue with [Setup the Gateway]({{base_path}}/api-gateway/platform-gateway/getting-started/#setup-the-gateway) in the Getting Started guide to download, configure, and start the gateway. When you create `configs/keys.env`, set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port. The gateway registers automatically the moment it connects - no Admin Portal step is required.
+Continue with [Setup the Gateway]({{base_path}}/api-gateway/platform-gateway/getting-started/#setup-the-gateway) in the Getting Started guide to download, configure, and start the gateway. When you create `configs/keys.env`, set `GATEWAY_REGISTRATION_TOKEN` to the same value you stored in `PLATFORM_GW_1_REGISTRATION_TOKEN` above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port. The gateway registers automatically the moment it connects - no Admin Portal step is required.
 
 Once the gateway is running and connected, continue with [Add an API and invoke it]({{base_path}}/api-gateway/platform-gateway/getting-started/#add-an-api-and-invoke-it) in the Getting Started guide.

--- a/en/docs/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
+++ b/en/docs/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
@@ -1,0 +1,42 @@
+# Registering a Platform Gateway via deployment.toml
+
+!!! note
+    This feature is available in WSO2 API Manager 4.7.0 starting from update level 7.
+
+As an alternative to the Admin Portal, you can declare a Platform Gateway directly in `<API-M_HOME>/repository/conf/deployment.toml`. This lets you onboard a gateway purely through configuration, for example to automate provisioning with GitOps. The gateway record is not created at Control Plane startup - it is created the first time the gateway connects, using the details below.
+
+## Configure the gateway
+
+1. Add a `[[apim.platform_gateway.connect]]` entry in `deployment.toml`:
+
+    ```toml
+    [[apim.platform_gateway.connect]]
+    registration_token = "$env{PLATFORM_GW_1_REGISTRATION_TOKEN}"
+    name = "platform-gw-1"
+    display_name = "Production Platform Gateway"
+    description = "Platform Gateway for production traffic"
+    url = "https://<gateway-host>:<gateway-port>"
+    organization = "carbon.super"
+    ```
+
+    | Parameter | Required | Description |
+    |---|---|---|
+    | `registration_token` | Yes | The gateway's registration token, in `<token-id>.<plain-token>` format. Choose any value for `<token-id>` (for example a UUID) and `<plain-token>` (for example a random string) - you are defining the token, not copying one from the Admin Portal. Use this same value as `GATEWAY_REGISTRATION_TOKEN` when you configure the gateway. Reference it with WSO2's `$env{...}` syntax (as shown above) instead of a literal value, especially if `deployment.toml` is checked into version control (for example under GitOps). |
+    | `url` | Yes | The URL where the gateway will be accessible, for example `https://<gateway-host>:<gateway-port>`. |
+    | `name` | No | Environment name shown in the Control Plane. Defaults to an ID derived from `registration_token`. |
+    | `display_name` | No | Display name shown in the Admin Portal and Publisher Portal. Defaults to `name`. |
+    | `description` | No | Optional description of the gateway. |
+    | `organization` | No | Tenant organization that owns the gateway. Defaults to `carbon.super`. A Platform Gateway is always scoped to a single tenant; `WSO2-ALL-TENANTS` is not supported here. |
+
+    You can repeat the `[[apim.platform_gateway.connect]]` block to declare multiple gateways. For the full parameter reference, see [apim.platform_gateway.connect]({{base_path}}/reference/config-catalog/#api-m-platform-gateway-connect-configurations) in the Configuration Catalog.
+
+2. Restart API Manager. `registration_token` and `url` are validated for every entry at startup; fix and restart if the server logs a configuration error.
+
+!!! note
+    If you later regenerate this gateway's token from the Admin Portal, update `registration_token` in `deployment.toml` to match. Once a gateway has connected, its stored token is authoritative, so a stale value in `deployment.toml` will fail to authenticate.
+
+## Start the gateway
+
+Continue with [Setup the Gateway]({{base_path}}/api-gateway/platform-gateway/getting-started/#setup-the-gateway) in the Getting Started guide to download, configure, and start the gateway. When you create `configs/keys.env`, set `GATEWAY_REGISTRATION_TOKEN` to the same `registration_token` value you configured above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port. The gateway registers automatically the moment it connects - no Admin Portal step is required.
+
+Once the gateway is running and connected, continue with [Add an API and invoke it]({{base_path}}/api-gateway/platform-gateway/getting-started/#add-an-api-and-invoke-it) in the Getting Started guide.

--- a/en/docs/api-gateway/platform-gateway/setting-up.md
+++ b/en/docs/api-gateway/platform-gateway/setting-up.md
@@ -217,3 +217,4 @@ This guide provides detailed instructions for deploying Platform Gateway in prod
 ## What's Next?
 
 - [Adding and Managing Policies]({{base_path}}/api-gateway/platform-gateway/adding-and-managing-policies/)
+- [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/)

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3926,6 +3926,220 @@ data_retention_period = "30d"
 
 
 
+## API-M platform gateway configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="126" type="checkbox" id="_tab_126">
+                <label class="tab-selector" for="_tab_126"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[apim.platform_gateway]
+versions = ["1.0.0", "1.1.0"]
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.platform_gateway]</code>
+                            
+                            <p>
+                                Configuration for Platform Gateway, a lightweight gateway distribution used for hybrid API Platform deployments.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>versions</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> array </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>[]</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>List of Platform Gateway package version strings. These values are listed in the <b>Gateway version</b> drop-down when adding or editing a platform gateway from the Admin Portal.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
+## API-M platform gateway connect configurations
+
+
+<div class="mb-config-catalog">
+    <section>
+        <div class="mb-config-options">
+            <div class="superfences-tabs">
+            
+            <input name="127" type="checkbox" id="_tab_127">
+                <label class="tab-selector" for="_tab_127"><i class="icon fa fa-code"></i></label>
+                <div class="superfences-content">
+                    <div class="mb-config-example">
+<pre><code class="toml">[[apim.platform_gateway.connect]]
+registration_token = "&lt;token-id&gt;.&lt;plain-token&gt;"
+name = "platform-gw-1"
+display_name = "Production Platform Gateway"
+description = "Platform Gateway for production traffic"
+url = "https://&lt;gateway-host&gt;:&lt;gateway-port&gt;"
+organization = "carbon.super"
+</code></pre>
+                    </div>
+                </div>
+                <div class="doc-wrapper">
+                    <div class="mb-config">
+                        <div class="config-wrap">
+                            <code>[apim.platform_gateway.connect]</code>
+                            
+                            <p>
+                                Declares a Platform Gateway that is registered through <code>deployment.toml</code> instead of the Admin Portal. Repeat this array-of-tables block once per gateway. The gateway record is created the first time the gateway connects to the Control Plane, not at startup. Note that this configuration is available in wso2am-4.7.0 starting from update level 7.
+                            </p>
+                        </div>
+                        <div class="params-wrap">
+                            <div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>registration_token</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The gateway's registration token, in <code>&lt;token-id&gt;.&lt;plain-token&gt;</code> format. Choose any value for <code>&lt;token-id&gt;</code> (for example a UUID) and <code>&lt;plain-token&gt;</code> (for example a random string) - this token is defined here, not copied from the Admin Portal. Configure the same value as <code>GATEWAY_REGISTRATION_TOKEN</code> on the gateway.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>url</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The URL where the gateway will be accessible, for example <code>https://&lt;gateway-host&gt;:&lt;gateway-port&gt;</code>. Must be a valid <code>http</code> or <code>https</code> URL with a host.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>name</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Environment name shown in the Control Plane. Use lowercase letters, numbers, and hyphens only. Defaults to an ID derived from <code>registration_token</code> when not set.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>display_name</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Display name shown in the Admin Portal and Publisher Portal. Defaults to <code>name</code> when not set.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>description</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Optional description of the gateway.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>organization</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>carbon.super</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Tenant organization that owns the gateway. A Platform Gateway is always scoped to a single tenant; <code>WSO2-ALL-TENANTS</code> is not supported here.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+
+
 ## API-M Mutual SSL Configuration
 
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -3996,7 +3996,7 @@ versions = ["1.0.0", "1.1.0"]
                 <div class="superfences-content">
                     <div class="mb-config-example">
 <pre><code class="toml">[[apim.platform_gateway.connect]]
-registration_token = "&lt;token-id&gt;.&lt;plain-token&gt;"
+registration_token = "$env{PLATFORM_GW_1_REGISTRATION_TOKEN}"
 name = "platform-gw-1"
 display_name = "Production Platform Gateway"
 description = "Platform Gateway for production traffic"
@@ -4008,7 +4008,7 @@ organization = "carbon.super"
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
-                            <code>[apim.platform_gateway.connect]</code>
+                            <code>[[apim.platform_gateway.connect]]</code>
                             
                             <p>
                                 Declares a Platform Gateway that is registered through <code>deployment.toml</code> instead of the Admin Portal. Repeat this array-of-tables block once per gateway. The gateway record is created the first time the gateway connects to the Control Plane, not at startup. Note that this configuration is available in wso2am-4.7.0 starting from update level 7.
@@ -4031,7 +4031,7 @@ organization = "carbon.super"
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The gateway's registration token, in <code>&lt;token-id&gt;.&lt;plain-token&gt;</code> format. Choose any value for <code>&lt;token-id&gt;</code> (for example a UUID) and <code>&lt;plain-token&gt;</code> (for example a random string) - this token is defined here, not copied from the Admin Portal. Configure the same value as <code>GATEWAY_REGISTRATION_TOKEN</code> on the gateway.</p>
+                                        <p>The gateway's registration token, in <code>&lt;token-id&gt;.&lt;plain-token&gt;</code> format. Choose any value for <code>&lt;token-id&gt;</code> (for example a UUID) and <code>&lt;plain-token&gt;</code> (for example a random string) - this token is defined here, not copied from the Admin Portal. Configure the same value as <code>GATEWAY_REGISTRATION_TOKEN</code> on the gateway. Reference it with WSO2's <code>$env{...}</code> syntax (as shown above) rather than a literal value in <code>deployment.toml</code>, especially when <code>deployment.toml</code> is checked into version control.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -4064,7 +4064,7 @@ organization = "carbon.super"
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code></code></span>
+                                            <span class="param-default-value">Default: <code>ID derived from registration_token</code></span>
                                         </div>
                                         
                                     </div>
@@ -4083,7 +4083,7 @@ organization = "carbon.super"
                                             
                                         </p>
                                         <div class="param-default">
-                                            <span class="param-default-value">Default: <code></code></span>
+                                            <span class="param-default-value">Default: <code>name</code></span>
                                         </div>
                                         
                                     </div>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -448,6 +448,7 @@ nav:
             - Getting Started: api-gateway/platform-gateway/getting-started.md
             - Setting Up: api-gateway/platform-gateway/setting-up.md
             - Adding and Managing Policies: api-gateway/platform-gateway/adding-and-managing-policies.md
+            - Registering via deployment.toml: api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
         - Classic Gateway (Universal):
             - Overview of the WSO2 Classic Gateway: api-gateway/overview-of-the-api-gateway.md
             - Deploy an API to Gateway: api-gateway/deploy-api-to-gateway.md


### PR DESCRIPTION
## Description
- Add a new "Register a Platform Gateway via deployment.toml" section to the Platform Gateway getting-started guide, documenting the `[[apim.platform_gateway.connect]]` declarative onboarding flow (registration token, name, display name, description, URL, organization) as an alternative to the Admin Portal.
- Add matching `apim.platform_gateway` and `apim.platform_gateway.connect` entries to the Configuration Catalog, including the full parameter reference table.
- Cross-link the new section into the existing Admin Portal and gateway setup steps so both onboarding paths converge on the same download/configure/start flow.



### Screenshots:

<img width="3456" height="25280" alt="screencapture-127-0-0-1-8000-en-4-7-0-api-gateway-platform-gateway-getting-started-2026-08-11-16_29_36" src="https://github.com/user-attachments/assets/4093615b-266b-44d2-9321-f51907247509" />

Config catalog: https://github.com/wso2/docs-apim/pull/11779#issuecomment-5252476326