### PR TITLE
Update RHEL version to 9.6 in tested operating systems (API-M 4.6.0)

### DIFF
--- a/en/docs/reference/product-compatibility.md
+++ b/en/docs/reference/product-compatibility.md
@@ -19,7 +19,7 @@ As WSO2 API Manager is a Java application, you can generally run it on most oper
 |Windows (ARM64)      | 11 (25H2)    |
 |Ubuntu              | 22.04        |
 |Rocky Linux         | 9.3          |
-|RHEL                | 9            |
+|RHEL                | 9.6          |
 
 #### Tested JDKs
 


### PR DESCRIPTION
## Summary
- Updates the RHEL entry from the generic major version "9" to "9.6" for the API-M 4.6.0 runtime in Product Compatibility, reflecting the specific minor version verified via testgrid integration test runs.

## Test plan
- [x] Verified against testgrid integration test logs for wso2am-4.6.0 on RHEL 9.6