### PR TITLE
Fix broken link to 42Crunch platform

### DIFF
--- a/en/docs/api-security/design-time/configuring-api-security-audit.md
+++ b/en/docs/api-security/design-time/configuring-api-security-audit.md
@@ -10,7 +10,7 @@ WSO2 API-M has partnered with [42Crunch](https://42crunch.com/), the only enterp
 
 Follow the instructions below to obtain the API token and collection ID from 42Crunch.
 
-1. Navigate to the [42Crunch platform](https://platform.42crunch.com) and register or sign in.
+1. Navigate to the [42Crunch platform](https://42crunch.com/customer-login/) and register or sign in.
 
 2. Click **Settings**.
 


### PR DESCRIPTION
## Purpose
The "42Crunch platform" link in Step 1.1 of the [Configuring API Security Audit](https://apim.docs.wso2.com/en/4.7.0/api-security/design-time/configuring-api-security-audit/) page no longer works. `https://platform.42crunch.com` returns an `AccessDenied` error instead of a sign-in page.

42Crunch appears to have restructured how users reach their platform. Their site now routes people through a login directory that splits by account tier (POC, Enterprise, and freemium), rather than exposing a single platform entry point.

## Goals
Restore the link so readers starting the API security audit setup can reach 42Crunch and obtain the API token the following steps require.

## Approach
Updated the link to 42Crunch's current login page:
`https://42crunch.com/customer-login/`

This is where 42Crunch's own site directs users. It covers signing in across all account tiers and also carries a "Start Free" path for readers without an account, which matches the "register or sign in" wording of the step.

Checked the following before settling on it:

| URL | Result |
|---|---|
| `https://platform.42crunch.com` (current link) | AccessDenied error |
| `https://42crunch.com/customer-login/` | Works - 42Crunch's login directory |
| `https://42crunch.com/freemium/` | Works - "Start Free" path |
| `app.42crunch.com`, `protect.42crunch.com` | Do not resolve |

Left the `base_url="https://platform.42crunch.com/api/v1/apis"` value on line 73 unchanged, as that is an API endpoint used in configuration rather than a link for readers to follow.

## User stories
N/A

## Release note
Fixed a broken link to the 42Crunch platform on the Configuring API Security Audit page.

## Documentation
N/A - this PR is the documentation change.

## Training
N/A

## Certification
N/A - link correction only; no change to product behavior.

## Marketing
N/A

## Automation tests
N/A - documentation-only change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - documentation-only change
- Ran FindSecurityBugs plugin and verified report? N/A - documentation-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A. The same broken link exists on the `4.7.0` branch - happy to raise a follow-up PR there if maintainers would like it.

## Migrations (if applicable)
N/A

## Test environment
N/A - documentation-only change. Link targets verified directly.

## Learning
Worth flagging for maintainers: because 42Crunch restructured their platform access, the steps that follow this link (Settings → API Tokens → Create new token, with accompanying screenshots) may also be out of date. I have scoped this PR to the broken link only, since verifying the full token-generation flow requires a 42Crunch account. That section may be worth a separate review.
