### PR TITLE
Fix broken link to Adding Dynamic Endpoints documentation

### DIFF
--- a/en/docs/api-design-manage/design/endpoints/endpoint-types.md
+++ b/en/docs/api-design-manage/design/endpoints/endpoint-types.md
@@ -25,7 +25,7 @@ An Endpoint is a specific destination for a message such as an address, WSDL, a 
 <td>The endpoints where the incoming requests are directed to in a round-robin manner. They automatically handle fail-over as well.</td>
 </tr>
 <tr><td>Dynamic Endpoint</td>
-<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/api-design-manage/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
+<td>Using a dynamic endpoint, the requests can be dynamically routed to an address based on a specific condition (e.g., request parameters, payload etc.). When using this endpoint type, a mediation sequence should be applied to the message <b>IN Flow</b> of the API. For more information, see <a href="{{base_path}}/api-gateway/policies/adding-dynamic-endpoints/">Adding Dynamic Endpoints</a>.</td>
 </tr>
 <tr><td>Mock Implementation</td>
 <td>


### PR DESCRIPTION
## Purpose
The "Adding Dynamic Endpoints" link in the Dynamic Endpoint row of the [Endpoint Types](https://apim.docs.wso2.com/en/4.7.0/api-design-manage/design/endpoints/endpoint-types/) page returns a 404.

The link points to:
`{{base_path}}/api-design-manage/design/api-policies/regular-gateway-policies/adding-dynamic-endpoints/`

That path does not exist. `en/redirects.yml` maps the eleven `regular-gateway-policies` paths that use the `manage-apis/` prefix, but there is no entry for the `api-design-manage/` prefix used here, so the request falls through to the 404 page.

## Goals
Restore the link so readers can reach the Adding Dynamic Endpoints page from the endpoint type description that references it.

## Approach
Updated the link to the path the page is actually published at, per the `mkdocs.yml` nav entry (`api-gateway/policies/adding-dynamic-endpoints.md`):
`{{base_path}}/api-gateway/policies/adding-dynamic-endpoints/`

This matches what `en/docs/llms.txt` already lists for the page, and matches how the same link is written on the `master` branch. Verified locally with `mkdocs serve` that the link resolves to the Adding Dynamic Endpoints page instead of the 404 page.

## User stories
N/A

## Release note
Fixed a broken link to the "Adding Dynamic Endpoints" documentation on the Endpoint Types page.

## Documentation
N/A - this PR is the documentation change.

## Training
N/A

## Certification
N/A - link correction only; no change to product behavior or documented procedure.

## Marketing
N/A

## Automation tests
N/A - documentation-only change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - documentation-only change
- Ran FindSecurityBugs plugin and verified report? N/A - documentation-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A - documentation-only change. Verified with a local `mkdocs serve` build and against the published 4.7.0 documentation site.

## Learning
The `master` branch already carries the corrected link, so this only reproduces on the published 4.7.0 site. Comparing the two branches is what isolated it. Worth noting that a stale link is not automatically a broken one here - `en/redirects.yml` covers many old paths, and I checked it before concluding this one was genuinely unmapped.