### PR TITLE
Fix OSGi console prompt in Admin Services documentation [4.7.0]

### DIFF
--- a/en/docs/reference/wso2-admin-services.md
+++ b/en/docs/reference/wso2-admin-services.md
@@ -41,7 +41,7 @@ By default, the WSDLs of admin services are hidden from consumers. Follow the in
      Type `listAdminServices` in the OSGi shell and press `Enter`.
 
     ``` shell
-    osgi> listAdminServices
+    g! listAdminServices
     ```
     
      The list of admin services related to WSO2 API Manager product will appear as shown below. 


### PR DESCRIPTION
## Purpose
Resolves #11713.
- The WSO2 Admin Services documentation shows the legacy `osgi>` shell prompt when running the `listAdminServices` command.
- WSO2 API Manager 4.7.0 uses the Apache Felix Gogo shell when started with `-DosgiConsole`, where the prompt is `g!`.

## Goals
Update the Admin Services documentation to show the correct Apache Felix Gogo shell prompt used by WSO2 API Manager 4.7.0.

## Approach
Updated the shell command example from:

`osgi> listAdminServices`

to:

`g! listAdminServices`

The change was verified against a local WSO2 API Manager 4.7.0 installation.

- [x] - Verified that `llms.txt` (located at `en/docs/llms.txt`) is up-to-date.
- [x] - Ensured meaningful alt text for images and that the information contained in an image also appears in text so the relevant info exists in the body of the document.

## User stories
As a WSO2 API Manager user following the Admin Services documentation, I should see the same shell prompt in the documentation that appears in API Manager 4.7.0, to avoid the confusing and questioning the accuracy of the documentation.

## Release note
Corrected the outdated OSGi shell prompt in the Admin Services documentation.

## Documentation
This PR directly updates the WSO2 API Manager Admin Services documentation.

## Training
N/A

## Certification
N/A - This documentation correction does not affect certification content.

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no - Documentation-only change.
 - Ran FindSecurityBugs plugin and verified report? no - Documentation-only change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- WSO2 API Manager 4.7.0
- Windows 11
- JDK 21.0.10
- Apache Felix Gogo shell enabled using `api-manager.bat -DosgiConsole`

Verified that:
- the shell prompt is `g!`
- `g! listAdminServices` successfully lists the deployed Admin Services
- the updated documentation renders correctly using MkDocs locally
 
## Learning

Reviewed the WSO2 API Manager 4.7.0 Admin Services documentation and reproduced issue #11713 locally.
Confirmed that API Manager 4.7.0 uses the Apache Felix Gogo shell instead of the legacy OSGi shell prompt shown in the documentation.