### PR TITLE
[4.7.0] Document Platform Gateway registration and deployment

### DIFF
--- a/en/docs/api-gateway/platform-gateway/adding-and-managing-policies.md
+++ b/en/docs/api-gateway/platform-gateway/adding-and-managing-policies.md
@@ -38,4 +38,4 @@ See [Policy Hub](https://wso2.com/api-platform/policy-hub) for available policie
 ## What's next
 
 - Return to [Getting Started]({{base_path}}/api-gateway/platform-gateway/getting-started/) to test API invocation with and without API-key-based authentication.
-- See [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/) to onboard a gateway declaratively instead of through the Admin Portal.
+- See [Gateway Registration and Deployment]({{base_path}}/api-gateway/platform-gateway/gateway-registration-and-deployment/) to onboard a gateway declaratively instead of through the Admin Portal.

--- a/en/docs/api-gateway/platform-gateway/gateway-registration-and-deployment.md
+++ b/en/docs/api-gateway/platform-gateway/gateway-registration-and-deployment.md
@@ -1,11 +1,24 @@
-# Registering a Platform Gateway via deployment.toml
+# Gateway Registration and Deployment
+
+## Overview
+
+A Platform Gateway can be registered with the Control Plane in two ways:
+
+- **Admin Portal** - create the gateway from the UI, then download and start it using the generated commands. This is the default, manual method.
+- **Automated Gateway Registration** - declare the gateway in `deployment.toml`, so it registers itself the first time it connects, without an Admin Portal step. Use this to automate provisioning, for example with GitOps.
+
+## Create a Platform Gateway in the Admin Portal
+
+Sign in to the Admin Portal, add a Platform Gateway environment with a display name, description, URL, and gateway version, then use the generated download, configuration, and start commands to bring the gateway up. See [Create a Platform Gateway in the Admin Portal]({{base_path}}/api-gateway/platform-gateway/getting-started/#create-a-platform-gateway-in-the-admin-portal) in the Getting Started guide for the full walkthrough.
+
+## Automated Gateway Registration
 
 !!! note
     This feature is available in WSO2 API Manager 4.7.0 starting from update level 7.
 
 As an alternative to the Admin Portal, you can declare a Platform Gateway directly in `<API-M_HOME>/repository/conf/deployment.toml`. This lets you onboard a gateway purely through configuration, for example to automate provisioning with GitOps. The gateway record is not created at Control Plane startup - it is created the first time the gateway connects, using the details below.
 
-## Configure the gateway
+### Configure the gateway
 
 1. Add a `[[apim.platform_gateway.connect]]` entry in `deployment.toml`:
 
@@ -35,7 +48,7 @@ As an alternative to the Admin Portal, you can declare a Platform Gateway direct
 !!! note
     If you later regenerate this gateway's token from the Admin Portal, update the environment variable or secret referenced by `PLATFORM_GW_1_REGISTRATION_TOKEN` and the gateway runtime's `GATEWAY_REGISTRATION_TOKEN` together - don't replace the `$env{...}` reference in `deployment.toml` with the literal token. Once a gateway has connected, its stored token is authoritative, so a stale value on either side will fail to authenticate.
 
-## Start the gateway
+### Start the gateway
 
 Continue with [Setup the Gateway]({{base_path}}/api-gateway/platform-gateway/getting-started/#setup-the-gateway) in the Getting Started guide to download, configure, and start the gateway. When you create `configs/keys.env`, set `GATEWAY_REGISTRATION_TOKEN` to the same value you stored in `PLATFORM_GW_1_REGISTRATION_TOKEN` above, and set `GATEWAY_CONTROLPLANE_HOST` to your Control Plane host and port. The gateway registers automatically the moment it connects - no Admin Portal step is required.
 

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -208,4 +208,4 @@ If authentication fails, confirm the policy is deployed, the header names match 
 
 - [Setting Up Platform Gateway]({{base_path}}/api-gateway/platform-gateway/setting-up/)
 - [Adding and Managing Policies]({{base_path}}/api-gateway/platform-gateway/adding-and-managing-policies/)
-- [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/)
+- [Gateway Registration and Deployment]({{base_path}}/api-gateway/platform-gateway/gateway-registration-and-deployment/)

--- a/en/docs/api-gateway/platform-gateway/getting-started.md
+++ b/en/docs/api-gateway/platform-gateway/getting-started.md
@@ -7,6 +7,8 @@ This guide walks you through setting up a Platform Gateway in your environment. 
 The Platform Gateway is a lightweight gateway distribution intended for hybrid API Platform deployments where the gateway runtime stays in your own infrastructure, while API design, deployment, and visibility are handled centrally through the Control Plane.
 You can also deploy gateway policies to APIs running on Platform Gateway through Policy Hub.
 
+Platform Gateway uses a subscription-less model: there is no Application or Subscribe step. Access to an API deployed on Platform Gateway is governed entirely by the security policies (API Key, JWT/OAuth, Basic Auth, and so on) you attach to it through Policy Hub.
+
 ## Prerequisites
 
 Before you begin, ensure that you have the following:
@@ -146,7 +148,7 @@ To redeploy the API:
 
 ## Test the API
 
-APIs deployed to **Platform Gateway** rely on [Policy Hub](https://wso2.com/api-platform/policy-hub) policies for runtime security. Depending on what you attach to the API, the gateway may expect **API key**, **JWT / OAuth-style bearer token**, **HTTP Basic** credentials, or other supported schemes.
+APIs deployed to **Platform Gateway** rely on [Policy Hub](https://wso2.com/api-platform/policy-hub) policies for runtime security. Depending on what you attach to the API, the gateway may expect **API key**, **JWT / OAuth-style bearer token**, **HTTP Basic** credentials, or other supported schemes. There is no subscription step. Any consumer that satisfies the attached policy can invoke the API.
 
 In the **Dev Portal**, open the API **Try out** (API Console) view. The **Security** section lists only the auth types that apply to that API (for example **OAuth2** for JWT-style policies, **API Key** for API key policies, **Basic** for basic auth). If the API has no auth policies, the Security section may be hidden.
 

--- a/en/docs/api-gateway/platform-gateway/setting-up.md
+++ b/en/docs/api-gateway/platform-gateway/setting-up.md
@@ -217,4 +217,4 @@ This guide provides detailed instructions for deploying Platform Gateway in prod
 ## What's Next?
 
 - [Adding and Managing Policies]({{base_path}}/api-gateway/platform-gateway/adding-and-managing-policies/)
-- [Registering a Platform Gateway via deployment.toml]({{base_path}}/api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml/)
+- [Gateway Registration and Deployment]({{base_path}}/api-gateway/platform-gateway/gateway-registration-and-deployment/)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -448,7 +448,7 @@ nav:
             - Getting Started: api-gateway/platform-gateway/getting-started.md
             - Setting Up: api-gateway/platform-gateway/setting-up.md
             - Adding and Managing Policies: api-gateway/platform-gateway/adding-and-managing-policies.md
-            - Registering via deployment.toml: api-gateway/platform-gateway/registering-a-gateway-via-deployment-toml.md
+            - Gateway Registration and Deployment: api-gateway/platform-gateway/gateway-registration-and-deployment.md
         - Classic Gateway (Universal):
             - Overview of the WSO2 Classic Gateway: api-gateway/overview-of-the-api-gateway.md
             - Deploy an API to Gateway: api-gateway/deploy-api-to-gateway.md


### PR DESCRIPTION
### Description

- Renamed the page to Gateway Registration and Deployment (gateway-registration-and-deployment.md).
- Added an Overview section explaining the two registration modes: Admin Portal (manual) and Automated Gateway Registration (declarative via deployment.toml).
 - Create a Platform Gateway in the Admin Portal is now a brief pointer to the existing walkthrough in Getting Started (#create-a-platform-gateway-in-the-admin-portal), instead of duplicating it.

Comment addressed: https://github.com/wso2/docs-apim/pull/11780#issuecomment-5274222893

### Screenshot
<img width="3456" height="5796" alt="screencapture-127-0-0-1-8000-en-4-7-0-api-gateway-platform-gateway-gateway-registration-and-deployment-2026-08-13-11_11_51" src="https://github.com/user-attachments/assets/d16c41a3-5f43-4ef5-a4bf-7b00b8a21788" />


