### PR TITLE
Add RHEL 9.6 to tested operating systems (API-M 4.2.0)

### DIFF
--- a/en/docs/install-and-setup/setup/reference/product-compatibility.md
+++ b/en/docs/install-and-setup/setup/reference/product-compatibility.md
@@ -14,7 +14,7 @@ As WSO2 API Manager is a Java application, you can generally run it on most oper
 |--------------------|--------------|
 |Windows             | 2016         |
 |Ubuntu              | 22.04 |
-|Red Hat Enterprise Linux   | 7.0, 8.7, 9.3   |
+|Red Hat Enterprise Linux   | 7.0, 8.7, 9.3, 9.6   |
 |CentOS              | 7.4, 7.5     |
 |Rockyise Linux   | 9.3   |
 


### PR DESCRIPTION
## Summary
- Adds RHEL 9.6 to the list of tested operating systems for the API-M 4.2.0 runtime in Product Compatibility, based on testgrid integration test runs verified against RHEL 9.6.

## Test plan
- [x] Verified against testgrid integration test logs for wso2am-4.2.0 on RHEL 9.6