### PR TITLE
[4.5.0] Add update level note for header and body capture

### DIFF
--- a/en/docs/monitoring/api-analytics/moesif-analytics/moesif-integration-guide.md
+++ b/en/docs/monitoring/api-analytics/moesif-analytics/moesif-integration-guide.md
@@ -89,6 +89,10 @@ cd <APIM-HOME>/bin
 ./api-manager.sh start
 ```
 
+!!! Note
+    The request and response header and body capture capabilities described in the following two sections are supported starting from WSO2 API Manager 4.5.0 Update Level 75 and onwards. Ensure that you are using a compatible update level of WSO2 API Manager 4.5.0.
+    Refer to this [guide]({{base_path}}/administer/updating-wso2-api-manager/) to update your WSO2 API Manager to the required or latest update level.
+
 ## Capturing Request and Response Headers
 
 By default, request and response headers are **not** sent to Moesif. To include them, set


### PR DESCRIPTION
## Purpose

Adds a note to the Moesif Analytics integration guide stating that request and response header and body capture is available from WSO2 API Manager 4.5.0 Update Level 75 onwards.

Follow-up to https://github.com/wso2/docs-apim/pull/11775, which added the header and body capture documentation to this branch but did not state the update level it requires.

## Approach

Adds an update level note directly above the *Capturing Request and Response Headers* and *Capturing Request and Response Bodies* sections, so a user on an earlier update level does not attempt a configuration that has no effect. It follows the same format as the existing Update Level 11 note for the Moesif Analytics integration itself.