### PR TITLE
Fix broken link to SoapUI download page

### DIFF
--- a/en/docs/api-developer-portal/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-a-soap-client.md
+++ b/en/docs/api-developer-portal/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-a-soap-client.md
@@ -21,7 +21,7 @@ Let's invoke the `PhoneVerification` API using a SOAP client.
     
 5.  Copy the access token to the clipboard as you need it later to invoke the API.
     
-6.  Download the SOAP UI installation that suits your operating system from <https://www.soapui.org/downloads/soapui.html> and open its console.
+6.  Download the SOAP UI installation that suits your operating system from <https://www.soapui.org/downloads/latest-release/> and open its console.
     
 7.  In the SOAP UI, right click on the **Projects** menu and create a new SOAP project.
     


### PR DESCRIPTION
## Purpose
Step 6 of the [Invoke an API using a SOAP Client](https://apim.docs.wso2.com/en/4.7.0/api-developer-portal/invoke-apis/invoke-apis-using-tools/invoke-an-api-using-a-soap-client/) page links to the SoapUI download page, but the link returns a 404:
`https://www.soapui.org/downloads/soapui.html`

SmartBear restructured the SoapUI site and the `.html` download path no longer exists.

## Goals
Restore the link so readers can download SoapUI and continue with the remaining steps of the tutorial, which depend on having it installed.

## Approach
Updated the link to the current SoapUI Open Source downloads page:
`https://www.soapui.org/downloads/latest-release/`

That page is titled "Latest SoapUI Open Source Downloads" and offers Windows, macOS, and Linux installers, which matches the step's wording about choosing the installation that suits your operating system.

Checked the alternatives before settling on it:

| URL | Result |
|---|---|
| `https://www.soapui.org/downloads/soapui.html` (current link) | 404 |
| `https://www.soapui.org/downloads/latest-release/` | Works - per-OS Open Source installers |
| `https://www.soapui.org/downloads/soapui/` | Works, but is a ReadyAPI/SoapUI comparison landing page rather than a direct download |
| `https://www.soapui.org/downloads/` | 404 |

Left the SoapUI reference in `en/docs/reference/wso2-admin-services.md` unchanged, as `http://www.soapui.org/` still resolves correctly.

## User stories
N/A

## Release note
Fixed a broken link to the SoapUI download page on the "Invoke an API using a SOAP Client" page.

## Documentation
N/A - this PR is the documentation change.

## Training
N/A

## Certification
N/A - link correction only; no change to product behavior or documented procedure.

## Marketing
N/A

## Automation tests
N/A - documentation-only change.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A - documentation-only change
- Ran FindSecurityBugs plugin and verified report? N/A - documentation-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A. The same broken link exists on the `4.7.0` branch - happy to raise a follow-up PR there if maintainers would like it.

## Migrations (if applicable)
N/A

## Test environment
N/A - documentation-only change. Link targets verified directly.

## Learning
SmartBear moved SoapUI's downloads from a flat `.html` page to a directory-style path, and the generic `/downloads/` path 404s as well, so the fix had to point at the specific latest-release page rather than a parent directory.
