### PR TITLE
Fix broken link to MySQL Connector/J SSL documentation

### DIFF
--- a/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
+++ b/en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md
@@ -477,7 +477,7 @@ Follow the  instructions below to change the type of the default datasources.
         ```
 
     !!! Tip "Recommendation"
-        It is **not recommended to disable the SSL connection** in Production Environments (with `useSSL=false`). For security reasons, enabling SSL connection with MySQL server is preferred in a Production Environment. For more information on establishing an SSL connection with the MySQL server, see [the official MySQL documentation](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html).   
+        It is **not recommended to disable the SSL connection** in Production Environments (with `useSSL=false`). For security reasons, enabling SSL connection with MySQL server is preferred in a Production Environment. For more information on establishing an SSL connection with the MySQL server, see [the official MySQL documentation](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-using-ssl.html).   
 
 3.  You can update the configuration elements given below for your database connection.
 


### PR DESCRIPTION
## Purpose
The "Change to MySQL" page links to the official MySQL documentation for establishing an SSL connection, but the link returns a 404.

MySQL removed the version segment from Connector/J documentation URLs, so the existing link no longer resolves:
`https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html`

## Goals
Restore the link so readers can reach the SSL guidance referenced by the recommendation note in `en/docs/install-and-setup/setup/setting-up-databases/changing-default-databases/changing-to-mysql.md`.

## Approach
Updated the URL to the current unversioned path:
`https://dev.mysql.com/doc/connector-j/en/connector-j-reference-using-ssl.html`

Verified it returns HTTP 200 and resolves to "MySQL Connector/J Developer Guide :: 6.9 Connecting Securely Using SSL" — the same page the original link intended. No redirect involved.

## User stories
N/A

## Release note
Fixed a broken link to the official MySQL Connector/J SSL documentation on the "Change to MySQL" page.

## Documentation
N/A — this PR is the documentation change.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a link correction with no change to product behavior or documented procedure.

## Marketing
N/A

## Automation tests
N/A — documentation-only change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A — documentation-only change
- Ran FindSecurityBugs plugin and verified report? N/A — documentation-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
None. The same link may exist in older release branches (4.5.0, 4.6.0, etc.) — happy to raise follow-up PRs if maintainers would like it backported.

## Migrations (if applicable)
N/A

## Test environment
N/A — documentation-only change. Link target verified as returning HTTP 200.

## Learning
MySQL restructured its Connector/J documentation URLs to drop the version segment, which broke previously valid `/8.0/` links. Confirmed the replacement URL resolves directly to the intended SSL page rather than through a redirect.