### PR TITLE
Add docs about AWS Elasticache as Vector DB

### DIFF
--- a/en/docs/ai-gateway/semantic-caching.md
+++ b/en/docs/ai-gateway/semantic-caching.md
@@ -98,8 +98,9 @@ The Semantic Cache supports Zilliz, Milvus, and AWS ElastiCache as vector databa
     [apim.ai.vector_db_provider.properties]
     host = "<your-elasticache-endpoint>"
     port = "6379"
-    ssl_enabled = "false"
-    cluster_mode_enabled = "true"
+    ssl_enabled = false
+    # When 'cluster_mode_enabled' is 'true', set 'host' to the ElastiCache cluster's Configuration Endpoint (its hostname contains 'clustercfg.') rather than an individual node/shard endpoint.
+    cluster_mode_enabled = true
     # The underlying Jedis connection pool used to talk to ElastiCache can be tuned via `jedis.pool.*` properties. Eg:
     "jedis.pool.max_total" = 15
     "jedis.pool.max_idle" = 5

--- a/en/docs/ai-gateway/semantic-caching.md
+++ b/en/docs/ai-gateway/semantic-caching.md
@@ -68,7 +68,7 @@ Choose one of the following embedding providers and add the configuration to you
 
 ### 2. Vector Database Configuration
 
-The Semantic Cache supports Zilliz and Milvus as vector database providers (**Support for additional vector database providers will be added soon**). Configure the desired provider in your `<APIM_HOME>/repository/conf/deployment.toml` file:
+The Semantic Cache supports Zilliz, Milvus, and AWS ElastiCache as vector database providers (**Support for additional vector database providers will be added soon**). Configure the desired provider in your `<APIM_HOME>/repository/conf/deployment.toml` file:
 
 === "Zilliz"
 
@@ -89,6 +89,24 @@ The Semantic Cache supports Zilliz and Milvus as vector database providers (**Su
     uri = "http://localhost:19530"
     token = "root:Milvus"
     ```
+
+=== "AWS ElastiCache"
+
+    ```toml
+    [apim.ai.vector_db_provider]
+    type = "elasticache"
+    [apim.ai.vector_db_provider.properties]
+    host = "<your-elasticache-endpoint>"
+    port = "6379"
+    ssl_enabled = "false"
+    cluster_mode_enabled = "true"
+    # The underlying Jedis connection pool used to talk to ElastiCache can be tuned via `jedis.pool.*` properties. Eg:
+    "jedis.pool.max_total" = 15
+    "jedis.pool.max_idle" = 5
+    ```
+
+!!! note "Important"
+    AWS ElastiCache is supported only from WSO2 API Manager 4.6.0 U2 update level (`wso2am-4.6.0.40`) onwards.
 
 You can optionally specify a `ttl` property to control the time-to-live for cached entries. If not set, the default TTL is 3600 seconds.
 

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -18184,11 +18184,11 @@ ttl = 3600
                                             <span class="param-default-value">Default: <code></code></span>
                                         </div>
                                         <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>zilliz</code></span>
+                                            <span class="param-possible-values">Possible Values: <code>zilliz,elasticache</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>The vector database provider type. Use zilliz to connect to either Zilliz Cloud or a Milvus instance.</p>
+                                        <p>The vector database provider type. Use zilliz to connect to either Zilliz Cloud or a Milvus instance, or elasticache to connect to AWS ElastiCache (Redis/Valkey). Support for elasticache is available only from WSO2 API Manager 4.6.0 U2 update level (wso2am-4.6.0.40) onwards.</p>
                                     </div>
                                 </div>
                             </div>
@@ -18216,7 +18216,7 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530).</p>
+                                        <p>The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Applicable only when type is zilliz.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -18235,7 +18235,125 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus).</p>
+                                        <p>The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Applicable only when type is zilliz.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>host</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>port</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            <span class="badge-required">Required</span>
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The port of the ElastiCache/Redis instance. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>username</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The username used to authenticate with the ElastiCache/Redis instance, if authentication is enabled. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>password</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> string </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code></code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>The password used to authenticate with the ElastiCache/Redis instance, if authentication is enabled. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>ssl_enabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether to use SSL/TLS when connecting to the ElastiCache/Redis instance. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>cluster_mode_enabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether the ElastiCache deployment is running in cluster mode. Applicable only when type is elasticache.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -18254,7 +18372,205 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>Time-to-live in seconds for cached vector entries. If not specified, defaults to 3600 seconds (1 hour).</p>
+                                        <p>Time-to-live in seconds for cached vector entries. If not specified, defaults to 3600 seconds (1 hour). Applicable to all vector database provider types.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.max_total</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>8</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Maximum number of connections the Jedis connection pool can allocate at a given time. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.max_idle</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>8</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Maximum number of idle connections kept in the Jedis connection pool. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.min_idle</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>0</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Minimum number of idle connections the Jedis connection pool tries to maintain. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.test_on_borrow</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether to validate a connection before it is handed out from the Jedis connection pool. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.test_on_return</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether to validate a connection before it is returned to the Jedis connection pool. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.test_while_idle</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether idle connections in the Jedis connection pool are validated by the idle object evictor. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.block_when_exhausted</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>true</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>true, false</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Whether callers block and wait for a connection when the Jedis connection pool is exhausted, instead of failing immediately. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.min_evictable_idle_time_millis</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>60000</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Minimum time (in milliseconds) a connection may sit idle in the Jedis connection pool before it becomes eligible for eviction. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.time_between_eviction_runs_millis</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>30000</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Time (in milliseconds) between runs of the idle connection evictor thread of the Jedis connection pool. Applicable only when type is elasticache.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>jedis.pool.num_tests_per_eviction_run</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> integer </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>-1</code></span>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="param-description">
+                                        <p>Number of connections checked per eviction run (-1 checks all idle connections). Applicable only when type is elasticache.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/docs/reference/config-catalog.md
+++ b/en/docs/reference/config-catalog.md
@@ -18216,7 +18216,7 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Applicable only when type is zilliz.</p>
+                                        <p>The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Not applicable to Vector DB providers other than Zilliz and Milvus.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -18235,7 +18235,7 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Applicable only when type is zilliz.</p>
+                                        <p>The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Not applicable to Vector DB providers other than Zilliz and Milvus.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -18254,7 +18254,7 @@ ttl = 3600
                                         
                                     </div>
                                     <div class="param-description">
-                                        <p>The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache.</p>
+                                        <p>The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache. When cluster_mode_enabled is true, this must be the ElastiCache cluster's Configuration Endpoint (its hostname contains clustercfg.) rather than an individual node/shard endpoint.</p>
                                     </div>
                                 </div>
                             </div><div class="param">

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6905,8 +6905,8 @@
                             "type": "string",
                             "required": true,
                             "default": "",
-                            "possible": "zilliz",
-                            "description": "The vector database provider type. Use zilliz to connect to either Zilliz Cloud or a Milvus instance."
+                            "possible": "zilliz,elasticache",
+                            "description": "The vector database provider type. Use zilliz to connect to either Zilliz Cloud or a Milvus instance, or elasticache to connect to AWS ElastiCache (Redis/Valkey). Support for elasticache is available only from WSO2 API Manager 4.6.0 U2 update level (wso2am-4.6.0.40) onwards."
                         }
                     ]
                 },
@@ -6921,7 +6921,7 @@
                             "required": true,
                             "default": "",
                             "possible": "",
-                            "description": "The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530)."
+                            "description": "The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Applicable only when type is zilliz."
                         },
                         {
                             "name": "token",
@@ -6929,7 +6929,55 @@
                             "required": true,
                             "default": "",
                             "possible": "",
-                            "description": "The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus)."
+                            "description": "The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Applicable only when type is zilliz."
+                        },
+                        {
+                            "name": "host",
+                            "type": "string",
+                            "required": true,
+                            "default": "",
+                            "possible": "",
+                            "description": "The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "port",
+                            "type": "string",
+                            "required": true,
+                            "default": "",
+                            "possible": "",
+                            "description": "The port of the ElastiCache/Redis instance. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "username",
+                            "type": "string",
+                            "required": false,
+                            "default": "",
+                            "possible": "",
+                            "description": "The username used to authenticate with the ElastiCache/Redis instance, if authentication is enabled. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "password",
+                            "type": "string",
+                            "required": false,
+                            "default": "",
+                            "possible": "",
+                            "description": "The password used to authenticate with the ElastiCache/Redis instance, if authentication is enabled. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "ssl_enabled",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Whether to use SSL/TLS when connecting to the ElastiCache/Redis instance. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "cluster_mode_enabled",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Whether the ElastiCache deployment is running in cluster mode. Applicable only when type is elasticache."
                         },
                         {
                             "name": "ttl",
@@ -6937,7 +6985,87 @@
                             "required": false,
                             "default": "3600",
                             "possible": "",
-                            "description": "Time-to-live in seconds for cached vector entries. If not specified, defaults to 3600 seconds (1 hour)."
+                            "description": "Time-to-live in seconds for cached vector entries. If not specified, defaults to 3600 seconds (1 hour). Applicable to all vector database provider types."
+                        },
+                        {
+                            "name": "jedis.pool.max_total",
+                            "type": "integer",
+                            "required": false,
+                            "default": "8",
+                            "possible": "",
+                            "description": "Maximum number of connections the Jedis connection pool can allocate at a given time. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.max_idle",
+                            "type": "integer",
+                            "required": false,
+                            "default": "8",
+                            "possible": "",
+                            "description": "Maximum number of idle connections kept in the Jedis connection pool. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.min_idle",
+                            "type": "integer",
+                            "required": false,
+                            "default": "0",
+                            "possible": "",
+                            "description": "Minimum number of idle connections the Jedis connection pool tries to maintain. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.test_on_borrow",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Whether to validate a connection before it is handed out from the Jedis connection pool. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.test_on_return",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "false",
+                            "possible": "true, false",
+                            "description": "Whether to validate a connection before it is returned to the Jedis connection pool. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.test_while_idle",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "true",
+                            "possible": "true, false",
+                            "description": "Whether idle connections in the Jedis connection pool are validated by the idle object evictor. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.block_when_exhausted",
+                            "type": "boolean",
+                            "required": false,
+                            "default": "true",
+                            "possible": "true, false",
+                            "description": "Whether callers block and wait for a connection when the Jedis connection pool is exhausted, instead of failing immediately. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.min_evictable_idle_time_millis",
+                            "type": "integer",
+                            "required": false,
+                            "default": "60000",
+                            "possible": "",
+                            "description": "Minimum time (in milliseconds) a connection may sit idle in the Jedis connection pool before it becomes eligible for eviction. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.time_between_eviction_runs_millis",
+                            "type": "integer",
+                            "required": false,
+                            "default": "30000",
+                            "possible": "",
+                            "description": "Time (in milliseconds) between runs of the idle connection evictor thread of the Jedis connection pool. Applicable only when type is elasticache."
+                        },
+                        {
+                            "name": "jedis.pool.num_tests_per_eviction_run",
+                            "type": "integer",
+                            "required": false,
+                            "default": "-1",
+                            "possible": "",
+                            "description": "Number of connections checked per eviction run (-1 checks all idle connections). Applicable only when type is elasticache."
                         }
                     ]
                 }

--- a/en/tools/config-catalog-generator/data/configs.json
+++ b/en/tools/config-catalog-generator/data/configs.json
@@ -6921,7 +6921,7 @@
                             "required": true,
                             "default": "",
                             "possible": "",
-                            "description": "The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Applicable only when type is zilliz."
+                            "description": "The URI of the vector database instance. For Zilliz, use the Zilliz Cloud cluster endpoint. For Milvus, use the Milvus server address (e.g., http://localhost:19530). Not applicable to Vector DB providers other than Zilliz and Milvus."
                         },
                         {
                             "name": "token",
@@ -6929,7 +6929,7 @@
                             "required": true,
                             "default": "",
                             "possible": "",
-                            "description": "The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Applicable only when type is zilliz."
+                            "description": "The access token for authenticating with the vector database. For Zilliz, use the Zilliz Cloud API token. For Milvus, use the username and password in the format username:password (e.g., root:Milvus). Not applicable to Vector DB providers other than Zilliz and Milvus."
                         },
                         {
                             "name": "host",
@@ -6937,7 +6937,7 @@
                             "required": true,
                             "default": "",
                             "possible": "",
-                            "description": "The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache."
+                            "description": "The hostname or endpoint of the ElastiCache/Redis instance. Applicable only when type is elasticache. When cluster_mode_enabled is true, this must be the ElastiCache cluster's Configuration Endpoint (its hostname contains clustercfg.) rather than an individual node/shard endpoint."
                         },
                         {
                             "name": "port",


### PR DESCRIPTION
## Purpose
> Adds AWS ElastiCache as a new supported Vector DB provider for the Semantic Cache AI Gateway policy, alongside the existing Zilliz/Milvus support. Related implementation: WSO2/carbon-apimgt (ElastiCache Vector DB Provider Service implementation). <!-- add issue link(s) here, e.g. Resolves wso2/product-apim#XXXX -->

## Goals
> - Document how to configure AWS ElastiCache as the `apim.ai.vector_db_provider` in `deployment.toml`.
> - Document the ElastiCache-specific connection properties (`host`, `port`, `ssl_enabled`, `cluster_mode_enabled`, optional `username`/`password`).
> - Document how to tune the underlying Jedis Redis connection pool via `jedis.pool.*` properties.
> - Note the minimum supported update level for this feature (WSO2 API Manager 4.6.0 U2, `wso2am-4.6.0.40`).
> - Extend the API Manager Configuration Catalog reference page with the new `type` value and properties, generated via the existing `config-catalog-generator` tool.

