### PR TITLE
[4.3.0] Correct the cnf / x5t#S256 example on the Securing APIs with Certificate Bound Access Tokens page.

### DIFF
--- a/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
+++ b/en/docs/design/api-security/api-authentication/securing-apis-using-certificate-bound-access-tokens.md
@@ -71,9 +71,13 @@ Import the certificate and private key to Postman.
    
      The token comprises of client certificate thumbprint as the cnf claim.
    
+    ```json
+    "cnf": {
+      "x5t#S256": "mgw1cKxzkr7hSkCOyziXiFKobTjLwIf-7uqrLJoHufE"
+    }
     ```
-    "cnf", "{"x5t#S256": "9a0c3570ac7392bee14a408ecb38978852a86d38cbc087feeeeaab2c9a07b9f1"}"
-    ```
+
+     The `x5t#S256` value is the base64url-encoded SHA-256 thumbprint of the DER-encoded client certificate, as defined in [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705#name-jwt-certificate-thumbprint-).
 
 4. Invoke the API from Postman.
 


### PR DESCRIPTION
### Purpose
- The documented example showed the `x5t#S256` value as a **64-char hex** SHA-256 digest, inside **invalid JSON**. Per [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705#name-jwt-certificate-thumbprint-) — which the same page cites — `x5t#S256` must be the **base64url-encoded** SHA-256 thumbprint of the DER-encoded client certificate (43 chars), and `cnf` must be a JSON object. A spec-compliant validator compares the base64url thumbprint, so the documented hex value would never match a real certificate binding.

### Changes

- Fix the malformed `cnf` snippet into a valid JSON object.
- Correct the `x5t#S256` value to its base64url form.
- Add a short note clarifying the RFC 8705 encoding.

**Before**
"cnf", "{"x5t#S256": "9a0c3570ac7392bee14a408ecb38978852a86d38cbc087feeeeaab2c9a07b9f1"}"

**After**
```json
"cnf": {
  "x5t#S256": "mgw1cKxzkr7hSkCOyziXiFKobTjLwIf-7uqrLJoHufE"
}
(The new value is the base64url encoding of the same SHA-256 digest the example previously showed as hex.)