### PR TITLE
Fix outdated OSGi resource link in Admin Services documentation [4.7.0]

### DIFF
--- a/en/docs/reference/wso2-admin-services.md
+++ b/en/docs/reference/wso2-admin-services.md
@@ -12,7 +12,7 @@ There can be instances where you want to call back-end web services directly. Fo
 
 ## Discovering the admin services
 
-By default, the WSDLs of admin services are hidden from consumers. Follow the instructions below to discover the WSDLs of the admin services using the [OSGi](https://www.osgi.org/developer/) console.
+By default, the WSDLs of admin services are hidden from consumers. Follow the instructions below to discover the WSDLs of the admin services using the [OSGi](https://www.osgi.org/resources/) console.
 
 1. Add the following configuration to the `<API-M_HOME>/repository/conf/deployment.toml` file.
 


### PR DESCRIPTION
## Purpose

Resolve: #11790

> The WSO2 Admin Services documentation contains an outdated OSGi link in the section that explains how to discover the WSDLs of admin services using the OSGi console.

> The existing link:
[[OSGi] https://www.osgi.org/developer](https://www.osgi.org/developer/?__mt=1a008c42641471-0540e912b8b734-26071851-190140)
> returns a 404 because the former OSGi /developer/ content was reorganized under the current /resources/ structure.

> This PR updates the broken link to the relevant current OSGi resource.

## Goals
- Remove the broken external OSGi link from the WSO2 Admin Services documentation.
- Point readers to the current official OSGi resource that explains OSGi.
- Preserve the existing documentation content and behavior while correcting only the outdated reference.

## Approach
> Replaced the outdated OSGi URL: [https://www.osgi.org/developer/](https://www.osgi.org/developer/?__mt=1a008c42641471-0540e912b8b734-26071851-190140)

> with: [https://www.osgi.org/resources](https://www.osgi.org/resources/)

## User stories
> I want the OSGi reference link to point to a valid and relevant official resource to avoid the confusing and questioning the accuracy of the documentation

## Release note
> Fixed an outdated OSGi reference link in the WSO2 Admin Services documentation.

## Documentation
> Updated:
`en/docs/reference/wso2-admin-services.md`

>Documentation page:
`https://apim.docs.wso2.com/en/latest/reference/wso2-admin-services/`

## Training
> N/A

## Certification
> N/A - This is a documentation-only link update

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no - This is a documentation-only link update
 - Ran FindSecurityBugs plugin and verified report? no - This is a documentation-only link update
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> Investigated the outdated OSGi /developer/ URL and the current OSGi website structure. The former developer resources were reorganized under the /resources/ section.

>The link in the WSO2 documentation is attached to the term OSGi and provides background information rather than instructions required to execute the WSO2 OSGi console commands. Therefore, the current official What is OSGi? resource was selected as the relevant replacement: [https://www.osgi.org/resources/](https://www.osgi.org/resources/)