### PR TITLE
Update apictl download links to v4.6.4

### DIFF
--- a/en/docs/apiops/cli/getting-started-with-wso2-api-controller.md
+++ b/en/docs/apiops/cli/getting-started-with-wso2-api-controller.md
@@ -6,13 +6,13 @@
 
 1.  Download **apictl** based on your preferred platform (i.e., Mac, Windows, Linux).
 
-    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-darwin-amd64.tar.gz)
-    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-darwin-arm64.tar.gz)
-    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-linux-i586.tar.gz)
-    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-linux-amd64.tar.gz)
-    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-linux-arm64.tar.gz)
-    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-windows-i586.zip)
-    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.1/apictl-4.6.1-windows-x64.zip)
+    - [For Mac with Intel Chip](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-darwin-amd64.tar.gz)
+    - [For Mac with Apple Silicon](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-darwin-arm64.tar.gz)
+    - [For Linux 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-linux-i586.tar.gz)
+    - [For Linux 64-bit with AMD processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-linux-amd64.tar.gz)
+    - [For Linux 64-bit with ARM processor](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-linux-arm64.tar.gz)
+    - [For Windows 32-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-windows-i586.zip)
+    - [For Windows 64-bit](https://github.com/wso2/product-apim-tooling/releases/download/v4.6.4/apictl-4.6.4-windows-x64.zip)
 
 2.  Extract the downloaded archive of the apictl to the desired location.
 3.  Navigate to the working directory where the executable apictl resides.


### PR DESCRIPTION
## Purpose
Resolves #11810. The apictl download links in the 4.6.0 getting started documentation were pointing to an older release (v4.6.1) instead of the latest available 4.6.x patch (v4.6.4).

## Goals
Update the WSO2 API Controller download links so users download the correct latest 4.6.4 version across all operating systems.

## Approach
Updated the version tags in the URLs and the binary file names from `4.6.1` to `4.6.4` for all 7 platform variants in `en/docs/apiops/cli/getting-started-with-wso2-api-controller.md`. Manually verified that all 7 new URLs resolve to actual published release assets.

## User stories
N/A - Documentation fix.

## Release note
Updated apictl download links to v4.6.4 in the 4.6.0 documentation.

## Documentation
This PR is a documentation update itself.

## Training
N/A

## Certification
N/A - Documentation fix.

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A - Documentation fix.
 - Integration tests
   > N/A - Documentation fix.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A - Link resolution manually verified.
 
## Learning
N/A